### PR TITLE
Worked around a compiler crash

### DIFF
--- a/Sources/Vapor/HTTP/Accept.swift
+++ b/Sources/Vapor/HTTP/Accept.swift
@@ -33,7 +33,7 @@ extension Request {
             return []
         }
 
-        return acceptString.characters.split(separator: ",").flatMap { acceptSlice in
+        let accepts: [Accept] = acceptString.characters.split(separator: ",").flatMap { acceptSlice in
             let pieces = acceptSlice.split(separator: ";")
             guard let mediaType = pieces.first.flatMap({ String($0) }) else { return nil }
 
@@ -52,5 +52,7 @@ extension Request {
 
             return Accept(mediaType: mediaType, preference: preference)
         }
+
+        return accepts
     }
 }


### PR DESCRIPTION
@ntokozo.online from Slack reached out to me with a test case where the runtime crashed. I cannot attach his sample code since it's private but the compiler fails to understand that the result from the flatMap is of the type `[Accept]`. This workaround fixes that.

Another possible solution is to explicitly define the return type in the flatMap closure.