### PR TITLE
Changed type TypeSafeGenerator to use functions

### DIFF
--- a/Sources/TypeSafeGenerator/Body.swift
+++ b/Sources/TypeSafeGenerator/Body.swift
@@ -47,7 +47,7 @@ extension Body: CustomStringConvertible {
 
     var stringInitializeTrys: String {
         return signature.wildcards.map { wildcard in
-            return "let e\(wildcard.name) = try \(wildcard.generic)(from: v\(wildcard.name))\n"
+            return "let e\(wildcard.name) = try \(wildcard.name)(v\(wildcard.name))\n"
         }.joined(separator: "\n")
     }
 

--- a/Sources/TypeSafeGenerator/Generator.swift
+++ b/Sources/TypeSafeGenerator/Generator.swift
@@ -30,10 +30,9 @@ class Generator {
             warning,
             "import Routing",
             "import HTTP",
-            "import HTTPRouting",
             "import WebSockets",
             " ",
-            "extension Routing.RouteBuilder where Value == HTTP.Responder {",
+            "extension Routing.RouteBuilder {",
         ]
         for function in functions {
             generated.append(function.description.indented)

--- a/Sources/TypeSafeGenerator/Signature.swift
+++ b/Sources/TypeSafeGenerator/Signature.swift
@@ -41,7 +41,7 @@ extension Signature {
         Blah blah blah ...
     */
 
-    public func get<T: StringInitializable>(_ p0: String, _ w0: T, handler: (Request, T) -> ResponseRepresentable)
+    public func get<T>(_ p0: String, _ w0: ((String) throws -> (T?), handler: (Request, T) -> ResponseRepresentable)
 
                    <----- generic map ---->
                                             <----- list -------->
@@ -85,7 +85,7 @@ extension Signature {
                 case .path(_):
                     string <<< "String"
                 case .wildcard(let wildcard):
-                    string <<< "\(wildcard.generic).Type"
+                    string <<< "@escaping ((String) throws -> (\(wildcard.generic)?))"
                 }
 
                 return string
@@ -127,7 +127,7 @@ extension Signature {
 
     var genericMap: String {
         return wildcards.map { wildcard in
-            return "\(wildcard.generic): StringInitializable"
+            return "\(wildcard.generic)"
         }.joined(separator: ", ")
     }
 


### PR DESCRIPTION
Rather than using type we can accept functions use the same signature as the StringInitializable's initializer. The syntax will change from `drop.get("...", MyType.self) {` to `drop.get("...", MyType.init) {` but allows more freedom in creating routes without any sacrifice.

An example using pseudo-swift-code that I didn't test:

```swift
extension MyUserModel {
  static func username(_ username: String) throws -> MyUserModel? {
    // fetch and return user model
    return User.// todo fetch using driver/Fluent/...
  }
}
```

This also allows all Fluent models to be initialized by their _id without conformance to a protocol.

```swift
extension Fluent.Entity {
  public static func identifier(_ identifer: String) throws -> Self? {
    return try Self.query(identifier: identfier).first()
  }
}
```

[The routing PR](https://github.com/vapor/routing/pull/11)