### PR TITLE
Workaround for Swift SR-3081

### DIFF
--- a/Sources/Vapor/Serve/Droplet+BootServers.swift
+++ b/Sources/Vapor/Serve/Droplet+BootServers.swift
@@ -35,7 +35,9 @@ extension Droplet {
             port: config.port,
             securityLayer: config.securityLayer,
             responder: self,
-            errors: serverErrors
+            errors: { e in
+                self.serverErrors(error: e)
+            }
         )
         startedServers[name] = server
         return server


### PR DESCRIPTION
This prevents the error message “duplicate symbol __TMRbBp”, which is caused by the following Swift compiler bug: https://bugs.swift.org/browse/SR-3081

Fixes https://github.com/vapor/vapor/issues/732