### PR TITLE
Detect file, function and line of a log call

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -271,7 +271,7 @@ public class Droplet {
         // iterate through any logs that were emitted
         // before the instance of Log was created.
         for item in logs {
-            log.log(item.level, message: item.message)
+            log.log(item.level, message: item.message, path: #file, function: #function, line: #line)
         }
 
         self.view = provided.view ?? LeafRenderer(viewsDir: workDir + "Resources/Views")

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -271,7 +271,7 @@ public class Droplet {
         // iterate through any logs that were emitted
         // before the instance of Log was created.
         for item in logs {
-            log.log(item.level, message: item.message, path: #file, function: #function, line: #line)
+            log.log(item.level, message: item.message, file: #file, function: #function, line: #line)
         }
 
         self.view = provided.view ?? LeafRenderer(viewsDir: workDir + "Resources/Views")

--- a/Sources/Vapor/Log/ConsoleLogger.swift
+++ b/Sources/Vapor/Log/ConsoleLogger.swift
@@ -26,8 +26,12 @@ public class ConsoleLogger: Log {
 
         - parameter level: the level with which to filter
         - parameter message: the message to log to console
+        - parameter path: String where logging happens, is automatically set on default
+        - parameter function: String where logging happens, is automatically set on default
+        - parameter line: String where logging happens, is automatically set on default
      */
-    public func log(_ level: LogLevel, message: String) {
+    public func log(_ level: LogLevel, message: String,
+                    path: String = #file, function: String = #function, line: Int = #line) {
         if enabled.contains(level) {
             console.output(message, style: level.consoleStyle)
         }

--- a/Sources/Vapor/Log/ConsoleLogger.swift
+++ b/Sources/Vapor/Log/ConsoleLogger.swift
@@ -26,12 +26,12 @@ public class ConsoleLogger: Log {
 
         - parameter level: the level with which to filter
         - parameter message: the message to log to console
-        - parameter path: String where logging happens, is automatically set on default
+        - parameter file: String where logging happens, is automatically set on default
         - parameter function: String where logging happens, is automatically set on default
         - parameter line: String where logging happens, is automatically set on default
      */
     public func log(_ level: LogLevel, message: String,
-                    path: String = #file, function: String = #function, line: Int = #line) {
+                    file: String = #file, function: String = #function, line: Int = #line) {
         if enabled.contains(level) {
             console.output(message, style: level.consoleStyle)
         }

--- a/Sources/Vapor/Log/Log+Convenience.swift
+++ b/Sources/Vapor/Log/Log+Convenience.swift
@@ -7,9 +7,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    //public func verbose(_ message: String) {
-    public func verbose(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func verbose(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.verbose, message: message, path: path, function: function, line: line)
     }
     
@@ -21,8 +20,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    public func debug(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func debug(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.debug, message: message, path: path, function: function, line: line)
     }
     
@@ -34,8 +33,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    public func info(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func info(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.info, message: message, path: path, function: function, line: line)
     }
     
@@ -47,8 +46,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    public func warning(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func warning(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.warning, message: message, path: path, function: function, line: line)
     }
     
@@ -60,8 +59,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    public func error(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func error(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.error, message: message, path: path, function: function, line: line)
     }
     
@@ -73,8 +72,8 @@ extension Log {
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
-    public func fatal(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line) {
+    public func fatal(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line) {
         log(.fatal, message: message, path: path, function: function, line: line)
     }
     
@@ -87,8 +86,8 @@ extension Log {
      - parameter line: String where logging happens, is automatically set on default
      - parameter label: String of a custom logging level
      */
-    public func custom(_ message: String, _
-        path: String = #file, _ function: String = #function, line: Int = #line, label: String) {
+    public func custom(_ message: String,
+        path: String = #file, function: String = #function, line: Int = #line, label: String) {
         log(.custom(label), message: message, path: path, function: function, line: line)
     }
 }

--- a/Sources/Vapor/Log/Log+Convenience.swift
+++ b/Sources/Vapor/Log/Log+Convenience.swift
@@ -1,64 +1,94 @@
 extension Log {
     /**
-        Logs verbose messages if .Verbose is enabled
-
-        - parameter message: String to log
+     Logs verbose messages if .Verbose is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func verbose(_ message: String) {
-        log(.verbose, message: message)
+    //public func verbose(_ message: String) {
+    public func verbose(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.verbose, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs debug messages if .Debug is enabled
-
-        - parameter message: String to log
+     Logs debug messages if .Debug is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func debug(_ message: String) {
-        log(.debug, message: message)
+    public func debug(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.debug, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs info messages if .Info is enabled
-
-        - parameter message: String to log
+     Logs info messages if .Info is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func info(_ message: String) {
-        log(.info, message: message)
+    public func info(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.info, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs warning messages if .Warning is enabled
-
-        - parameter message: String to log
+     Logs warning messages if .Warning is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func warning(_ message: String) {
-        log(.warning, message: message)
+    public func warning(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.warning, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs error messages if .Error is enabled
-
-        - parameter message: String to log
+     Logs error messages if .Error is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func error(_ message: String) {
-        log(.error, message: message)
+    public func error(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.error, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs fatal messages if .Fatal is enabled
-
-        - parameter message: String to log
+     Logs fatal messages if .Fatal is enabled
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
      */
-    public func fatal(_ message: String) {
-        log(.fatal, message: message)
+    public func fatal(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        log(.fatal, message: message, path: path, function: function, line: line)
     }
-
+    
     /**
-        Logs custom messages if .Always is enabled.
-
-        - parameter message: String to log
+     Logs custom messages if .Always is enabled.
+     
+     - parameter message: String to log
+     - parameter path: String where logging happens, is automatically set on default
+     - parameter function: String where logging happens, is automatically set on default
+     - parameter line: String where logging happens, is automatically set on default
+     - parameter label: String of a custom logging level
      */
-    public func custom(_ message: String, label: String) {
-        log(.custom(label), message: message)
+    public func custom(_ message: String, _
+        path: String = #file, _ function: String = #function, line: Int = #line, label: String) {
+        log(.custom(label), message: message, path: path, function: function, line: line)
     }
 }

--- a/Sources/Vapor/Log/Log+Convenience.swift
+++ b/Sources/Vapor/Log/Log+Convenience.swift
@@ -3,91 +3,91 @@ extension Log {
      Logs verbose messages if .Verbose is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func verbose(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.verbose, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.verbose, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs debug messages if .Debug is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func debug(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.debug, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.debug, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs info messages if .Info is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func info(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.info, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.info, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs warning messages if .Warning is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func warning(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.warning, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.warning, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs error messages if .Error is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func error(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.error, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.error, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs fatal messages if .Fatal is enabled
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      */
     public func fatal(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line) {
-        log(.fatal, message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line) {
+        log(.fatal, message: message, file: file, function: function, line: line)
     }
     
     /**
      Logs custom messages if .Always is enabled.
      
      - parameter message: String to log
-     - parameter path: String where logging happens, is automatically set on default
+     - parameter file: String where logging happens, is automatically set on default
      - parameter function: String where logging happens, is automatically set on default
      - parameter line: String where logging happens, is automatically set on default
      - parameter label: String of a custom logging level
      */
     public func custom(_ message: String,
-        path: String = #file, function: String = #function, line: Int = #line, label: String) {
-        log(.custom(label), message: message, path: path, function: function, line: line)
+        file: String = #file, function: String = #function, line: Int = #line, label: String) {
+        log(.custom(label), message: message, file: file, function: function, line: line)
     }
 }

--- a/Sources/Vapor/Log/Log.swift
+++ b/Sources/Vapor/Log/Log.swift
@@ -11,8 +11,8 @@ public protocol Log: class {
 
     /**
         Log the given message at the passed filter level.
-        path, function and line of the logging call
+        file, function and line of the logging call
         are automatically injected in the convenience function.
     */
-    func log(_ level: LogLevel, message: String, path: String, function: String, line: Int)
+    func log(_ level: LogLevel, message: String, file: String, function: String, line: Int)
 }

--- a/Sources/Vapor/Log/Log.swift
+++ b/Sources/Vapor/Log/Log.swift
@@ -11,6 +11,8 @@ public protocol Log: class {
 
     /**
         Log the given message at the passed filter level.
+        path, function and line of the logging call
+        are automatically injected in the convenience function.
     */
-    func log(_ level: LogLevel, message: String)
+    func log(_ level: LogLevel, message: String, path: String, function: String, line: Int)
 }

--- a/Tests/VaporTests/LogTests.swift
+++ b/Tests/VaporTests/LogTests.swift
@@ -14,9 +14,9 @@ private class DummyLogger: Log {
         enabled = LogLevel.all
     }
     
-    func log(_ level: LogLevel, message: String, path: String, function: String, line: Int) {
+    func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
         output = "level: \(level.description), message: '\(message)', "
-        output += "path: \(path), function: \(function), line: \(line)"
+        output += "file: \(file), function: \(function), line: \(line)"
     }
 }
 
@@ -31,7 +31,7 @@ class LogTests: XCTestCase {
         
         // is the file, function and source code line of the logging call automatically detected?
         var expectedString = "level: VERBOSE, message: 'Hello', "
-        expectedString += "path: \(#file), function: \(#function), line: \((#line - 4))"
+        expectedString += "file: \(#file), function: \(#function), line: \((#line - 4))"
         
         XCTAssertEqual(log.output, expectedString)
     }

--- a/Tests/VaporTests/LogTests.swift
+++ b/Tests/VaporTests/LogTests.swift
@@ -13,9 +13,10 @@ private class DummyLogger: Log {
         output = ""
         enabled = LogLevel.all
     }
-
-    func log(_ level: LogLevel, message: String) {
-        output = "\(level.description) \(message)"
+    
+    func log(_ level: LogLevel, message: String, path: String, function: String, line: Int) {
+        output = "level: \(level.description), message: '\(message)', "
+        output += "path: \(path), function: \(function), line: \(line)"
     }
 }
 
@@ -27,8 +28,11 @@ class LogTests: XCTestCase {
     func testDummyLogger() {
         let log = DummyLogger()
         log.verbose("Hello")
-
-        XCTAssertEqual(log.output, "VERBOSE Hello")
-
+        
+        // is the file, function and source code line of the logging call automatically detected?
+        var expectedString = "level: VERBOSE, message: 'Hello', "
+        expectedString += "path: \(#file), function: \(#function), line: \((#line - 4))"
+        
+        XCTAssertEqual(log.output, expectedString)
     }
 }


### PR DESCRIPTION
Currently just the log level and the message are used for logging based
on the given protocol. Where the logging call is actually happening is
ignored which makes debugging much harder.

To fix that, I changed the protocol and all files that consume it in
the main Vapor project to get the file, function and line of a log call
by using “magic” Swift variables. These values can then be used for a
more sophisticated logging and can be ignored if not used.

The position of these variables is important to get the correct
position of the log call in the source code.