### PR TITLE
Always use staticServerMiddleware in Droplet

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -494,7 +494,7 @@ public class Droplet {
             // if not config was supplied,
             // use whatever middlewares were
             // provided
-            serverEnabledMiddleware = Array(middleware.values)
+            serverEnabledMiddleware += Array(middleware.values)
         }
 
         self.enabledMiddleware = serverEnabledMiddleware.reversed()


### PR DESCRIPTION
Vapor currently won't use any of the middleware when no middleware is supplied in a config file:

```swift
let drop = Droplet(
    staticServerMiddleware: [
        /* custom middleware here */
    ])
```

Is this the intended behavior? If not, this PR fixes that