### PR TITLE
Implemented conditional requests, Fixes #539

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -269,7 +269,7 @@ public class Droplet {
 
         // default available middleware
         var am: [String: Middleware] = [
-            "file": FileMiddleware(workDir: workDir),
+            "file": FileMiddleware(publicDir: workDir + "Public"),
             "validation": ValidationMiddleware(),
             "date": DateMiddleware(),
             "type-safe": TypeSafeErrorMiddleware(),

--- a/Sources/Vapor/File/FileManager.swift
+++ b/Sources/Vapor/File/FileManager.swift
@@ -17,33 +17,33 @@ class FileManager {
     }
 
     // TODO: Try FileManager
-    static func fileAtPath(_ path: String) -> (exists: Bool, isDirectory: Bool) {
+    static func fileAtPath(_ path: String) -> (exists: Bool, isDirectory: Bool, status: stat) {
         var isDirectory = false
-        var s = stat()
-        if lstat(path, &s) >= 0 {
-            if (s.st_mode & S_IFMT) == S_IFLNK {
-                if stat(path, &s) >= 0 {
-                    isDirectory = (s.st_mode & S_IFMT) == S_IFDIR
+        var status = stat()
+        if lstat(path, &status) >= 0 {
+            if (status.st_mode & S_IFMT) == S_IFLNK {
+                if stat(path, &status) >= 0 {
+                    isDirectory = (status.st_mode & S_IFMT) == S_IFDIR
                 } else {
-                    return (false, isDirectory)
+                    return (false, isDirectory, status)
                 }
             } else {
-                isDirectory = (s.st_mode & S_IFMT) == S_IFDIR
+                isDirectory = (status.st_mode & S_IFMT) == S_IFDIR
             }
 
             // don't chase the link for this magic case -- we might be /Net/foo
             // which is a symlink to /private/Net/foo which is not yet mounted...
-            if (s.st_mode & S_IFMT) == S_IFLNK {
-                if (s.st_mode & S_ISVTX) == S_ISVTX {
-                    return (true, isDirectory)
+            if (status.st_mode & S_IFMT) == S_IFLNK {
+                if (status.st_mode & S_ISVTX) == S_ISVTX {
+                    return (true, isDirectory, status)
                 }
                 // chase the link; too bad if it is a slink to /Net/foo
-                let _ = stat(path, &s) >= 0
+                let _ = stat(path, &status) >= 0
             }
         } else {
-            return (false, isDirectory)
+            return (false, isDirectory, status)
         }
-        return (true, isDirectory)
+        return (true, isDirectory, status)
     }
 
     static func expandPath(_ path: String) throws -> String {

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -25,11 +25,12 @@ public class FileMiddleware: Middleware {
             
             var headers: [HeaderKey: String] = [:]
             
+            st_mtim
             // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
-            #if !_POSIX_C_SOURCE || _DARWIN_C_SOURCE
-                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtimespec.tv_sec, fileAttributes.status.st_size)
+            #if os(Linux)
+                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtim.tv_sec, fileAttributes.status.st_size)
             #else
-                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtime, fileAttributes.status.st_size)
+                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtimespec.tv_sec, fileAttributes.status.st_size)
             #endif
             
             headers["ETag"] = fileETag

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -26,7 +26,12 @@ public class FileMiddleware: Middleware {
             var headers: [HeaderKey: String] = [:]
             
             // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
-            let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtimespec.tv_sec, fileAttributes.status.st_size)
+            #if !_POSIX_C_SOURCE || _DARWIN_C_SOURCE
+                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtimespec.tv_sec, fileAttributes.status.st_size)
+            #else
+                let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtime, fileAttributes.status.st_size)
+            #endif
+            
             headers["ETag"] = fileETag
             
             // Check if file has been cached already and return NotModified response if the etags match

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -1,26 +1,42 @@
+import Foundation
 import HTTP
 
 public class FileMiddleware: Middleware {
-    public var workDir: String
-    public init(workDir: String) {
-        self.workDir = workDir
+    
+    private var publicDir: String
+    
+    public init(publicDir: String) {
+        // Remove last "/" from the publicDir if present, so we can directly append uri path from the request.
+        self.publicDir  = publicDir.hasSuffix("/") ? String(publicDir.characters.dropLast()) : publicDir
     }
-
+    
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
         do {
             return try next.respond(to: request)
         } catch Abort.notFound {
             // Check in file system
-            let filePath = self.workDir + "Public" + request.uri.path
+            let filePath = publicDir + request.uri.path
 
-            guard FileManager.fileAtPath(filePath).exists else {
+            let fileAttributes = FileManager.fileAtPath(filePath)
+
+            guard fileAttributes.exists else {
                 throw Abort.notFound
             }
+            
+            var headers: [HeaderKey: String] = [:]
+            
+            // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
+            let fileETag = String(format: "%x-%x", fileAttributes.status.st_mtimespec.tv_sec, fileAttributes.status.st_size)
+            headers["ETag"] = fileETag
+            
+            // Check if file has been cached already and return NotModified response if the etags match
+            if fileETag == request.headers["If-None-Match"] {
+                return Response(status: .notModified, headers: headers, body: .data([]))
+            }
 
-            // File exists
+            // File exists and was not cached, returning content of file.
             if let fileBody = try? FileManager.readBytesFromFile(filePath) {
-                var headers: [HeaderKey: String] = [:]
-
+                
                 if
                     let fileExtension = filePath.components(separatedBy: ".").last,
                     let type = mediaTypes[fileExtension]

--- a/Tests/VaporTests/FileManagerTests.swift
+++ b/Tests/VaporTests/FileManagerTests.swift
@@ -13,7 +13,11 @@ import Core
 class FileManagerTests: XCTestCase {
     static let allTests = [
         ("testReadsFromExistingFile", testReadsFromExistingFile),
-        ("testReadsFromNonExistingFile", testReadsFromNonExistingFile)
+        ("testReadsFromNonExistingFile", testReadsFromNonExistingFile),
+        ("testFileExists", testFileExists),
+        ("testFileDoesNotExist", testFileDoesNotExist),
+        ("testDirectoryExists", testDirectoryExists),
+        ("testDirectoryDoesNotExist", testDirectoryDoesNotExist)
     ]
     
     func testReadsFromExistingFile() {
@@ -30,6 +34,38 @@ class FileManagerTests: XCTestCase {
         } catch DataFile.Error.fileLoad {
             // We're happy here
         }
+    }
+    
+    func testFileExists() {
+        let fileName = #file
+        let existingFileResult = FileManager.fileAtPath(fileName)
+        
+        XCTAssertTrue(existingFileResult.exists, "exists is FALSE for existing file.")
+        XCTAssertFalse(existingFileResult.isDirectory, "isDirectory is TRUE for a file.")
+    }
+    
+    func testFileDoesNotExist() {
+        let fileName = #file + "foo"
+        let existingFileResult = FileManager.fileAtPath(fileName)
+        
+        XCTAssertFalse(existingFileResult.exists, "exists is TRUE for nonexisting file.")
+        XCTAssertFalse(existingFileResult.isDirectory, "isDirectory is TRUE for nonexisting file.")
+    }
+    
+    func testDirectoryExists() {
+        let directory = "/"
+        let attributes = FileManager.fileAtPath(directory)
+        
+        XCTAssertTrue(attributes.exists, "exists is FALSE for existing directory.")
+        XCTAssertTrue(attributes.isDirectory, "isDirectory is FALSE for existing directory.")
+    }
+    
+    func testDirectoryDoesNotExist() {
+        let directory = "/nonsense/"
+        let attributes = FileManager.fileAtPath(directory)
+        
+        XCTAssertFalse(attributes.exists, "exists is FALSE for nonexisting directory.")
+        XCTAssertFalse(attributes.isDirectory, "exists is FALSE for nonexisting directory.")
     }
     
 }

--- a/Tests/VaporTests/FileMiddlewareTests.swift
+++ b/Tests/VaporTests/FileMiddlewareTests.swift
@@ -1,0 +1,71 @@
+//
+//  FileMiddlewareTests.swift
+//  Vapor
+//
+//  Created by Sergo Beruashvili on 15/09/16.
+//
+//
+
+import XCTest
+import HTTP
+import Vapor
+
+class FileMiddlewareTests: XCTestCase {
+    static let allTests = [
+        ("testETag", testETag),
+        ("testNonExistingFile", testNonExistingFile)
+    ]
+    
+    func testETag() {
+        
+        let file = #file
+        let fileMiddleWare = FileMiddleware(publicDir: "/")
+        let drop = Droplet(availableMiddleware: ["file": fileMiddleWare])
+        
+        var headers: [HeaderKey: String] = [:]
+        
+        // First make sure it returns data with 200
+        do {
+            let response = try drop.respond(to: Request(method: .get, path: file))
+            XCTAssertTrue(response.status == .ok, "Status code is not OK ( 200 ) for existing file.")
+            XCTAssertTrue(response.body.bytes!.count > 0, "File content body IS NOT provided for existing file.")
+            
+            if let ETag = response.headers["ETag"] {
+                headers["If-None-Match"] = ETag
+            } else {
+                XCTFail("File MiddleWare not return ETag header")
+            }
+        } catch {
+            XCTFail("Droplet did break on existing file request.")
+        }
+        
+        // Now check that returns 304
+        do {
+            let request = Request(method: .get, path: file)
+            request.headers = headers
+            
+            let response = try drop.respond(to: request)
+            XCTAssertTrue(response.status == .notModified, "Status code is not 304 for existing cached file.")
+            XCTAssertTrue(response.body.bytes!.count == 0, "File content body IS provided for existing file.")
+            
+            // Make sure ETag did not change
+            XCTAssertTrue(headers["If-None-Match"] == response.headers["ETag"], "Generated ETag for cached file does not match old one.")
+        } catch {
+            XCTFail("Droplet did break on existing file request.")
+        }
+    }
+    
+    
+    func testNonExistingFile() {
+        let file = "/nonsense/file.notexists"
+        let fileMiddleWare = FileMiddleware(publicDir: "/")
+        let drop = Droplet(availableMiddleware: ["file": fileMiddleWare])
+        
+        do {
+            let response = try drop.respond(to: Request(method: .get, path: file))
+            XCTAssertTrue(response.status == .notFound, "Status code is not 404 for nonexisting file.")
+        } catch {
+            XCTFail("Droplet did break on existing file request.")
+        }
+    }
+}


### PR DESCRIPTION
Implemented conditional requests for static files using ETag ( https://github.com/vapor/vapor/issues/539 )

Added few tests to FileManager.


This commit handles requests to the Public Directory.

It checks for header "If-None-Match" and compares to the local files ETag, If ETags match, returns 304 not modified,

If header is not present or does not match local ETag, returns 200 with actual file's content and ETag header.