### PR TITLE
Fix `Response had no 'Content-Type' header. when request files in Public folder

### DIFF
--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -40,7 +40,15 @@ public final class FileMiddleware: Middleware {
             // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
             let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize.intValue)"
             headers["ETag"] = fileETag
-            
+			
+			// Set Content-Type header based on the media type
+			if
+				let fileExtension = filePath.components(separatedBy: ".").last,
+				let type = mediaTypes[fileExtension]
+			{
+				headers["Content-Type"] = type
+			}
+			
             // Check if file has been cached already and return NotModified response if the etags match
             if fileETag == request.headers["If-None-Match"] {
                 return Response(status: .notModified, headers: headers, body: .data([]))
@@ -48,14 +56,6 @@ public final class FileMiddleware: Middleware {
 
             // File exists and was not cached, returning content of file.
             if let fileBody = try? loader.load(path:filePath) {
-                
-                if
-                    let fileExtension = filePath.components(separatedBy: ".").last,
-                    let type = mediaTypes[fileExtension]
-                {
-                    headers["Content-Type"] = type
-                }
-
                 return Response(status: .ok, headers: headers, body: .data(fileBody))
             } else {
                 print("unable to load path")

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -40,15 +40,15 @@ public final class FileMiddleware: Middleware {
             // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
             let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize.intValue)"
             headers["ETag"] = fileETag
-			
-			// Set Content-Type header based on the media type
-			if
-				let fileExtension = filePath.components(separatedBy: ".").last,
-				let type = mediaTypes[fileExtension]
-			{
-				headers["Content-Type"] = type
-			}
-			
+            
+            // Set Content-Type header based on the media type
+            if
+                let fileExtension = filePath.components(separatedBy: ".").last,
+                let type = mediaTypes[fileExtension]
+            {
+                headers["Content-Type"] = type
+            }
+            
             // Check if file has been cached already and return NotModified response if the etags match
             if fileETag == request.headers["If-None-Match"] {
                 return Response(status: .notModified, headers: headers, body: .data([]))

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -37,10 +37,6 @@ public final class FileMiddleware: Middleware {
 
             var headers: [HeaderKey: String] = [:]
 
-            // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
-            let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize.intValue)"
-            headers["ETag"] = fileETag
-            
             // Set Content-Type header based on the media type
             if
                 let fileExtension = filePath.components(separatedBy: ".").last,
@@ -48,6 +44,10 @@ public final class FileMiddleware: Middleware {
             {
                 headers["Content-Type"] = type
             }
+            
+            // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
+            let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize.intValue)"
+            headers["ETag"] = fileETag
             
             // Check if file has been cached already and return NotModified response if the etags match
             if fileETag == request.headers["If-None-Match"] {


### PR DESCRIPTION
#### Issue: 
When requesting a file in `/Public` folder, if this file is cached, the HTTP response had no 'Content-Type' header.` set.

#### Problem
FilleMiddle returns a `Response` without setting `Content-Type` header if the requested file has been cached.

#### Fix
This PR set `Content-Type` header regardless of the file is new or cached.