### PR TITLE
Add in logger in non-deprecated init()

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+Deprecated.swift
+++ b/Sources/Vapor/Droplet/Droplet+Deprecated.swift
@@ -16,13 +16,13 @@ extension Droplet {
         environment environmentProvided: Environment? = nil,
         config configProvided: Settings.Config? = nil,
         localization localizationProvided: Localization? = nil,
+        log: LogProtocol? = nil,
 
         // providable
         server: ServerProtocol.Type? = nil,
         hash: HashProtocol? = nil,
         cipher: CipherProtocol? = nil,
         console: ConsoleProtocol? = nil,
-        log: LogProtocol? = nil,
         view: ViewRenderer? = nil,
         client: ClientProtocol.Type? = nil,
         database: Database? = nil,
@@ -47,7 +47,8 @@ extension Droplet {
             workDir: workDirProvided,
             environment: environmentProvided,
             config: configProvided,
-            localization: localizationProvided
+            localization: localizationProvided,
+            log: log
         )
 
         // create an array of all providers
@@ -77,10 +78,6 @@ extension Droplet {
 
         if let console = console {
             self.console = console
-        }
-
-        if let log = log {
-            self.log = log
         }
 
         if let view = view {

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -178,7 +178,6 @@ public class Droplet {
         } else {
             // logging is needed for emitting errors
             self.log = ConsoleLogger(console: terminal)
-            self.log.enabled = LogLevel.all
         }
 
         // the current droplet environment


### PR DESCRIPTION
This change allows users of the non-deprecated init() of Droplet to pass in an optional logger.  This will allow development of loggers that capture ALL logged output, including items that occur during the initialization of the logger.  Currently, all logs currently always go to the ConsoleLogger during initialization and only after this can the logger be replaced for subsequent logging.  