### PR TITLE
safer error messages

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+Deprecated.swift
+++ b/Sources/Vapor/Droplet/Droplet+Deprecated.swift
@@ -101,7 +101,7 @@ extension Droplet {
             "validation": ValidationMiddleware(),
             "date": DateMiddleware(),
             "type-safe": TypeSafeErrorMiddleware(),
-            "abort": AbortMiddleware(),
+            "abort": AbortMiddleware(environment: environment),
             "sessions": SessionsMiddleware(sessions: MemorySessions())
         ]
 

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -306,7 +306,7 @@ public class Droplet {
             // apply all middleware
             middleware = [
                 SessionsMiddleware(sessions: MemorySessions()),
-                AbortMiddleware(),
+                AbortMiddleware(environment: environment),
                 DateMiddleware(),
                 TypeSafeErrorMiddleware(),
                 ValidationMiddleware(),
@@ -316,7 +316,7 @@ public class Droplet {
         } else {
             // add all configurable middleware
             addConfigurable(middleware: SessionsMiddleware(sessions: MemorySessions()), name: "sessions")
-            addConfigurable(middleware: AbortMiddleware(), name: "abort")
+            addConfigurable(middleware: AbortMiddleware(environment: environment), name: "abort")
             addConfigurable(middleware: DateMiddleware(), name: "date")
             addConfigurable(middleware: TypeSafeErrorMiddleware(), name: "type-safe")
             addConfigurable(middleware: ValidationMiddleware(), name: "validation")

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -29,7 +29,9 @@ public class AbortMiddleware: Middleware {
         } catch let error as AbortError {
             return try errorResponse(request, error)
         } catch {
-            return try errorResponse(request, .internalServerError, error.localizedDescription)
+            let errorType = type(of: error)
+            let message = "\(errorType): \(error)"
+            return try errorResponse(request, .internalServerError, message)
         }
     }
 

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -70,5 +70,17 @@ public class AbortMiddleware: Middleware {
             return response
         }
     }
+
+    // MARK: Deprecated
+
+    @available(*, deprecated: 1.5, message: "This method will be removed in a future version.")
+    public static func errorResponse(_ request: Request, _ status: Status, _ message: String) throws -> Response {
+        return try AbortMiddleware().errorResponse(request, status, message)
+    }
+
+    @available(*, deprecated: 1.5, message: "This method will be removed in a future version.")
+    public static func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
+        return try AbortMiddleware().errorResponse(request, error)
+    }
 }
 

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -8,7 +8,10 @@ import HTTP
     AbortMiddleware for the Droplet's `middleware` array.
 */
 public class AbortMiddleware: Middleware {
-    public init() { }
+    let environment: Environment
+    public init(environment: Environment = .production) {
+        self.environment = environment
+    }
 
     /**
         Respond to a given request chaining to the next
@@ -24,32 +27,48 @@ public class AbortMiddleware: Middleware {
         do {
             return try chain.respond(to: request)
         } catch let error as AbortError {
-            return try AbortMiddleware.errorResponse(request, error)
+            return try errorResponse(request, error)
         } catch {
-            return try AbortMiddleware.errorResponse(request, .internalServerError, error.localizedDescription)
+            return try errorResponse(request, .internalServerError, error.localizedDescription)
         }
     }
+
+    // MARK: Private
     
-    public static func errorResponse(_ request: Request, _ status: Status, _ message: String) throws -> Response {
+    private func errorResponse(_ request: Request, _ status: Status, _ message: String) throws -> Response {
         let error = Abort.custom(status: status, message: message)
         return try errorResponse(request, error)
     }
     
-    public static func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
-        if request.accept.prefers("html") {
-            return ErrorView.shared.makeResponse(error.status, error.message)
-        }
+    private func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
+        if environment == .production {
+            let message = error.code < 500 ? error.message : "Something went wrong"
 
-        let json = try JSON(node: [
-            "error": true,
-            "message": "\(error.message)",
-            "code": error.code,
-            "metadata": error.metadata
+            if request.accept.prefers("html") {
+                return ErrorView.shared.makeResponse(error.status, message)
+            }
+
+            let response = Response(status: error.status)
+            response.json = try JSON(node: [
+                "error": true,
+                "message": message,
+                "code": error.code
             ])
-        let data = try json.makeBytes()
-        let response = Response(status: error.status, body: .data(data))
-        response.headers["Content-Type"] = "application/json; charset=utf-8"
-        return response
+            return response
+        } else {
+            if request.accept.prefers("html") {
+                return ErrorView.shared.makeResponse(error.status, error.message)
+            }
+
+            let response = Response(status: error.status)
+            response.json = try JSON(node: [
+                "error": true,
+                "message": error.message,
+                "code": error.code,
+                "metadata": error.metadata
+            ])
+            return response
+        }
     }
 }
 

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -133,7 +133,7 @@ class MiddlewareTests: XCTestCase {
     func testAbortMiddleware() throws {
         let drop = Droplet()
 
-        drop.middleware = [AbortMiddleware()]
+        drop.middleware = [AbortMiddleware(environment: .development)]
 
         drop.get("*") { req in
             let path = req.uri.path


### PR DESCRIPTION
This PR makes error messages more consistent and prevents Vapor from outputting sensitive information to the response when in production mode.

Fixes https://github.com/vapor/vapor/issues/811