### PR TITLE
Log production errors in AbortMiddleware

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -306,7 +306,7 @@ public class Droplet {
             // apply all middleware
             middleware = [
                 SessionsMiddleware(sessions: MemorySessions()),
-                AbortMiddleware(environment: environment),
+                AbortMiddleware(environment: environment, log: log),
                 DateMiddleware(),
                 TypeSafeErrorMiddleware(),
                 ValidationMiddleware(),
@@ -316,7 +316,7 @@ public class Droplet {
         } else {
             // add all configurable middleware
             addConfigurable(middleware: SessionsMiddleware(sessions: MemorySessions()), name: "sessions")
-            addConfigurable(middleware: AbortMiddleware(environment: environment), name: "abort")
+			addConfigurable(middleware: AbortMiddleware(environment: environment, log: log), name: "abort")
             addConfigurable(middleware: DateMiddleware(), name: "date")
             addConfigurable(middleware: TypeSafeErrorMiddleware(), name: "type-safe")
             addConfigurable(middleware: ValidationMiddleware(), name: "validation")

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -44,6 +44,8 @@ public class AbortMiddleware: Middleware {
     
     private func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
         if environment == .production {
+			log.error("Uncaught Error: \(type(of: error)).\(error)")
+			
             let message = error.code < 500 ? error.message : "Something went wrong"
 
             if request.accept.prefers("html") {

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -44,7 +44,7 @@ public class AbortMiddleware: Middleware {
     
     private func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
         if environment == .production {
-			log.error("Uncaught Error: \(type(of: error)).\(error)")
+            log.error("Uncaught Error: \(type(of: error)).\(error)")
 			
             let message = error.code < 500 ? error.message : "Something went wrong"
 

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -9,8 +9,11 @@ import HTTP
 */
 public class AbortMiddleware: Middleware {
     let environment: Environment
-    public init(environment: Environment = .production) {
+	var log: LogProtocol?
+	
+    public init(environment: Environment = .production, log: LogProtocol? = nil) {
         self.environment = environment
+		self.log = log
     }
 
     /**

--- a/Sources/Vapor/Error/AbortMiddleware.swift
+++ b/Sources/Vapor/Error/AbortMiddleware.swift
@@ -47,7 +47,7 @@ public class AbortMiddleware: Middleware {
     
     private func errorResponse(_ request: Request, _ error: AbortError) throws -> Response {
         if environment == .production {
-            log.error("Uncaught Error: \(type(of: error)).\(error)")
+            self.log?.error("Uncaught Error: \(type(of: error)).\(error)")
 			
             let message = error.code < 500 ? error.message : "Something went wrong"
 


### PR DESCRIPTION
`AbortMiddleware` shows a beautiful HTML page with a generic error message when catching an error. However, it does not log the error in production, which makes it impossible to debug. In this PR, I add code for logging production errors.