### PR TITLE
vapor run prepare --revert logic change

### DIFF
--- a/Sources/Vapor/Fluent/Prepare.swift
+++ b/Sources/Vapor/Fluent/Prepare.swift
@@ -38,12 +38,9 @@ public struct Prepare: Command {
         guard let database = database else {
             throw CommandError.general("Can not run preparations, droplet has no database")
         }
-
-        if arguments.option("revert").bool == true {
-            guard console.confirm("Are you sure you want to revert the database?", style: .warning) else {
-                console.error("Reversion cancelled")
-                return
-            }
+        
+        if arguments.option("revert").bool == true &&
+            console.confirm("Are you sure you want to revert the database?", style: .warning)  {
 
             for preparation in preparations {
                 let name = preparation.name

--- a/Sources/Vapor/Fluent/Prepare.swift
+++ b/Sources/Vapor/Fluent/Prepare.swift
@@ -67,35 +67,34 @@ public struct Prepare: Command {
             let schema = Schema.delete(entity: "fluent")
             try database.driver.schema(schema)
             console.success("Reversion complete")
-        } else {
-            for preparation in preparations {
-                let name = preparation.name
+        }
+        
+        for preparation in preparations {
+            let name = preparation.name
+            let hasPrepared: Bool
 
-                let hasPrepared: Bool
-
-                do {
-                    hasPrepared = try database.hasPrepared(preparation)
-                } catch {
-                    console.error("Failed to start preparation")
-                    throw CommandError.general("\(error)")
-                }
-
-                if !hasPrepared {
-                    print("Preparing \(name)")
-                    do {
-                        try database.prepare(preparation)
-                        console.success("Prepared '\(name)'")
-                    } catch PreparationError.automationFailed(let string) {
-                        console.error("Automatic preparation for \(name) failed.")
-                        throw CommandError.general("\(string)")
-                    } catch {
-                        console.error("Failed to prepare \(name)")
-                        throw CommandError.general("\(error)")
-                    }
-                }
+            do {
+                hasPrepared = try database.hasPrepared(preparation)
+            } catch {
+                console.error("Failed to start preparation")
+                throw CommandError.general("\(error)")
             }
 
-            console.info("Database prepared")
+            if !hasPrepared {
+                print("Preparing \(name)")
+                do {
+                    try database.prepare(preparation)
+                    console.success("Prepared '\(name)'")
+                } catch PreparationError.automationFailed(let string) {
+                    console.error("Automatic preparation for \(name) failed.")
+                    throw CommandError.general("\(string)")
+                } catch {
+                    console.error("Failed to prepare \(name)")
+                    throw CommandError.general("\(error)")
+                }
+            }
         }
+
+        console.info("Database prepared")
     }
 }


### PR DESCRIPTION
Thanks for the awesome project guys! 

While working on a vapor project, I have been making frequent use of the ```vapor run prepare --revert``` option. With --revert, the models run ```revert(database:)``` but not ```prepare(database:)```. This means that the the dev needs to stop and start the server to prepare the database. 

I cannot think of any advantages to not immediately running ```prepare(database:)``` after reverting. It will automatically prepare the next time you start anyways since the migration table was deleted.

Here is a proposed code change that always runs ```prepare(database:)``` after reverting.