### PR TITLE
tls config

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+TLS.swift
+++ b/Sources/Vapor/Droplet/Droplet+TLS.swift
@@ -1,0 +1,92 @@
+import TLS
+
+extension Droplet {
+    func parseTLSConfig(_ tlsConfig: [String: Polymorphic]) throws -> TLS.Config {
+        let verifyHost = tlsConfig["verifyHost"]?.bool ?? true
+        let verifyCertificates = tlsConfig["verifyCertificates"]?.bool ?? true
+
+        let certs = parseTLSCertificates(tlsConfig)
+        let config = try TLS.Config(
+            mode: .server,
+            certificates: certs,
+            verifyHost: verifyHost,
+            verifyCertificates: verifyCertificates
+        )
+
+        return config
+    }
+
+    func parseTLSCertificates(_ tlsConfig: [String: Polymorphic]) -> TLS.Certificates {
+        let certs: TLS.Certificates
+
+        if let certsConfig = tlsConfig["certificates"]?.string {
+            switch certsConfig {
+            case "none":
+                certs = .none
+            case "files":
+                if let chain = tlsConfig["chainFile"]?.string {
+                    let sig = parseTLSSignature(tlsConfig)
+                    certs = .chain(chainFile: chain, signature: sig)
+                } else {
+                    log.error("No TLS chainFile supplied, defaulting to none.")
+                    certs = .none
+                }
+            case "chain":
+                if
+                    let cert = tlsConfig["certificateFile"]?.string,
+                    let key = tlsConfig["privateKeyFile"]?.string
+                {
+                    let sig = parseTLSSignature(tlsConfig)
+                    certs = .files(certificateFile: cert, privateKeyFile: key, signature: sig)
+                } else {
+                    log.error("No TLS certificateFile or privateKeyFile supplied, defaulting to none.")
+                    certs = .none
+                }
+            case "ca":
+                let sig = parseTLSSignature(tlsConfig)
+                certs = .certificateAuthority(signature: sig)
+            default:
+                log.error("Unsupported TLS certificates \(certsConfig), defaulting to none.")
+                certs = .none
+            }
+        } else {
+            log.error("No TLS certificates supplied, defaulting to none.")
+            certs = .none
+        }
+
+        return certs
+    }
+
+    func parseTLSSignature(_ tlsConfig: [String: Polymorphic]) -> TLS.Certificates.Signature {
+        let signature: TLS.Certificates.Signature
+
+        if let sigConfig = tlsConfig["signature"]?.string {
+            switch sigConfig {
+            case "selfSigned":
+                signature = .selfSigned
+            case "signedFile":
+                if let caFile = tlsConfig["caCertificateFile"]?.string {
+                    signature = .signedFile(caCertificateFile: caFile)
+                } else {
+                    signature = .selfSigned
+                    log.error("No TLS signature caCertificateFile supplied, defaulting to selfSigned.")
+                }
+            case "signedDirectory":
+                if let caDir = tlsConfig["caCertificateDirectory"]?.string {
+                    signature = .signedDirectory(caCertificateDirectory: caDir)
+                } else {
+                    signature = .selfSigned
+                    log.error("No TLS signature caCertificateDirectory supplied, defaulting to selfSigned.")
+                }
+            default:
+                log.error("Unsupported TLS signature \(sigConfig), defaulting to selfSigned.")
+                signature = .selfSigned
+            }
+        } else {
+            log.error("No TLS signature supplied, defaulting to selfSigned.")
+            signature = .selfSigned
+        }
+
+        return signature
+    }
+}

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -144,6 +144,7 @@ public class Droplet {
     */
     public let environment: Environment
 
+
     internal private(set) lazy var routerResponder: Request.Handler = Request.Handler { [weak self] request in
         // Routed handler
         if let handler = self?.router.route(request, with: request) {
@@ -163,8 +164,6 @@ public class Droplet {
             }
         }
     }
-
-
 
     /**
         Initialize the Droplet.

--- a/Tests/VaporTests/DropletTests.swift
+++ b/Tests/VaporTests/DropletTests.swift
@@ -37,4 +37,22 @@ class DropletTests: XCTestCase {
 
         XCTAssert(found, "CSS Content Type not found")
     }
+
+    func testTLSConfig() throws {
+        let config = Config([
+            "servers": [
+                "secure": [
+                    "host": "vapor.codes",
+                    "port": 443,
+                    "securityLayer": "tls",
+                    "tls": [
+                        "certificates": "ca",
+                        "signature": "selfSigned"
+                    ]
+                ]
+            ]
+        ])
+
+        _ = Droplet(config: config)
+    }
 }


### PR DESCRIPTION
Fixes #557 


Allows TLS and certificates to be configured through JSON files.

### Examples

```json
{
	"host": "vapor.codes",
	"port": 443,
	"securityLayer": "tls",
	"tls": {
		"certificates": "ca",
		"signature": "signedFile",
		"caCertificateFile": "/path/to/file.pem"
	}
}
```

```json
{
	"host": "vapor.codes",
	"port": 443,
	"securityLayer": "tls",
	"tls": {
		"certificates": "files",
		"certificateFile": "/path/to/file.pem",
		"privateKeyFile": "/path/to/file.pem",
		"signature": "signedFile",
		"caCertificateFile": "/path/to/file.pem"
	}
}
```

