### PR TITLE
Fix: Process should exit if no servers are started after `run`

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+Run.swift
+++ b/Sources/Vapor/Droplet/Droplet+Run.swift
@@ -13,9 +13,12 @@ extension Droplet {
     public func run(servers: [String: ServerConfig]? = nil) -> Never  {
         do {
             try runCommands(servers: servers)
-            let group = DispatchGroup()
-            group.enter()
-            group.wait()
+            if (self.startedServers.count > 0) {
+                // if servers were started, wait (forever) on a DispatchGroup to prevent the process from exiting
+                let group = DispatchGroup()
+                group.enter()
+                group.wait()
+            }
             exit(0)
         } catch CommandError.general(let error) {
             console.output(error, style: .error)


### PR DESCRIPTION
In the blocking version, the process would live as long as a server
loop was running. Since the non-blocking version doesn’t use loops, a
`DispatchQueue` was used to keep the process alive when a `run` command
was issued. However, some `run` commands don’t start servers and are
expected to exit. This patch fixes that.

Fixes https://github.com/vapor/vapor/issues/735