### PR TITLE
Add setter for Request.formURLEncoded

### DIFF
--- a/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
+++ b/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
@@ -7,7 +7,7 @@ extension Message {
         get {
             if let existing = storage["form-urlencoded"] as? Node {
                 return existing
-            } else if let type = headers["Content-Type"], type.contains("application/x-www-form-urlencoded") {
+            } else if let type = headers[.contentType], type.contains("application/x-www-form-urlencoded") {
                 guard case let .data(body) = body else { return nil }
                 let formURLEncoded = Node(formURLEncoded: body)
                 storage["form-urlencoded"] = formURLEncoded
@@ -22,7 +22,7 @@ extension Message {
 
             if let data = data, let bytes = try? data.formURLEncoded() {
                 body = .data(bytes)
-                headers["Content-Type"] = "application/x-www-form-urlencoded"
+                headers[.contentType] = "application/x-www-form-urlencoded"
             } else if let type = headers[.contentType], type.contains("application/x-www-form-urlencoded") {
                 body = .data([])
                 headers.removeValue(forKey: .contentType)

--- a/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
+++ b/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
@@ -1,7 +1,7 @@
 import Node
 import HTTP
 
-extension Request {
+extension Message {
     /// form url encoded encoded request data
     public var formURLEncoded: Node? {
         get {

--- a/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
+++ b/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
@@ -4,15 +4,26 @@ import HTTP
 extension Request {
     /// form url encoded encoded request data
     public var formURLEncoded: Node? {
-        if let existing = storage["form-urlencoded"] as? Node {
-            return existing
-        } else if let type = headers["Content-Type"], type.contains("application/x-www-form-urlencoded") {
-            guard case let .data(body) = body else { return nil }
-            let formURLEncoded = Node(formURLEncoded: body)
-            storage["form-urlencoded"] = formURLEncoded
-            return formURLEncoded
-        } else {
-            return nil
+        get {
+            if let existing = storage["form-urlencoded"] as? Node {
+                return existing
+            } else if let type = headers["Content-Type"], type.contains("application/x-www-form-urlencoded") {
+                guard case let .data(body) = body else { return nil }
+                let formURLEncoded = Node(formURLEncoded: body)
+                storage["form-urlencoded"] = formURLEncoded
+                return formURLEncoded
+            } else {
+                return nil
+            }
+        }
+        
+        set(data) {
+            if let data = data, let bytes = try? data.formURLEncoded() {
+                body = .data(bytes)
+                headers["Content-Type"] = "application/x-www-form-urlencoded"
+            }
+            
+            storage["form-urlencoded"] = data
         }
     }
 }

--- a/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
+++ b/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
@@ -18,12 +18,15 @@ extension Message {
         }
         
         set(data) {
+            storage["form-urlencoded"] = data
+
             if let data = data, let bytes = try? data.formURLEncoded() {
                 body = .data(bytes)
                 headers["Content-Type"] = "application/x-www-form-urlencoded"
+            } else if let type = headers[.contentType], type.contains("application/x-www-form-urlencoded") {
+                body = .data([])
+                headers.removeValue(forKey: .contentType)
             }
-            
-            storage["form-urlencoded"] = data
         }
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -17,6 +17,7 @@ class TestResponder: Responder {
 class ContentTests: XCTestCase {
     static var allTests = [
         ("testSetJSON", testSetJSON),
+        ("testSetFormURLEncodedBody", testSetFormURLEncodedBody),
         ("testParse", testParse),
         ("testMultipart", testMultipart),
         ("testMultipartEmptyContent", testMultipartEmptyContent),
@@ -35,6 +36,17 @@ class ContentTests: XCTestCase {
         let json = JSON(["hello": "world"])
         request.json = json
         XCTAssertEqual(json, request.json)
+    }
+
+    func testSetFormURLEncodedBody() throws {
+        let request = Request(method: .post, path: "/")
+        let data = Node(["hello": "world"])
+        request.formURLEncoded = data
+        XCTAssertEqual(data, request.formURLEncoded)
+        XCTAssertEqual("application/x-www-form-urlencoded", request.headers["Content-Type"])
+        XCTAssertNotNil(request.body.bytes)
+        let bodyString = try request.body.bytes!.string().removingPercentEncoding
+        XCTAssertEqual("hello=world", bodyString)
     }
 
     func testParse() {


### PR DESCRIPTION
Following up a [discussion](https://qutheory.slack.com/archives/help/p1484181070013069) on Slack, this PR extends Request.formURLEncoded with a setter that fills the body and the `Content-Type` header automatically.

The actual behavior is a close mirror of the JSON extension: if there's any error, the request is not mutated, except for the `storage`.

---

In the test, I added `removePercentEncoding` as a workaround for the current behavior of [Node.formURLEndoded](https://github.com/vapor/vapor/blob/1.3.9/Sources/Vapor/FormURLEncoded/StructuredData%2BFormURLEncoded.swift#L73-L75), whereas every single character is percent encoded, including alphanumeric characters.

To me, this makes more sense than hardcoding `%68%65%6c%6c%6f=%77%6f%72%6c%64` as an expected body – which is not "expected", neither de facto nor de jure –, but please give me a nudge if you think otherwise.