### PR TITLE
Fixing a small warning in unit tests

### DIFF
--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -29,7 +29,7 @@ class ContentTests: XCTestCase {
     ]
 
     func testSetJSON() throws {
-        let request = try Request(method: .get, path: "/")
+        let request = Request(method: .get, path: "/")
         let json = JSON(["hello": "world"])
         request.json = json
         XCTAssertEqual(json, request.json)


### PR DESCRIPTION
This call is using `try` but it does not need to.