### PR TITLE
AbortError: error codes, messages and metadata

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -1,4 +1,24 @@
 import HTTP
+import Node
+
+/**
+    Represents errors that can be thrown in any Vapor closure.
+    Then, these errors can be caught in `Middleware` to give a
+    desired response.
+ */
+public protocol AbortError: Error {
+    /// Textual representation on the error.
+    var message: String { get }
+    
+    /// An integer representation of the error.
+    var code: Int { get }
+    
+    /// The HTTP status code to return.
+    var status: Status { get }
+    
+    /// `Optional` metadata.
+    var metadata: Node? { get }
+}
 
 /**
     A handful of standard errors that can be thrown
@@ -11,4 +31,49 @@ public enum Abort: Swift.Error {
     case notFound
     case serverError
     case custom(status: Status, message: String)
+}
+
+extension Abort: AbortError {
+    public var message: String {
+        switch self {
+        case .badRequest:
+            return "Invalid request"
+        case .notFound:
+            return "Page not Found"
+        case .serverError:
+            return "Something went wrong"
+        case .custom(status: _, message: let message):
+            return message
+        }
+    }
+    
+    public var code: Int {
+        switch self {
+        case .badRequest:
+            return 400
+        case .notFound:
+            return 404
+        case .serverError:
+            return 500
+        case .custom(status: let status, message: _):
+            return status.statusCode
+        }
+    }
+    
+    public var status: Status {
+        switch self {
+        case .badRequest:
+            return .badRequest
+        case .notFound:
+            return .notFound
+        case .serverError:
+            return .internalServerError
+        case .custom(status: let status, message: _):
+            return status
+        }
+    }
+    
+    public var metadata: Node? {
+        return nil
+    }
 }

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -39,7 +39,7 @@ extension Abort: AbortError {
         case .badRequest:
             return "Invalid request"
         case .notFound:
-            return "Page not Found"
+            return "Page not found"
         case .serverError:
             return "Something went wrong"
         case .custom(status: _, message: let message):

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -27,20 +27,34 @@ public class AbortMiddleware: Middleware {
             return try AbortMiddleware.errorResponse(request, error)
         }
     }
-
+    
     public static func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
+        return try errorResponse(request, error.status, error.message, error.code, error.metadata)
+    }
+    
+    public static func errorResponse(_ request: Request, _ status: Status, _ message: String) throws -> Response {
+        return try errorResponse(request, status, message, status.statusCode)
+    }
+    
+    public static func errorResponse(
+        _ request: Request,
+        _ status: Status,
+        _ message: String,
+        _ code: Int,
+        _ metadata: Node? = nil
+    ) throws -> Response {
         if request.accept.prefers("html") {
-            return ErrorView.shared.makeResponse(error.status, error.message)
+            return ErrorView.shared.makeResponse(status, message)
         }
 
         let json = try JSON(node: [
             "error": true,
-            "message": "\(error.message)",
-            "code": error.code,
-            "metadata": error.metadata
+            "message": "\(message)",
+            "code": code,
+            "metadata": metadata
             ])
         let data = try json.makeBytes()
-        let response = Response(status: error.status, body: .data(data))
+        let response = Response(status: status, body: .data(data))
         response.headers["Content-Type"] = "application/json; charset=utf-8"
         return response
     }

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -23,14 +23,8 @@ public class AbortMiddleware: Middleware {
     public func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
         do {
             return try chain.respond(to: request)
-        } catch Abort.badRequest {
-            return try AbortMiddleware.errorResponse(request, .badRequest, "Invalid request")
-        } catch Abort.notFound {
-            return try AbortMiddleware.errorResponse(request, .notFound, "Page not found")
-        } catch Abort.serverError {
-            return try AbortMiddleware.errorResponse(request, .internalServerError, "Something went wrong")
-        } catch Abort.custom(let status, let message) {
-            return try AbortMiddleware.errorResponse(request, status, message)
+        } catch let error as AbortError {
+            return try AbortMiddleware.errorResponse(request, error.status, error.message)
         }
     }
 
@@ -48,6 +42,5 @@ public class AbortMiddleware: Middleware {
         response.headers["Content-Type"] = "application/json; charset=utf-8"
         return response
     }
-
 }
 


### PR DESCRIPTION
This adds support for custom errors with error codes and metadata (without breaking public API). Thusly, making it easier for Abort and Logging middleware to handle default and custom errors. As well as making it possible for them to determine whether or not they need to report the errors to some kind of bug tracking/internal system.

@LoganWright @tannernelson should I/we deprecate the old error enumeration or just keep the default implementation as is. I think it's fine as is, but I don't know what you have in mind.

@Casperhr Did I miss anything you were looking for? I was thinking the `shouldReport: Bool` would just go into the `metadata` node or that we could just make our own conformation to `AbortError` that has the `shouldReport` field. I prefer the latter, honestly.