### PR TITLE
Add --force option when reverting DB from command line

### DIFF
--- a/Sources/Vapor/Fluent/Prepare.swift
+++ b/Sources/Vapor/Fluent/Prepare.swift
@@ -9,6 +9,7 @@ public struct Prepare: Command {
 
     public let signature: [Argument] = [
         Option(name: "revert"),
+        Option(name: "force"),
     ]
 
     public let help: [String] = [
@@ -40,7 +41,7 @@ public struct Prepare: Command {
         }
 
         if arguments.option("revert")?.bool == true {
-            guard console.confirm("Are you sure you want to revert the database?", style: .warning) else {
+            guard arguments.option("force")?.bool == true || console.confirm("Are you sure you want to revert the database?", style: .warning) else {
                 console.error("Reversion cancelled")
                 return
             }


### PR DESCRIPTION
## Motivation

When tests are running, in the `XCTest.setup` method you may want to set up a Droplet connected to a test database (e.g. using a specific configuration in `MyApp/Config/test/`). However, you may also need to reset the DB in the `teardown` method. An easy way to do this is to revert all preparations to drop all tables.

Running `vapor run prepare --revert` or using the `Prepare` command in code, makes the console ask the user to confirm the reversion, hence blocking the tests. The `--force` option introduced by this PR ensures that, if passed, the tests aren't blocked as no confirmation will be required.

## Notes

I'm not sure how this is going to play with the removal of Vapor/Fluent in Vapor 2.0 at this point. I couldn't find similar code in the Fluent repository. However, I guess it can be discussed and something similar could be introduced in the next alpha of Fluent 2.0.