### PR TITLE
status reasons

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -14,7 +14,11 @@ public struct Abort: AbortError, Debuggable {
     public static let readableName = "Abort request error"
 
     /// See Debuggable.reason
-    public let reason: String
+    /// - Warning: This string will be
+    /// displayed in production mode.
+    public var reason: String {
+        return status.reasonPhrase
+    }
 
     /// See Debuggable.identifier
     public let identifier: String
@@ -47,9 +51,15 @@ public struct Abort: AbortError, Debuggable {
         stackOverflowQuestions: [String]? = nil,
         gitHubIssues: [String]? = nil
     ) {
-        self.status = status
+        if let reason = reason {
+            self.status = Status.other(
+                statusCode: status.statusCode,
+                reasonPhrase: reason
+            )
+        } else {
+            self.status = status
+        }
         self.metadata = metadata
-        self.reason = reason ?? status.reasonPhrase
         self.identifier = identifier ?? "\(status)"
         self.possibleCauses = possibleCauses ?? []
         self.suggestedFixes = suggestedFixes ?? []

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -13,12 +13,8 @@ public struct Abort: AbortError, Debuggable {
     /// See Debuggable.readableName
     public static let readableName = "Abort request error"
 
-    /// See Debuggable.reason
-    /// - Warning: This string will be
-    /// displayed in production mode.
-    public var reason: String {
-        return status.reasonPhrase
-    }
+    /// See AbortError.reason
+    public var reason: String
 
     /// See Debuggable.identifier
     public let identifier: String
@@ -51,15 +47,9 @@ public struct Abort: AbortError, Debuggable {
         stackOverflowQuestions: [String]? = nil,
         gitHubIssues: [String]? = nil
     ) {
-        if let reason = reason {
-            self.status = Status.other(
-                statusCode: status.statusCode,
-                reasonPhrase: reason
-            )
-        } else {
-            self.status = status
-        }
+        self.status = status
         self.metadata = metadata
+        self.reason = reason ?? status.reasonPhrase
         self.identifier = identifier ?? "\(status)"
         self.possibleCauses = possibleCauses ?? []
         self.suggestedFixes = suggestedFixes ?? []

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -14,7 +14,7 @@ public struct Abort: AbortError, Debuggable {
     public static let readableName = "Abort request error"
 
     /// See AbortError.reason
-    public var reason: String
+    public let reason: String
 
     /// See Debuggable.identifier
     public let identifier: String

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -8,7 +8,13 @@ public protocol AbortError: Swift.Error {
     /// The HTTP status code to return.
     var status: Status { get }
 
+    // The reason this error was thrown.
+    /// - Warning: This string will be
+    /// displayed in production mode.
+    var reason: String { get }
+
     /// `Optional` metadata.
+    /// This will not be shown in production mode.
     var metadata: Node? { get }
 }
 
@@ -25,5 +31,9 @@ extension AbortError {
 extension HTTP.Status: AbortError {
     public var status: Status {
         return self
+    }
+
+    public var reason: String {
+        return self.reasonPhrase
     }
 }

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -11,3 +11,19 @@ public protocol AbortError: Swift.Error {
     /// `Optional` metadata.
     var metadata: Node? { get }
 }
+
+// MARK: Optional
+
+extension AbortError {
+    public var metadata: Node? {
+        return nil
+    }
+}
+
+// MARK: Conformances
+
+extension HTTP.Status: AbortError {
+    public var status: Status {
+        return self
+    }
+}


### PR DESCRIPTION
This PR makes custom `HTTP.Status` reason phrases appear in production mode. This allows users to do something like:

```swift
throw Abort(.unauthorized, reason: "No authorization header")
```

This will now return
```http
401 Unauthorized
```
```json
{
    "error": true,
    "reason": "No authorization header"
}
```

As opposed to what it returns now:
```http
401 Unauthorized
```
```json
{
    "error": true,
    "reason": "Unauthorized"
}
```