### PR TITLE
Switching back to httpOnly=true as the default

### DIFF
--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -26,7 +26,9 @@ public class AuthMiddleware<U: User>: Middleware {
             return Cookie(
                 name: cookieName,
                 value: value,
-                expires: Date().addingTimeInterval(cookieTimeout)
+                expires: Date().addingTimeInterval(cookieTimeout),
+                secure: false,
+                httpOnly: true
             )
         }
     }

--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -26,9 +26,7 @@ public class AuthMiddleware<U: User>: Middleware {
             return Cookie(
                 name: cookieName,
                 value: value,
-                expires: Date().addingTimeInterval(cookieTimeout),
-                secure: false,
-                httpOnly: false
+                expires: Date().addingTimeInterval(cookieTimeout)
             )
         }
     }

--- a/Sources/Cookies/Cookie.swift
+++ b/Sources/Cookies/Cookie.swift
@@ -23,7 +23,7 @@ public struct Cookie {
         domain: String? = nil,
         path: String? = "/",
         secure: Bool = false,
-        httpOnly: Bool = true
+        httpOnly: Bool = false
     ) {
         self.name = name
         self.value = value

--- a/Sources/Cookies/Cookie.swift
+++ b/Sources/Cookies/Cookie.swift
@@ -23,7 +23,7 @@ public struct Cookie {
         domain: String? = nil,
         path: String? = "/",
         secure: Bool = false,
-        httpOnly: Bool = false
+        httpOnly: Bool = true
     ) {
         self.name = name
         self.value = value

--- a/Tests/AuthTests/AuthMiddlewareTests.swift
+++ b/Tests/AuthTests/AuthMiddlewareTests.swift
@@ -22,7 +22,7 @@ class AuthMiddlewareTests: XCTestCase {
         XCTAssertNotNil(cookie.value)
         XCTAssertNotNil(cookie.expires)
         XCTAssertFalse(cookie.secure)
-        XCTAssertFalse(cookie.httpOnly)
+        XCTAssertTrue(cookie.httpOnly)
     }
 
     func testAuthHelperPersistence() throws {


### PR DESCRIPTION
After a discussion about the security implications of switching the default to httpOnly=true on the #deveopment slack channel, here's a PR to switch it back. I figured if httpOnly should be the default, it should be the default on the `Cookie init`.