### PR TITLE
Added missing JSON content-type to validation middleware Response

### DIFF
--- a/Sources/Vapor/Validation/ValidationMiddleware.swift
+++ b/Sources/Vapor/Validation/ValidationMiddleware.swift
@@ -17,7 +17,9 @@ public class ValidationMiddleware: Middleware {
                 "message": error.message
             ])
             let data = try json.makeBytes()
-            return Response(status: .badRequest, body: .data(data))
+            let response = Response(status: .badRequest, body: .data(data))
+            response.headers["Content-Type"] = "application/json; charset=utf-8"
+            return response
         }
     }
     


### PR DESCRIPTION
The ValidationMiddleware's response was missing the JSON content type in the headers, as seen on other middleware response (Abort for example).