### PR TITLE
bundled middleware public access

### DIFF
--- a/Sources/Vapor/Date/DateMiddleware.swift
+++ b/Sources/Vapor/Date/DateMiddleware.swift
@@ -3,6 +3,9 @@ import HTTP
 import Core
 
 public final class DateMiddleware: Middleware {
+
+    public init() {}
+
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
         let response = try next.respond(to: request)
 

--- a/Sources/Vapor/Middleware/AbortMiddleware.swift
+++ b/Sources/Vapor/Middleware/AbortMiddleware.swift
@@ -9,6 +9,8 @@ import HTTP
 */
 public class AbortMiddleware: Middleware {
 
+    public init() {}
+
     /**
         Respond to a given request chaining to the next
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -9,15 +9,15 @@ import Cookies
     If an active Session is found on the request when the response
     is being made, the Session identifier is returned as a `vapor-session` cookie.
 */
-class SessionMiddleware: Middleware {
+public class SessionMiddleware: Middleware {
 
-    var sessions: Sessions
+    public var sessions: Sessions
 
-    init(sessions: Sessions) {
+    public init(sessions: Sessions) {
         self.sessions = sessions
     }
 
-    func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
+    public func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
         // mutable -- MUST be declared at top of function
         if
             let identifier = request.cookies["vapor-session"],

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -11,7 +11,7 @@ import Cookies
 */
 public class SessionMiddleware: Middleware {
 
-    public var sessions: Sessions
+    var sessions: Sessions
 
     public init(sessions: Sessions) {
         self.sessions = sessions

--- a/Sources/Vapor/Validation/ValidationMiddleware.swift
+++ b/Sources/Vapor/Validation/ValidationMiddleware.swift
@@ -4,9 +4,11 @@ import HTTP
     Catches validation errors and prints
     out a more readable JSON response.
 */
-class ValidationMiddleware: Middleware {
+public class ValidationMiddleware: Middleware {
 
-    func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
+    public init() {}
+
+    public func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
         do {
             return try chain.respond(to: request)
         } catch let error as ValidationErrorProtocol {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -32,6 +32,7 @@ XCTMain([
     testCase(HashTests.allTests),
     testCase(LocalizationTests.allTests),
     testCase(LogTests.allTests),
+    testCase(MiddlewareTests.allTests),
     testCase(MemorySessionDriverTests.allTests),
     testCase(ProcessTests.allTests),
     testCase(ProviderTests.allTests),

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -19,7 +19,7 @@ class MiddlewareTests: XCTestCase {
         ]
 
         for middleware in bundledMiddleware {
-            drop.middleware = drop.middleware.filter() { !($0.dynamicType == middleware.dynamicType) }
+            drop.middleware = drop.middleware.filter() { (type(of: $0) != type(of: middleware) }
         }
 
         XCTAssert(drop.middleware.count == 0, "Bundled middleware not all removed")

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -19,7 +19,7 @@ class MiddlewareTests: XCTestCase {
         ]
 
         for middleware in bundledMiddleware {
-            drop.middleware = drop.middleware.filter() { (type(of: $0) != type(of: middleware) }
+            drop.middleware = drop.middleware.filter() { type(of: $0) != type(of: middleware) }
         }
 
         XCTAssert(drop.middleware.count == 0, "Bundled middleware not all removed")

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -1,0 +1,33 @@
+import Vapor // not @testable to ensure Middleware classes are public 
+import XCTest
+
+class MiddlewareTests: XCTestCase {
+    static let allTests = [
+        ("testBundledMiddleware", testBundledMiddleware)
+    ]
+
+    func testBundledMiddleware() throws {
+        let drop = Droplet()
+
+        let bundledMiddleware: [Middleware] = [
+            FileMiddleware(workDir: drop.workDir),
+            SessionMiddleware(sessions: drop.sessions),
+            ValidationMiddleware(),
+            DateMiddleware(),
+            TypeSafeErrorMiddleware(),
+            AbortMiddleware()
+        ]
+
+        for middleware in bundledMiddleware {
+            drop.middleware = drop.middleware.filter() { !($0.dynamicType == middleware.dynamicType) }
+        }
+
+        XCTAssert(drop.middleware.count == 0, "Bundled middleware not all removed")
+
+        for middleware in bundledMiddleware {
+            drop.middleware += middleware
+        }
+
+        XCTAssert(drop.middleware.count == bundledMiddleware.count, "Bundled middleware not all added")
+    }
+}


### PR DESCRIPTION
Some of the bundled middleware did not have public access level so it was difficult to opt-in/opt-out at the user's discretion. Included a test to check that bundled middleware (well the ones in drop.middleware by default) is publicly accessible.