### PR TITLE
Use JSONContext in Model.makeJSON instead of empty

### DIFF
--- a/Sources/Vapor/Fluent/Model.swift
+++ b/Sources/Vapor/Fluent/Model.swift
@@ -17,7 +17,7 @@ extension Model {
 
 extension Model {
     public func makeJSON() throws -> JSON {
-        let node = try makeNode()
+        let node = try makeNode(context: JSONContext())
         return try JSON(node: node)
     }
 }


### PR DESCRIPTION
This change is a logical consequence of the default Database- and JSONContexts.

With this, both the custom makeJSON and the context-aware makeNode strategies can work out of the box.