### PR TITLE
Fix warning about deprecated '.mozilla' certsConfig

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+TLS.swift
+++ b/Sources/Vapor/Droplet/Droplet+TLS.swift
@@ -46,7 +46,12 @@ extension Droplet {
                 let sig = parseTLSSignature(tlsConfig)
                 certs = .certificateAuthority(signature: sig)
             case "mozilla":
+                print("[deprecated] Mozilla certificates have been deprecated and will be removed in future releases. Using 'defaults' instead.")
+                certs = .defaults
+            case "openbsd":
                 certs = .openbsd
+            case "defaults", "default":
+                certs = .defaults
             default:
                 log.error("Unsupported TLS certificates \(certsConfig), defaulting to none.")
                 certs = .none

--- a/Sources/Vapor/Droplet/Droplet+TLS.swift
+++ b/Sources/Vapor/Droplet/Droplet+TLS.swift
@@ -46,7 +46,7 @@ extension Droplet {
                 let sig = parseTLSSignature(tlsConfig)
                 certs = .certificateAuthority(signature: sig)
             case "mozilla":
-                certs = .mozilla
+                certs = .openbsd
             default:
                 log.error("Unsupported TLS certificates \(certsConfig), defaulting to none.")
                 certs = .none


### PR DESCRIPTION
The fix is doing what the compiler warning wants: it replaces `.mozilla` with `.openbsd`

<img width="257" alt="screenshot 2016-11-04 at 11 03 53" src="https://cloud.githubusercontent.com/assets/564725/20002036/12593f5a-a27f-11e6-8ef1-08f8f8e96ac2.png">
