### PR TITLE
Revert in reversed order

### DIFF
--- a/Sources/Vapor/Fluent/Prepare.swift
+++ b/Sources/Vapor/Fluent/Prepare.swift
@@ -45,7 +45,7 @@ public struct Prepare: Command {
                 return
             }
 
-            for preparation in preparations {
+            for preparation in preparations.reversed() {
                 let name = preparation.name
                 let hasPrepared: Bool
 


### PR DESCRIPTION
When starting to use preparation for setting up foreign keys or migrations, I believe it makes sense to revert in the reversed order.