### PR TITLE
Fix FluentCache not updating the value if key already exists in DB

### DIFF
--- a/Sources/Cache/FluentCache.swift
+++ b/Sources/Cache/FluentCache.swift
@@ -17,6 +17,7 @@ public final class FluentCache: CacheProtocol {
 
     public func set(_ key: String, _ value: Node) throws {
         if var entity = try _find(key) {
+            entity.value = value
             try entity.save()
         } else {
             var entity = Entity(key: key, value: value)


### PR DESCRIPTION
I've seen [it's been fixed for 2.0](https://github.com/vapor/fluent-provider/blob/master/Sources/VaporFluent/Cache.swift#L19), but even 1.x users might profit from a working FluentCache implementation.