### PR TITLE
access request from view

### DIFF
--- a/Sources/Vapor/HTTP/HTTP+Node.swift
+++ b/Sources/Vapor/HTTP/HTTP+Node.swift
@@ -1,0 +1,86 @@
+import Node
+import URI
+import HTTP
+import Sessions
+
+extension Request: NodeRepresentable {
+    /**
+        Converts the Request into a Node.
+     
+        Contains the following information:
+            - Session
+            - Storage
+            - Method
+            - Version
+            - URI
+    */
+    public func makeNode(context: Context) throws -> Node {
+        var nodeStorage: [String: Node] = [:]
+        
+        for (key, val) in storage {
+            if let node = val as? NodeRepresentable {
+                nodeStorage[key] = try node.makeNode()
+            }
+        }
+        
+        return try Node(node: [
+            "session": try session().makeNode(context: context),
+            "storage": Node.object(nodeStorage),
+            "method": method.description,
+            "version": version.makeNode(context: context),
+            "uri": uri.makeNode(context: context)
+        ])
+    }
+}
+
+extension Session: NodeRepresentable {
+    /**
+        Converts the Session in a Node.
+     
+        Contains the following information:
+            - Data
+            - Identifier
+    */
+    public func makeNode(context: Context) throws -> Node {
+        return try Node(node: [
+            "data": data,
+            "identifier": identifier
+        ])
+    }
+}
+
+extension Version: NodeRepresentable {
+    /**
+        Converts the Version in a Node.
+     
+        Contains the following information:
+            - Major
+            - Minor
+            - Patch
+    */
+    public func makeNode(context: Context) throws -> Node {
+        return try Node(node: [
+            "major": major,
+            "minor": minor,
+            "patch": patch
+        ])
+    }
+}
+
+extension URI: NodeRepresentable {
+    /**
+        Converts the URI in a Node.
+     
+        Contains the following information:
+            - Path
+            - Host
+            - Scheme
+    */
+    public func makeNode(context: Context) throws -> Node {
+        return try Node(node: [
+            "path": path,
+            "host": host,
+            "scheme": scheme
+        ])
+    }
+}

--- a/Sources/Vapor/View/ViewRenderer+Request.swift
+++ b/Sources/Vapor/View/ViewRenderer+Request.swift
@@ -1,0 +1,58 @@
+import HTTP
+
+extension ViewRenderer {
+    /**
+        Creates a view at the given path
+        using a Request as the data that will
+        be supplied to the view.
+     
+        Data from the `Request` is available in the
+        view under the key "request".
+    */
+    public func make(_ path: String, for request: Request) throws -> View {
+        let context = try Node(node: [
+            "request": request.makeNode()
+        ])
+        
+        return try make(path, context)
+    }
+    
+    /**
+        Creates a view at the given path
+        using a `NodeRepresentable` context
+        that will be merged with the given `Request`
+        and supplied as the data to the view.
+     
+        Data from the `Request` is available in the
+        view under the key "request".
+    */
+    public func make(_ path: String, _ context: NodeRepresentable, for request: Request) throws -> View {
+        let node: Node
+        
+        if case .object(var nodeObject) = try context.makeNode() {
+            nodeObject["request"] = try request.makeNode()
+            node = Node.object(nodeObject)
+        } else {
+            node = try context.makeNode()
+        }
+        
+        return try make(path, node)
+    }
+    
+    /**
+        Creates a view at the given path
+        using a `NodeRepresentable` dictionary
+        that will be merged with the given `Request`
+        and supplied as the data to the view.
+     
+        Data from the `Request` is available in the
+        view under the key "request".
+    */
+    public func make(_ path: String, _ context: [String: NodeRepresentable], for request: Request) throws -> View {
+        var context = context
+        
+        context["request"] = try request.makeNode()
+        
+        return try make(path, try context.makeNode())
+    }
+}

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -2,12 +2,15 @@ import XCTest
 import Leaf
 import Core
 @testable import Vapor
+import HTTP
+import Sessions
 
 class ViewTests: XCTestCase {
     static let allTests = [
         ("testBasic", testBasic),
         ("testViewBytes", testViewBytes),
         ("testViewResponse", testViewResponse),
+        ("testViewRequest", testViewRequest)
     ]
 
     func testBasic() throws {
@@ -34,6 +37,39 @@ class ViewTests: XCTestCase {
 
         XCTAssertEqual(response.headers["content-type"], "text/html; charset=utf-8")
         XCTAssertEqual(try response.bodyString(), "42 🚀")
+    }
+    
+    func testViewRequest() throws {
+        let drop = Droplet()
+        
+        let request = Request(method: .get, path: "/foopath")
+        
+        let memory = MemorySessions()
+        let sessions = SessionsMiddleware(sessions: memory)
+        drop.middleware.append(sessions)
+        
+        // sets up a session on the request
+        let _ = try drop.respond(to: request)
+        
+        request.storage["test"] = "foobar"
+        try request.session().data["name"] = "Vapor"
+        
+        final class TestRenderer: ViewRenderer {
+            init(viewsDir: String) { }
+            
+            func make(_ path: String, _ context: Node) throws -> View {
+                return View(data: "\(context)".bytes)
+            }
+        }
+        
+        drop.view = TestRenderer(viewsDir: "")
+        
+        let view = try drop.view.make("test-template", for: request)
+        let string = try view.data.string()
+        
+        XCTAssert(string.contains("Vapor"))
+        XCTAssert(string.contains("foopath"))
+        XCTAssert(string.contains("foobar"))
     }
 
     func testLeafRenderer() throws {


### PR DESCRIPTION
This pull request adds access to the `Request` (including sessions, storage, and more) from views.

### Access Request from View

```swift
drop.get("view") { req in
    return try drop.view.make("form", [
        "name": "Foo"
    ], for: request)
}
```

```leaf
<h1>My Form: #(name)</h1>

#if(request.session.data.user) {
    Welcome #(request.session.data.user.name)
}
```