### PR TITLE
Updated AuthMiddleware to allow for a custom cookie name

### DIFF
--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -4,21 +4,24 @@ import Cookies
 import Foundation
 import Cache
 
-private let cookieName = "vapor-auth"
+private let defaultCookieName = "vapor-auth"
 private let cookieTimeout: TimeInterval = 7 * 24 * 60 * 60
 
 public class AuthMiddleware<U: User>: Middleware {
     private let turnstile: Turnstile
+    private let cookieName: String
     private let cookieFactory: CookieFactory
 
     public typealias CookieFactory = (String) -> Cookie
 
     public init(
         turnstile: Turnstile,
+        cookieName: String,
         makeCookie cookieFactory: CookieFactory?
     ) {
         self.turnstile = turnstile
-
+        
+        self.cookieName = cookieName
         self.cookieFactory = cookieFactory ?? { value in
             return Cookie(
                 name: cookieName,
@@ -29,16 +32,24 @@ public class AuthMiddleware<U: User>: Middleware {
             )
         }
     }
+    
+    public convenience init(
+        turnstile: Turnstile,
+        makeCookie cookieFactory: CookieFactory?
+        ) {
+        self.init(turnstile: turnstile, cookieName: defaultCookieName, makeCookie: cookieFactory)
+    }
 
     public convenience init(
         user: U.Type = U.self,
         realm: Realm = AuthenticatorRealm(U.self),
         cache: CacheProtocol = MemoryCache(),
+        cookieName: String = defaultCookieName,
         makeCookie cookieFactory: CookieFactory? = nil
     ) {
         let session = CacheSessionManager(cache: cache, realm: realm)
         let turnstile = Turnstile(sessionManager: session, realm: realm)
-        self.init(turnstile: turnstile, makeCookie: cookieFactory)
+        self.init(turnstile: turnstile, cookieName: cookieName, makeCookie: cookieFactory)
     }
 
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
@@ -54,7 +65,8 @@ public class AuthMiddleware<U: User>: Middleware {
             let sid = try request.subject().sessionIdentifier,
             request.cookies[cookieName] != sid
         {
-            let cookie = cookieFactory(sid)
+            var cookie = cookieFactory(sid)
+            cookie.name = cookieName
             response.cookies.insert(cookie)
         } else if
             try request.subject().sessionIdentifier == nil,

--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -16,7 +16,7 @@ public class AuthMiddleware<U: User>: Middleware {
 
     public init(
         turnstile: Turnstile,
-        cookieName: String,
+        cookieName: String = defaultCookieName,
         makeCookie cookieFactory: CookieFactory?
     ) {
         self.turnstile = turnstile
@@ -31,13 +31,6 @@ public class AuthMiddleware<U: User>: Middleware {
                 httpOnly: true
             )
         }
-    }
-    
-    public convenience init(
-        turnstile: Turnstile,
-        makeCookie cookieFactory: CookieFactory?
-        ) {
-        self.init(turnstile: turnstile, cookieName: defaultCookieName, makeCookie: cookieFactory)
     }
 
     public convenience init(

--- a/Tests/AuthTests/AuthMiddlewareTests.swift
+++ b/Tests/AuthTests/AuthMiddlewareTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import HTTP
+@testable import Auth
+
+class AuthMiddlewareTests: XCTestCase {
+    static let allTests = [
+        ("testCustomCookieName", testCustomCookieName),
+    ]
+
+    func testCustomCookieName() throws {
+        let cookieName = "custom-auth-cookie-name"
+        let authMiddleware = AuthMiddleware(user: AuthUser.self, cookieName: cookieName)
+        
+        let request = try Request(method: .get, uri: "test")
+        
+        let responder = AuthMiddlewareResponser()
+        let response = try authMiddleware.respond(to: request, chainingTo: responder)
+        
+        let cookie = response.cookies[cookieName]
+        XCTAssertNotNil(cookie)
+    }
+}

--- a/Tests/AuthTests/Utilities/AuthMiddlewareResponser.swift
+++ b/Tests/AuthTests/Utilities/AuthMiddlewareResponser.swift
@@ -1,0 +1,9 @@
+import HTTP
+import Turnstile
+
+class AuthMiddlewareResponser : Responder {
+    func respond(to request: Request) throws -> Response {
+        try request.auth.login(UsernamePassword(username: "username", password: "password"))
+        return "test".makeResponse()
+    }
+}

--- a/Tests/AuthTests/Utilities/AuthMiddlewareResponser.swift
+++ b/Tests/AuthTests/Utilities/AuthMiddlewareResponser.swift
@@ -1,7 +1,7 @@
 import HTTP
 import Turnstile
 
-class AuthMiddlewareResponser : Responder {
+class AuthMiddlewareResponser: Responder {
     func respond(to request: Request) throws -> Response {
         try request.auth.login(UsernamePassword(username: "username", password: "password"))
         return "test".makeResponse()

--- a/Tests/AuthTests/Utilities/AuthUser.swift
+++ b/Tests/AuthTests/Utilities/AuthUser.swift
@@ -1,0 +1,41 @@
+import Vapor
+import Auth
+
+final class AuthUser: Model, User {
+    var id: Node?
+    var name: String
+    var exists: Bool = false
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    init(node: Node, in context: Context) throws {
+        self.id = nil
+        self.name = try node.extract("name")
+    }
+    
+    func makeNode(context: Context) throws -> Node {
+        return try Node(node: [
+            "id": id,
+            "name": name
+        ])
+    }
+    
+    static func prepare(_ database: Database) throws {
+        
+    }
+    
+    static func revert(_ database: Database) throws {
+        
+    }
+    
+    static func authenticate(credentials: Credentials) throws -> Auth.User {
+        return AuthUser(name: "test")
+    }
+    
+    
+    static func register(credentials: Credentials) throws -> Auth.User {
+        throw Abort.custom(status: .badRequest, message: "Register not supported.")
+    }
+}


### PR DESCRIPTION
The `AuthMiddleware` has an option to pass a cookie factory closure. The name of the cookie however, is fixed to a private string variable. This makes the cookie factory closure a bit difficult to use, as the name has to be hardcoded as the same private string in `AuthMiddleware`. 

This pull request overcomes this, by making the cookie name a property that can be passed when creating the `AuthMiddleware`.