### PR TITLE
slight error response cleanup

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -25,7 +25,6 @@ XCTMain([
     testCase(ConsoleTests.allTests),
     testCase(ContentTests.allTests),
     testCase(CORSMiddlewareTests.allTests),
-    testCase(DataSplitTests.allTests),
     testCase(DropletTests.allTests),
     testCase(EnvironmentTests.allTests),
     testCase(EventTests.allTests),


### PR DESCRIPTION
I noticed nothing in here actually threw, then ended up with some clean up. I think a few of these might be worth porting into Node for this type of stuff, namely the rethrow closure so you can do `set("foo", thing.makeNode)` and it only requires try on throwing implementation.

For now it's all additive, so file private here to prevent an impossible code path :+1: