### PR TITLE
fix vapor Accept-Language parsing

### DIFF
--- a/Sources/Vapor/Localization/Localization.swift
+++ b/Sources/Vapor/Localization/Localization.swift
@@ -39,9 +39,18 @@ public class Localization {
         return self[languageCode, paths]
     }
 
-    public subscript(_ languageCode: String, _ paths: [PathIndex]) -> String {
-        return localizations[languageCode.lowercased()]?[paths]?.string  // Index by language
-            ?? localizations[defaultDialect]?[paths]?.string // Index the default language
+    public subscript(_ languageCodes: String, _ paths: [PathIndex]) -> String {
+        let codeComponents = languageCodes.components(separatedBy: ",")  // Separate language components by ,
+        for code in codeComponents {
+            let langCode = code.components(separatedBy: ";").first!.string!
+            if langCode.isEmpty {
+                continue
+            }
+            if let result = localizations[langCode.lowercased()]?[paths]?.string {
+                return result
+            }
+        }
+        return localizations[defaultDialect]?[paths]?.string // Index the default language
             ?? paths.map { "\($0)" }.joined(separator: ".") // Return the literal path indexed if no translation
     }
 }

--- a/Sources/Vapor/Localization/Localization.swift
+++ b/Sources/Vapor/Localization/Localization.swift
@@ -47,7 +47,7 @@ public class Localization {
                 continue
             }
             if let result = localizations[langCode.lowercased()]?[paths]?.string {
-                return result
+                return result    //First localization which matches will be returned
             }
         }
         return localizations[defaultDialect]?[paths]?.string // Index the default language


### PR DESCRIPTION
the browser could accept multiple languages separated by ','  
just like:

Accept-Language: da, en-gb;q=0.8, en;q=0.7

I've choosed the first matched localization file in vapor locales to return

ref:
https://www.w3.org/International/questions/qa-lang-priorities
