### PR TITLE
Added LoginRedirectMiddleware

### DIFF
--- a/Sources/Auth/Authentication/LoginRedirectMiddleware.swift
+++ b/Sources/Auth/Authentication/LoginRedirectMiddleware.swift
@@ -1,0 +1,16 @@
+import HTTP
+
+public class LoginRedirectMiddleware: Middleware {
+    public let loginRoute: String
+    public init(loginRoute: String) {
+        self.loginRoute = loginRoute
+    }
+    
+    public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
+        guard try request.subject().authenticated else {
+            return Response(redirect: loginRoute)
+        }
+
+        return try next.respond(to: request)
+    }
+}


### PR DESCRIPTION
Works just like the protect middleware, except if users are unauthenticated this automatically redirects to the login page instead of throwing an error. 

I've found this middleware to be very useful for my servers. Makes it really easy to set up routes that users need to be authenticated for, but send them to the login page automatically instead of making the user manually enter the login page url.

Could probably be renamed to just "RedirectMiddleware" though