### PR TITLE
adding initial mailer protocol for subsequent implementations

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -97,6 +97,8 @@ public class Droplet {
     /// Storage to add/manage dependencies, identified by a string
     public var storage: [String: Any]
 
+    /// Implemented by your email client
+    public var mailer: Mailer
 
     /// The responder will be loaded the first time the droplet is asked
     /// to respond to a request, this prevents having to construct it
@@ -225,6 +227,7 @@ public class Droplet {
             defaultKey: Bytes(repeating: 0, count: 16),
             defaultIV: nil
         )
+        mailer = UnimplementedMailer()
 
         // CONFIGURABLE
         addConfigurable(server: Server<TCPServerStream, Parser<Request>, Serializer<Response>>.self, name: "engine")

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -98,7 +98,7 @@ public class Droplet {
     public var storage: [String: Any]
 
     /// Implemented by your email client
-    public var mailer: Mailer
+    public var mail: MailProtocol
 
     /// The responder will be loaded the first time the droplet is asked
     /// to respond to a request, this prevents having to construct it
@@ -227,7 +227,7 @@ public class Droplet {
             defaultKey: Bytes(repeating: 0, count: 16),
             defaultIV: nil
         )
-        mailer = UnimplementedMailer()
+        mail = UnimplementedMailer()
 
         // CONFIGURABLE
         addConfigurable(server: Server<TCPServerStream, Parser<Request>, Serializer<Response>>.self, name: "engine")

--- a/Sources/Vapor/Mail/Mail.swift
+++ b/Sources/Vapor/Mail/Mail.swift
@@ -1,19 +1,29 @@
 import SMTP
 import Foundation
 import Transport
+import Settings
 
-public protocol Mailer {
+/// Defines objects capable of transmitting emails
+public protocol MailProtocol {
+    /// Send a single email
     func send(_ mail: Email) throws
+
+    /// Send a batched email
+    /// by default, this will iterate list
+    /// and send mail individually
+    /// clients that support batch proper should
+    /// override this function
     func send(batch: [Email]) throws
 }
 
-extension Mailer {
+extension MailProtocol {
     public func send(batch: [Email]) throws {
         try batch.forEach(send)
     }
 }
 
-public final class SMTPMailer: Mailer {
+/// SMTP Mailer to use basic SMTP Protocols
+public final class SMTPMailer: MailProtocol {
     let host: String
     let port: Int
     let securityLayer: SecurityLayer
@@ -42,12 +52,10 @@ public final class SMTPMailer: Mailer {
 }
 
 extension SMTPMailer {
-    /*
-     https://sendgrid.com/
-
-     Credentials:
-     https://app.sendgrid.com/settings/credentials
-     */
+    /// https://sendgrid.com/
+    ///
+    /// Credentials:
+    /// https://app.sendgrid.com/settings/credentials
     public static func makeSendGrid(with credentials: SMTPCredentials) -> SMTPMailer {
         return SMTPMailer(
             host: "smtp.sendgrid.net",
@@ -57,13 +65,11 @@ extension SMTPMailer {
         )
     }
 
-    /*
-     https://www.digitalocean.com/community/tutorials/how-to-use-google-s-smtp-server
-
-     Credentials:
-     user: Your full Gmail or Google Apps email address (e.g. example@gmail.com or example@yourdomain.com)
-     pass: Your Gmail or Google Apps email password
-     */
+    /// https://www.digitalocean.com/community/tutorials/how-to-use-google-s-smtp-server
+    ///
+    /// Credentials:
+    /// user: Your full Gmail or Google Apps email address (e.g. example@gmail.com or example@yourdomain.com)
+    /// pass: Your Gmail or Google Apps email password
     public static func makeGmail(with credentials: SMTPCredentials) -> SMTPMailer {
         return SMTPMailer(
             host: "smtp.gmail.com",
@@ -73,12 +79,10 @@ extension SMTPMailer {
         )
     }
 
-    /*
-     https://mailgun.com/
-
-     Credentials:
-     https://mailgun.com/app/domains
-     */
+    /// https://mailgun.com/
+    ///
+    /// Credentials:
+    /// https://mailgun.com/app/domains
     public static func makeMailgun(with credentials: SMTPCredentials) -> SMTPMailer {
         return SMTPMailer(
             host: "smtp.mailgun.org",
@@ -93,17 +97,17 @@ extension SMTPMailer {
 /// which would be annoying long term, this is a place holder
 /// that simply throws, but provides info on how to setup
 /// a proper mailer in the error
-final class UnimplementedMailer: Mailer {
-    enum MailerError: Debuggable {
-        case unimplemented
-    }
-
+final class UnimplementedMailer: MailProtocol {
     func send(_ mail: Email) throws {
         throw MailerError.unimplemented
     }
 }
 
-extension UnimplementedMailer.MailerError {
+enum MailerError: Debuggable {
+    case unimplemented
+}
+
+extension MailerError {
     var identifier: String {
         return "unimplemented"
     }

--- a/Sources/Vapor/Mail/Mailer.swift
+++ b/Sources/Vapor/Mail/Mailer.swift
@@ -1,0 +1,126 @@
+import SMTP
+import Foundation
+import Transport
+
+public protocol Mailer {
+    func send(_ mail: Email) throws
+    func send(batch: [Email]) throws
+}
+
+extension Mailer {
+    public func send(batch: [Email]) throws {
+        try batch.forEach(send)
+    }
+}
+
+public final class SMTPMailer: Mailer {
+    let host: String
+    let port: Int
+    let securityLayer: SecurityLayer
+    let credentials: SMTPCredentials
+
+    public init(host: String, port: Int, securityLayer: SecurityLayer, credentials: SMTPCredentials) {
+        self.host = host
+        self.port = port
+        self.securityLayer = securityLayer
+        self.credentials = credentials
+    }
+
+    public func send(_ mail: Email) throws {
+        let client = try makeClient()
+        try client.send(mail, using: credentials)
+    }
+
+    public func send(batch: [Email]) throws {
+        let client = try makeClient()
+        try client.send(batch, using: credentials)
+    }
+
+    private func makeClient() throws -> SMTPClient<TCPClientStream> {
+        return try SMTPClient(host: host, port: port, securityLayer: securityLayer)
+    }
+}
+
+extension SMTPMailer {
+    /*
+     https://sendgrid.com/
+
+     Credentials:
+     https://app.sendgrid.com/settings/credentials
+     */
+    public static func makeSendGrid(with credentials: SMTPCredentials) -> SMTPMailer {
+        return SMTPMailer(
+            host: "smtp.sendgrid.net",
+            port: 465,
+            securityLayer: .tls(nil),
+            credentials: credentials
+        )
+    }
+
+    /*
+     https://www.digitalocean.com/community/tutorials/how-to-use-google-s-smtp-server
+
+     Credentials:
+     user: Your full Gmail or Google Apps email address (e.g. example@gmail.com or example@yourdomain.com)
+     pass: Your Gmail or Google Apps email password
+     */
+    public static func makeGmail(with credentials: SMTPCredentials) -> SMTPMailer {
+        return SMTPMailer(
+            host: "smtp.gmail.com",
+            port: 465,
+            securityLayer: .tls(nil),
+            credentials: credentials
+        )
+    }
+
+    /*
+     https://mailgun.com/
+
+     Credentials:
+     https://mailgun.com/app/domains
+     */
+    public static func makeMailgun(with credentials: SMTPCredentials) -> SMTPMailer {
+        return SMTPMailer(
+            host: "smtp.mailgun.org",
+            port: 465,
+            securityLayer: .tls(nil),
+            credentials: credentials
+        )
+    }
+}
+
+/// To avoid forcing users to deal with an optional on mailer 
+/// which would be annoying long term, this is a place holder
+/// that simply throws, but provides info on how to setup
+/// a proper mailer in the error
+final class UnimplementedMailer: Mailer {
+    enum MailerError: Debuggable {
+        case unimplemented
+    }
+
+    func send(_ mail: Email) throws {
+        throw MailerError.unimplemented
+    }
+}
+
+extension UnimplementedMailer.MailerError {
+    var identifier: String {
+        return "unimplemented"
+    }
+
+    var reason: String {
+        return "mailer hasn't been setup yet"
+    }
+
+    var possibleCauses: [String] {
+        return [
+            "a mailer hasn't been setup yet on droplet"
+        ]
+    }
+
+    var suggestedFixes: [String] {
+        return [
+            "add a mailer to your droplet, for example `drop.mailer = SMTPMailer.makeGmail(with: creds)`"
+        ]
+    }
+}

--- a/Sources/Vapor/Validation/Convenience/Email.swift
+++ b/Sources/Vapor/Validation/Convenience/Email.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Validate a string input represents a valid Email address
-public class Email: Validator {
+public class EmailValidator: Validator {
     public init() {}
 
     public func validate(_ input: String) throws {

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -69,15 +69,15 @@ class ValidationTests: XCTestCase {
 
     func testValidEmail() {
         // Thanks again Ben Wu :)
-        XCTAssertFalse("".passes(Email()))
-        XCTAssertFalse("@".passes(Email()))
-        XCTAssertFalse("@.".passes(Email()))
-        XCTAssertFalse("@.com".passes(Email()))
-        XCTAssertFalse("foo@.com".passes(Email()))
-        XCTAssertFalse("@foo.com".passes(Email()))
-        XCTAssertTrue("f@b.c".passes(Email()))
-        XCTAssertTrue("foo@bar.com".passes(Email()))
-        XCTAssertFalse("f@b.".passes(Email()))
-        XCTAssertFalse("æøå@gmail.com".passes(Email()))
+        XCTAssertFalse("".passes(EmailValidator()))
+        XCTAssertFalse("@".passes(EmailValidator()))
+        XCTAssertFalse("@.".passes(EmailValidator()))
+        XCTAssertFalse("@.com".passes(EmailValidator()))
+        XCTAssertFalse("foo@.com".passes(EmailValidator()))
+        XCTAssertFalse("@foo.com".passes(EmailValidator()))
+        XCTAssertTrue("f@b.c".passes(EmailValidator()))
+        XCTAssertTrue("foo@bar.com".passes(EmailValidator()))
+        XCTAssertFalse("f@b.".passes(EmailValidator()))
+        XCTAssertFalse("æøå@gmail.com".passes(EmailValidator()))
     }
 }


### PR DESCRIPTION
```swift
let email = Email(
    from: "me@foo.com",
    to: "you@you.bar",
    subject: "Just sayin' hi",
    body: "Hello from mailer"
)

try drop.mailer.send(email)
```

If we like the style, I'll make do some file cleanup and merge it
