### PR TITLE
Add Content-Type helper

### DIFF
--- a/Sources/Vapor/HTTP/ContentType.swift
+++ b/Sources/Vapor/HTTP/ContentType.swift
@@ -1,0 +1,57 @@
+import HTTP
+import Vapor
+
+extension Vapor.KeyAccessible where Key == HeaderKey, Value == String {
+    
+    var contentType: String? {
+        get {
+            return self["Content-Type"]
+        }
+        set {
+            self["Content-Type"] = newValue
+        }
+    }
+    
+}
+
+public enum ContentType: Hashable {
+    case any
+    case html
+    case json
+    case other(String)
+    
+    var stringValue: String {
+        switch self {
+        case .any:
+            return "*/*"
+        case .html:
+            return "text/html"
+        case .json:
+            return "application/json"
+        case .other(let type):
+            return type
+        }
+    }
+    
+    public static func from(string: String) -> ContentType {
+        switch string {
+        case ContentType.html.stringValue:
+            return .html
+        case ContentType.json.stringValue:
+            return .json
+        case ContentType.any.stringValue:
+            return .any
+        default:
+            return .other(string)
+        }
+    }
+    
+    public var hashValue: Int {
+        return stringValue.hashValue
+    }
+    
+    public static func ==(lhs: ContentType, rhs: ContentType) -> Bool {
+        return lhs.stringValue == rhs.stringValue
+    }
+    
+}


### PR DESCRIPTION
## Motivation

When dealing with multiple types of requests - e.g. JSON vs HTML - it's important to distinguish what is the correct data format to expect and to return. Controllers should check both the `Accept` and the `Content-Type` headers to achieve this.

## Example usage

An example use of this helpers could be this:

```swift
func foo() -> ReponseRepresentable {
    return try respond(to: request, with: [.json: JSON([:]),
                                           .html: Response(redirect: "/")])
}

public func respond(to request: Request, with responses: [ContentType : ResponseRepresentable]) throws -> ResponseRepresentable {
    let contentType: ContentType
    if let header = request.accept.first {
        var requestedContentType = ContentType.from(string: header.mediaType)
        if requestedContentType == .any {
            if let requestContentType = request.contentType {
                requestedContentType = ContentType.from(string: requestContentType)
            }
            else {
                requestedContentType = .html
            }
        }
        contentType = requestedContentType
    }
    else {
        contentType = ContentType.html
    }
    guard let response = responses[contentType] else { throw Abort.badRequest }
    return response
}
```