### PR TITLE
_method support

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -249,17 +249,22 @@ public class Droplet {
             }
         }
         addConfigurable(middleware: contentTypeLogger, name: "content-type-log")
+        addConfigurable(middleware: MethodSwap(), name: "method-swap")
 
         if config["droplet", "middleware", "server"]?.array == nil {
             // if no configuration has been supplied
             // apply all middleware
             middleware = [
+                // Should run 1st, ensure method 
+                // appropriate for subsequent middleware
+                MethodSwap(),
+                // Should run 2nd incase swapped to `.head` request
+                HeadMiddleware(),
                 SessionsMiddleware(MemorySessions()),
                 DateMiddleware(),
                 TypeSafeErrorMiddleware(),
                 ValidationMiddleware(),
                 FileMiddleware(publicDir: workDir + "Public/"),
-                HeadMiddleware(),
                 contentTypeLogger,
             ]
             log.debug("No `middleware.server` key in `droplet.json` found, using default middleware.")

--- a/Sources/Vapor/Middleware/MethodSwapMiddleware.swift
+++ b/Sources/Vapor/Middleware/MethodSwapMiddleware.swift
@@ -1,0 +1,12 @@
+import HTTP
+
+public final class MethodSwap: Middleware {
+    public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
+        guard let method = request.data["_method"]?.string else {
+            return try next.respond(to: request)
+        }
+
+        request.method = Method(method)
+        return try next.respond(to: request)
+    }
+}

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -9,7 +9,8 @@ class ViewTests: XCTestCase {
         ("testBasic", testBasic),
         ("testViewBytes", testViewBytes),
         ("testViewResponse", testViewResponse),
-        ("testViewRequest", testViewRequest)
+        ("testViewRequest", testViewRequest),
+        ("testMethodOverride", testMethodOverride),
     ]
 
     func testBasic() throws {
@@ -28,7 +29,6 @@ class ViewTests: XCTestCase {
         let view = try View(bytes: "42".makeBytes())
         XCTAssertEqual(try view.makeBytes(), "42".makeBytes())
     }
-
 
     func testViewResponse() throws {
         let view = try View(bytes: "42 🚀".makeBytes())
@@ -71,5 +71,21 @@ class ViewTests: XCTestCase {
         XCTAssert(string.contains("Vapor"))
         XCTAssert(string.contains("foopath"))
         XCTAssert(string.contains("foobar"))
+    }
+
+    func testMethodOverride() throws {
+        let drop = try Droplet()
+
+        drop.patch { req in
+            return "yes"
+        }
+
+        let req = Request(method: .get, path: "")
+        req.json = try JSON(node: [
+            "_method": "patch"
+        ])
+
+        let res = drop.respond(to: req)
+        XCTAssertEqual(try res.bodyString(), "yes")
     }
 }


### PR DESCRIPTION
Adds ability to override request method using `_method` in request data.

Fixes #770 