### PR TITLE
run

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+Run.swift
+++ b/Sources/Vapor/Droplet/Droplet+Run.swift
@@ -9,7 +9,7 @@ extension Droplet {
     /**
         Runs the Droplet's commands, defaulting to serve.
     */
-    public func serve(_ closure: Serve.ServeFunction? = nil) -> Never  {
+    public func run(_ closure: Serve.ServeFunction? = nil) -> Never  {
         do {
             try runCommands()
             exit(0)


### PR DESCRIPTION
`drop.serve` isn't always clear since the droplet's roles extend beyond just serving.  Moving to run for parity w/ toolbox. `vapor run serve`, `vapor run prepare`
