### PR TITLE
Extend CacheProtocol and CacheSessions with expiration time (for Vapor 2)

### DIFF
--- a/Sources/Cache/CacheProtocol.swift
+++ b/Sources/Cache/CacheProtocol.swift
@@ -1,13 +1,17 @@
 import Node
+import Foundation
 
 public protocol CacheProtocol {
     func get(_ key: String) throws -> Node?
-    func set(_ key: String, _ value: Node) throws
+    func set(_ key: String, _ value: Node, expiration: Date?) throws
     func delete(_ key: String) throws
 }
 
 extension CacheProtocol {
-    public func set(_ key: String, _ value: NodeRepresentable) throws {
-        return try set(key, try value.makeNode(in: nil))
+    public func set(_ key: String, _ value: Node) throws {
+        return try set(key, value, expiration: nil)
+    }
+    public func set(_ key: String, _ value: NodeRepresentable, expiration: Date? = nil) throws {
+        return try set(key, try value.makeNode(in: nil), expiration: expiration)
     }
 }

--- a/Sources/Cache/MemoryCache.swift
+++ b/Sources/Cache/MemoryCache.swift
@@ -1,18 +1,27 @@
 import Node
+import Foundation
 
 public final class MemoryCache: CacheProtocol {
-    private var _storage: [String: Node]
+    private var _storage: [String: (Date?, Node)]
 
     public init() {
         _storage = [:]
     }
 
     public func get(_ key: String) throws -> Node? {
-        return _storage[key]
+        guard let (expiration, value) = _storage[key] else {
+            return nil
+        }
+
+        if let expiration = expiration {
+            return expiration.timeIntervalSinceNow > 0 ? value : nil
+        }
+
+        return value
     }
 
-    public func set(_ key: String, _ value: Node) throws {
-        _storage[key] = value
+    public func set(_ key: String, _ value: Node, expiration: Date?) throws {
+        _storage[key] = (expiration, value)
     }
 
     public func delete(_ key: String) throws {

--- a/Sources/Sessions/CacheSessions.swift
+++ b/Sources/Sessions/CacheSessions.swift
@@ -1,11 +1,15 @@
 import Crypto
 import Cache
 import Node
+import Foundation
 
 public final class CacheSessions: SessionsProtocol {
     public let cache: CacheProtocol
-    public init(_ cache: CacheProtocol) {
+    private let defaultExpiration: TimeInterval?
+
+    public init(_ cache: CacheProtocol, defaultExpiration: TimeInterval? = nil) {
         self.cache = cache
+        self.defaultExpiration = defaultExpiration
     }
 
     public func get(identifier: String) throws -> Session? {
@@ -17,12 +21,12 @@ public final class CacheSessions: SessionsProtocol {
     }
 
     public func set(_ session: Session) throws {
-        try cache.set(session.identifier, session.data)
+        let expiration = defaultExpiration.map { Date(timeIntervalSinceNow: $0) }
+        try cache.set(session.identifier, session.data, expiration: expiration)
     }
-    
+
     public func destroy(identifier: String) throws{
         try cache.delete(identifier)
-        
     }
 
     public func makeIdentifier() throws -> String {

--- a/Tests/CacheTests/MemoryCacheTests.swift
+++ b/Tests/CacheTests/MemoryCacheTests.swift
@@ -1,10 +1,12 @@
 import XCTest
+import Foundation
 @testable import Cache
 
 class MemoryCacheTests: XCTestCase {
     static let allTests = [
         ("testBasic", testBasic),
         ("testDelete", testDelete),
+        ("testExpiration", testExpiration)
     ]
 
     var cache: MemoryCache!
@@ -23,5 +25,12 @@ class MemoryCacheTests: XCTestCase {
         XCTAssertEqual(try cache.get("ephemeral")?.string, "42")
         try cache.delete("ephemeral")
         XCTAssertEqual(try cache.get("ephemeral"), nil)
+    }
+
+    func testExpiration() throws {
+        try cache.set("ephemeral", 42, expiration: Date(timeIntervalSinceNow: 0.5))
+        XCTAssertEqual(try cache.get("ephemeral")?.string, "42")
+        sleep(1)
+        XCTAssertTrue(try cache.get("ephemeral")?.isNull ?? false)
     }
 }


### PR DESCRIPTION
This PR is practically the same as #906 (which I'll close in a second), but applied on top of master instead of the 1.x versions.

The rationale is still in #907.