### PR TITLE
Avoid setting an empty string as a Set-Cookie header.

### DIFF
--- a/Sources/Cookies/Request+Cookies.swift
+++ b/Sources/Cookies/Request+Cookies.swift
@@ -23,7 +23,14 @@ extension Request {
         }
         set(cookie) {
             storage["Cookie"] = cookie
-            headers["Cookie"] = cookie.serialize(for: .request)
+            
+            let cookieHeader = cookie.serialize(for: .request)
+            if !cookieHeader.isEmpty {
+                headers["Cookie"] = cookieHeader
+            }
+            else {
+                headers["Cookie"] = nil
+            }
         }
     }
 }

--- a/Sources/Cookies/Request+Cookies.swift
+++ b/Sources/Cookies/Request+Cookies.swift
@@ -27,8 +27,7 @@ extension Request {
             let cookieHeader = cookie.serialize(for: .request)
             if !cookieHeader.isEmpty {
                 headers["Cookie"] = cookieHeader
-            }
-            else {
+            } else {
                 headers["Cookie"] = nil
             }
         }

--- a/Sources/Cookies/Response+Cookies.swift
+++ b/Sources/Cookies/Response+Cookies.swift
@@ -27,8 +27,7 @@ extension Response {
             let cookieHeader = cookie.serialize(for: .response)
             if !cookieHeader.isEmpty {
                 headers["Set-Cookie"] = cookieHeader
-            }
-            else {
+            } else {
                 headers["Set-Cookie"] = nil
             }
         }

--- a/Sources/Cookies/Response+Cookies.swift
+++ b/Sources/Cookies/Response+Cookies.swift
@@ -23,7 +23,14 @@ extension Response {
         }
         set(cookie) {
             storage["Set-Cookie"] = cookie
-            headers["Set-Cookie"] = cookie.serialize(for: .response)
+            
+            let cookieHeader = cookie.serialize(for: .response)
+            if !cookieHeader.isEmpty {
+                headers["Set-Cookie"] = cookieHeader
+            }
+            else {
+                headers["Set-Cookie"] = nil
+            }
         }
     }
 }


### PR DESCRIPTION
When no cookies were set, Vapor was still returning an empty `Set-Cookie` header. This resulted in problems when I was testing with Postman and I am assuming this is not wanted behaviour.

This pull request fixes this, by validating that the serialisation result of the cookies is not empty. In the case that it is empty, it simply removes the `Set-Cookie` header altogether.