### PR TITLE
Remove force unwrap in favour of throws

### DIFF
--- a/Sources/Vapor/Fluent/Model.swift
+++ b/Sources/Vapor/Fluent/Model.swift
@@ -16,9 +16,9 @@ extension Model {
 // MARK: JSONRepresentable
 
 extension Model {
-    public func makeJSON() -> JSON {
-        let node = try! makeNode()
-        return try! JSON(node: node)
+    public func makeJSON() throws -> JSON {
+        let node = try makeNode()
+        return try JSON(node: node)
     }
 }
 


### PR DESCRIPTION
### Problem
- the current implementation of `makeJSON()` in protocol extension does not take into account that
`makeJSON()` throws that's why there is a force unwrap `try` which might lead to crash

### Solution 
- make `makeJSON()` throwable function 