### PR TITLE
Align the Vapor Log APIs to use StaticStrings

### DIFF
--- a/Sources/Vapor/Log/ConsoleLogger.swift
+++ b/Sources/Vapor/Log/ConsoleLogger.swift
@@ -33,8 +33,8 @@ public class ConsoleLogger: LogProtocol {
     public func log(
         _ level: LogLevel,
         message: String,
-        file: String = #file,
-        function: String = #function,
+        file: StaticString = #file,
+        function: StaticString = #function,
         line: Int = #line
     ) {
         if enabled.contains(level) {

--- a/Sources/Vapor/Log/Log+Convenience.swift
+++ b/Sources/Vapor/Log/Log+Convenience.swift
@@ -8,7 +8,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func verbose(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.verbose, message: message, file: file, function: function, line: line)
     }
     
@@ -21,7 +21,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func debug(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.debug, message: message, file: file, function: function, line: line)
     }
     
@@ -34,7 +34,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func info(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.info, message: message, file: file, function: function, line: line)
     }
     
@@ -47,7 +47,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func warning(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.warning, message: message, file: file, function: function, line: line)
     }
     
@@ -60,7 +60,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func error(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.error, message: message, file: file, function: function, line: line)
     }
     
@@ -73,7 +73,7 @@ extension LogProtocol {
      - parameter line: String where logging happens, is automatically set on default
      */
     public func fatal(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line) {
         log(.fatal, message: message, file: file, function: function, line: line)
     }
     
@@ -87,7 +87,7 @@ extension LogProtocol {
      - parameter label: String of a custom logging level
      */
     public func custom(_ message: String,
-        file: String = #file, function: String = #function, line: Int = #line, label: String) {
+        file: StaticString = #file, function: StaticString = #function, line: Int = #line, label: String) {
         log(.custom(label), message: message, file: file, function: function, line: line)
     }
 }

--- a/Sources/Vapor/Log/Log.swift
+++ b/Sources/Vapor/Log/Log.swift
@@ -14,7 +14,7 @@ public protocol LogProtocol {
         file, function and line of the logging call
         are automatically injected in the convenience function.
     */
-    func log(_ level: LogLevel, message: String, file: String, function: String, line: Int)
+    func log(_ level: LogLevel, message: String, file: StaticString, function: StaticString, line: Int)
 }
 
 @available(*, deprecated: 1.0, message: "Use `LogProtocol` instead.")

--- a/Tests/VaporTests/LogTests.swift
+++ b/Tests/VaporTests/LogTests.swift
@@ -14,7 +14,7 @@ private class DummyLogger: LogProtocol {
         enabled = LogLevel.all
     }
     
-    func log(_ level: LogLevel, message: String, file: String, function: String, line: Int) {
+    func log(_ level: LogLevel, message: String, file: StaticString, function: StaticString, line: Int) {
         output = "level: \(level.description), message: '\(message)', "
         output += "file: \(file), function: \(function), line: \(line)"
     }


### PR DESCRIPTION
In working to integrate XCGLogger into Vapor, the API for the LogProtocol and the API for XCGLogger diverge in a manner that cannot be integrated.  The XCGLogger uses `StaticString` in the APIs for Filename and Functions to allow the compiler to better optimize the log output.

This PR introduces the changes to address this and improve the Vapor.LogProtocol to allow XCGLogger integration.