### PR TITLE
Retain cycle between Request and Auth Header Helper

### DIFF
--- a/Sources/Auth/Authentication/Header/Request+Authorization.swift
+++ b/Sources/Auth/Authentication/Header/Request+Authorization.swift
@@ -2,13 +2,13 @@ import HTTP
 import Turnstile
 
 public final class Helper {
-    public let request: Request
+    public weak var request: Request?
     public init(request: Request) {
         self.request = request
     }
 
     public var header: Authorization? {
-        guard let authorization = request.headers["Authorization"] else {
+        guard let authorization = request?.headers["Authorization"] else {
             return nil
         }
 
@@ -16,17 +16,17 @@ public final class Helper {
     }
 
     public func login(_ credentials: Credentials, persist: Bool = true) throws {
-        return try request.subject().login(credentials: credentials, persist: persist)
+        try request?.subject().login(credentials: credentials, persist: persist)
     }
     
     public func logout() throws {
-        return try request.subject().logout()
+        try request?.subject().logout()
     }
 
     public func user() throws -> User {
-        let subject = try request.subject()
+        let subject = try request?.subject()
 
-        guard let details = subject.authDetails else {
+        guard let details = subject?.authDetails else {
             throw AuthError.notAuthenticated
         }
 


### PR DESCRIPTION
When using Auth Header the Helper class holds a strong reference to Request, which itself holds a strong reference to Helper through the storage dictionary.
It seems that this causes every request to leak, this is mostly noticeable with large multipart requests. 

This pull request should break the retain cycle and avoid the leak.  