### PR TITLE
Droplet's workingDirectory should be public

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+WorkingDirectory.swift
+++ b/Sources/Vapor/Droplet/Droplet+WorkingDirectory.swift
@@ -1,5 +1,5 @@
 extension Droplet {
-    static func workingDirectory(from arguments: [String]) -> String {
+    public static func workingDirectory(from arguments: [String]) -> String {
         func fileWorkDirectory() -> String? {
             let parts = #file.components(separatedBy: "/Packages/Vapor-")
             guard parts.count == 2 else {


### PR DESCRIPTION
Making the Droplet's `workingDirectory()` public.