### PR TITLE
Free leaked string in FileManager.contentsOfDirectory

### DIFF
--- a/Sources/Vapor/File/FileManager.swift
+++ b/Sources/Vapor/File/FileManager.swift
@@ -40,6 +40,7 @@ class FileManager {
 
         let path = try self.expandPath(path).finished(with: "/")
         let pattern = strdup(path + "{*,.*}")
+        defer { free(pattern) }
 
         switch glob(pattern, GLOB_MARK | GLOB_NOSORT | GLOB_BRACE, nil, &gt) {
         case GLOB_NOMATCH:


### PR DESCRIPTION
The `pattern` C string was not deallocated, and this commit fixes that.

While this is not likely to cause a problem in a real-life application, it's better to plug all the holes in the framework IMHO.

(This is #784 moved to the vapor repository to allow CircleCI to run.)