### PR TITLE
Fix a crash where parsing a Multipart with empty content

### DIFF
--- a/Sources/Vapor/Utilities/Byte/Data.swift
+++ b/Sources/Vapor/Utilities/Byte/Data.swift
@@ -42,7 +42,7 @@ extension Collection where Iterator.Element == Byte, IndexDistance == Int, Index
                 // Take the data inbetween this and the next boundry
                 let nextRange = ranges[pos + 1]
                 // Skip if there is no content
-                if range.to > nextRange.from {
+                guard range.to < nextRange.from else {
                     break
                 }
                 parts.append(self[range.to..<nextRange.from].array)

--- a/Sources/Vapor/Utilities/Byte/Data.swift
+++ b/Sources/Vapor/Utilities/Byte/Data.swift
@@ -43,7 +43,7 @@ extension Collection where Iterator.Element == Byte, IndexDistance == Int, Index
                 let nextRange = ranges[pos + 1]
                 // Skip if there is no content
                 if range.to > nextRange.from {
-                  continue
+                    break
                 }
                 parts.append(self[range.to..<nextRange.from].array)
 

--- a/Sources/Vapor/Utilities/Byte/Data.swift
+++ b/Sources/Vapor/Utilities/Byte/Data.swift
@@ -41,7 +41,10 @@ extension Collection where Iterator.Element == Byte, IndexDistance == Int, Index
             if pos < ranges.count - 1 {
                 // Take the data inbetween this and the next boundry
                 let nextRange = ranges[pos + 1]
-
+                // Skip if there is no content
+                if range.to > nextRange.from {
+                  continue
+                }
                 parts.append(self[range.to..<nextRange.from].array)
 
             // If this is after the last separator and shouldn't be thrown away

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -69,6 +69,11 @@ class ContentTests: XCTestCase {
         body += "\r\n"
         body += "\r\n"
         body += "--" + boundary + "\r\n"
+        body += "Content-Disposition: form-data; name=\"value2\"\r\n"
+        body += "Content-Type: image/gif\r\n"
+        body += "\r\n"
+        body += "123"
+        body += "--" + boundary + "\r\n"
         print("Body: \(body)")
 
         let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
@@ -76,6 +81,7 @@ class ContentTests: XCTestCase {
         let data = Multipart.parse(body.bytes, boundary: parsedBoundary)
         print("Data: \(data)")
         XCTAssertNil(data["value"], "Request did not parse correctly")
+        XCTAssertEqual(data["value2"]?.file?.data ?? [1,2,3], "123".bytes, "Request did not parse correctly")
     }
 
     func testMultipartFile() {

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -19,7 +19,9 @@ class ContentTests: XCTestCase {
         ("testSetJSON", testSetJSON),
         ("testParse", testParse),
         ("testMultipart", testMultipart),
+        ("testMultipartEmptyContent", testMultipartEmptyContent),
         ("testMultipartFile", testMultipartFile),
+        ("testMultipartFileEmptyContent", testMultipartFileEmptyContent),
         ("testFormURLEncoded", testFormURLEncoded),
         ("testFormURLEncodedEdge", testFormURLEncodedEdge),
         ("testSplitString", testSplitString),
@@ -59,6 +61,23 @@ class ContentTests: XCTestCase {
         XCTAssertEqual(data["value"]?.int, 123, "Request did not parse correctly")
     }
 
+    func testMultipartEmptyContent() throws {
+        let boundary = "~~vapor~~"
+
+        var body = "--" + boundary + "\r\n"
+        body += "Content-Disposition: form-data; name=\"value\"\r\n"
+        body += "\r\n"
+        body += "\r\n"
+        body += "--" + boundary + "\r\n"
+        print("Body: \(body)")
+
+        let parsedBoundary = try Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+        print("Parsed boundary: \(parsedBoundary)")
+        let data = Multipart.parse(body.bytes, boundary: parsedBoundary)
+        print("Data: \(data)")
+        XCTAssertNil(data["value"], "Request did not parse correctly")
+    }
+
     func testMultipartFile() {
         let boundary = "~~vapor~~"
 
@@ -74,6 +93,23 @@ class ContentTests: XCTestCase {
         let data = Multipart.parse(body.bytes, boundary: parsedBoundary)
 
         XCTAssertEqual(data["value"]?.file?.data ?? [1,2,3], "123".bytes, "Request did not parse correctly")
+    }
+
+    func testMultipartFileEmptyContent() throws {
+        let boundary = "~~vapor~~"
+
+        var body = "--" + boundary + "\r\n"
+        body += "Content-Disposition: form-data; name=\"value\"; filename=\"filename\"\r\n"
+        body += "Content-Type: application/octet-stream\r\n"
+        body += "\r\n"
+        body += "\r\n"
+        body += "--" + boundary + "\r\n"
+
+        let parsedBoundary = try! Multipart.parseBoundary(contentType: "multipart/form-data; charset=utf-8; boundary=\(boundary)")
+        print("Got parsed boundary: \(parsedBoundary)")
+        let data = Multipart.parse(body.bytes, boundary: parsedBoundary)
+
+        XCTAssertNil(data["value"], "Request did not parse correctly")
     }
 
     func testFormURLEncoded() {


### PR DESCRIPTION
Reported in Slack, a crash when parsing this body:

```
------WebKitFormBoundaryUIJNcsyK0GGA6kOU
Content-Disposition: form-data; name="xib"; filename=""
Content-Type: application/octet-stream


------WebKitFormBoundaryUIJNcsyK0GGA6kOU
Content-Disposition: form-data; name="ajax"

1
------WebKitFormBoundaryUIJNcsyK0GGA6kOU
Content-Disposition: form-data; name="xib"; filename="AlarmSettings.xib"
Content-Type: application/octet-stream

<?xml version="1.0" encoding="UTF-8" standalone="no"?>
....SNIP...
------WebKitFormBoundaryUIJNcsyK0GGA6kOU———
```

The crash was caused by the first part, which was created by an HTML `file` input which had been left empty. Vapor crashed on line 45 of Vapor/Utilities/Byte/Data.swift trying to make a range where the lower bound was greater than the upper bound.

I've simply put in a conditional that stops that from happening, and causes an empty part to be ignored. There may be a better solution but this stops the crash.