### PR TITLE
Add refreshCookieEveryRequest to AuthMiddleware

### DIFF
--- a/Sources/Auth/Authentication/AuthMiddleware.swift
+++ b/Sources/Auth/Authentication/AuthMiddleware.swift
@@ -12,15 +12,15 @@ public class AuthMiddleware<U: User>: Middleware {
     private let cookieName: String
     private let cookieFactory: CookieFactory
     private let refreshCookieEveryRequest: Bool
-    
+
     public typealias CookieFactory = (String) -> Cookie
-    
+
     public init(
         turnstile: Turnstile,
         cookieName: String = defaultCookieName,
         refreshCookieEveryRequest: Bool = false,
         makeCookie cookieFactory: CookieFactory?
-        ) {
+    ) {
         self.turnstile = turnstile
         self.cookieName = cookieName
         self.refreshCookieEveryRequest = refreshCookieEveryRequest
@@ -34,7 +34,7 @@ public class AuthMiddleware<U: User>: Middleware {
             )
         }
     }
-    
+
     public convenience init(
         user: U.Type = U.self,
         realm: Realm = AuthenticatorRealm(U.self),
@@ -42,25 +42,25 @@ public class AuthMiddleware<U: User>: Middleware {
         cookieName: String = defaultCookieName,
         refreshCookieEveryRequest: Bool = false,
         makeCookie cookieFactory: CookieFactory? = nil
-        ) {
+    ) {
         let session = CacheSessionManager(cache: cache, realm: realm)
         let turnstile = Turnstile(sessionManager: session, realm: realm)
         self.init(turnstile: turnstile, cookieName: cookieName, refreshCookieEveryRequest: refreshCookieEveryRequest, makeCookie: cookieFactory)
     }
-    
+
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
         request.storage["subject"] = Subject(
             turnstile: turnstile,
             sessionID: request.cookies[cookieName]
         )
-        
+
         let response = try next.respond(to: request)
-        
+
         // If we have a new session, set a new cookie
         if
             let sid = try request.subject().sessionIdentifier,
             request.cookies[cookieName] != sid ||
-                self.refreshCookieEveryRequest
+            refreshCookieEveryRequest
         {
             var cookie = cookieFactory(sid)
             cookie.name = cookieName
@@ -72,7 +72,7 @@ public class AuthMiddleware<U: User>: Middleware {
             // If we have a cookie but no session, delete it.
             response.cookies[cookieName] = nil
         }
-        
+
         return response
     }
 }


### PR DESCRIPTION
If true, this allows the cookie factory to run every time so that with each request the expiration date can be reset. So, a short expiration date can be set like 10 minutes, but it will be 10 minutes from each successful auth request instead of just 10 minutes from the first login.

fyi: I incorrectly assumed that the `edit` button in GitHub would create a PR, instead it made the edits directly 😳: https://github.com/vapor/vapor/commit/b3abd80be444f34bc17c0765ae2ccb764ec4bd8a, I reverted this(https://github.com/vapor/vapor/commit/5a0191f924de3458b8398f85cfffb52ee7045bc5) and am submitting a PR for it, sorry 😔