### PR TITLE
Add name to the cookie factory closure.

### DIFF
--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -12,7 +12,7 @@ public class AuthMiddleware<U: User>: Middleware {
     private let cookieName: String
     private let cookieFactory: CookieFactory
 
-    public typealias CookieFactory = (String) -> Cookie
+    public typealias CookieFactory = (String, String) -> Cookie
 
     public init(
         turnstile: Turnstile,
@@ -22,9 +22,9 @@ public class AuthMiddleware<U: User>: Middleware {
         self.turnstile = turnstile
         
         self.cookieName = cookieName
-        self.cookieFactory = cookieFactory ?? { value in
+        self.cookieFactory = cookieFactory ?? { name, value in
             return Cookie(
-                name: cookieName,
+                name: name,
                 value: value,
                 expires: Date().addingTimeInterval(cookieTimeout),
                 secure: false,
@@ -58,8 +58,7 @@ public class AuthMiddleware<U: User>: Middleware {
             let sid = try request.subject().sessionIdentifier,
             request.cookies[cookieName] != sid
         {
-            var cookie = cookieFactory(sid)
-            cookie.name = cookieName
+            let cookie = cookieFactory(cookieName, sid)
             response.cookies.insert(cookie)
         } else if
             try request.subject().sessionIdentifier == nil,

--- a/Tests/AuthTests/AuthMiddlewareTests.swift
+++ b/Tests/AuthTests/AuthMiddlewareTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import HTTP
+import Cookies
 @testable import Auth
 
 class AuthMiddlewareTests: XCTestCase {
@@ -22,6 +23,32 @@ class AuthMiddlewareTests: XCTestCase {
         XCTAssertNotNil(cookie.value)
         XCTAssertNotNil(cookie.expires)
         XCTAssertFalse(cookie.secure)
+        XCTAssertTrue(cookie.httpOnly)
+    }
+    
+    func testCustomCookie() throws {
+        let expires = Date()
+        let cookieName = "custom-auth-cookie-name"
+        let authMiddleware = AuthMiddleware(user: AuthUser.self, cookieName: cookieName) { name, value in
+            return Cookie(
+                name: name,
+                value: value,
+                expires: expires,
+                secure: true,
+                httpOnly: true
+            )
+        }
+        
+        let request = try Request(method: .get, uri: "test")
+        
+        let responder = AuthMiddlewareResponser()
+        let response = try authMiddleware.respond(to: request, chainingTo: responder)
+        
+        let cookie = response.cookies.cookies.first!
+        XCTAssertEqual(cookie.name, cookieName)
+        XCTAssertNotNil(cookie.value)
+        XCTAssertEqual(cookie.expires, expires)
+        XCTAssertTrue(cookie.secure)
         XCTAssertTrue(cookie.httpOnly)
     }
 


### PR DESCRIPTION
This is to make it clear this name should be used.