### PR TITLE
swift 3.1 workdir fix

### DIFF
--- a/Sources/Vapor/Droplet/Droplet+WorkingDirectory.swift
+++ b/Sources/Vapor/Droplet/Droplet+WorkingDirectory.swift
@@ -1,7 +1,11 @@
 extension Droplet {
     static func workingDirectory(from arguments: [String]) -> String {
         func fileWorkDirectory() -> String? {
-            let parts = #file.components(separatedBy: "/Packages/Vapor-")
+            #if swift(>=3.1)
+                let parts = #file.components(separatedBy: "/.build")
+            #else
+                let parts = #file.components(separatedBy: "/Packages/Vapor-")
+            #endif
             guard parts.count == 2 else {
                 return nil
             }


### PR DESCRIPTION
Fixes automatic detection of the working directory in Swift 3.1.