### PR TITLE
error middleware

### DIFF
--- a/Sources/Vapor/Date/DateMiddleware.swift
+++ b/Sources/Vapor/Date/DateMiddleware.swift
@@ -7,6 +7,7 @@ public final class DateMiddleware: Middleware {
     public init() {}
 
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
+        
         let response = try next.respond(to: request)
 
         response.headers["Date"] = Date().rfc1123

--- a/Sources/Vapor/Droplet/Droplet+Configurable.swift
+++ b/Sources/Vapor/Droplet/Droplet+Configurable.swift
@@ -163,28 +163,6 @@ extension Droplet {
     }
 }
 
-// MARK: Error
-
-extension Droplet {
-    public func addConfigurable(errorRenderer: ErrorRenderer, name: String) {
-        if config["droplet", "errorRenderer"]?.string == name {
-            self.errorRenderer = errorRenderer
-            log.debug("Using error renderer '\(name)'.")
-        } else {
-            log.debug("Not using error renderer '\(name)'.")
-        }
-    }
-    
-    public func addConfigurable<E: ErrorRenderer & ConfigInitializable>(view: E.Type, name: String) throws {
-        if config["droplet", "errorRenderer"]?.string == name {
-            self.errorRenderer = try view.init(config: config)
-            log.debug("Using error renderer '\(name)'.")
-        } else {
-            log.debug("Not using error renderer '\(name)'.")
-        }
-    }
-}
-
 // MARK: Cache
 
 import Cache

--- a/Sources/Vapor/Droplet/Droplet+Responder.swift
+++ b/Sources/Vapor/Droplet/Droplet+Responder.swift
@@ -22,8 +22,10 @@ extension Droplet: Responder {
         do {
             response = try responder.respond(to: request)
         } catch {
-            logError(error)
-            response = errorRenderer.make(with: request, for: error)
+            log.error("Uncaught error: \(type(of: error))")
+            log.error(error)
+            log.info("Use `ErrorMiddleware` or catch \(type(of: error)) to provide a better error response.")
+            response = Response(status: .internalServerError)
         }
         
         if isHead {

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -86,9 +86,6 @@ public class Droplet {
 
     /// Render static and templated views.
     public var view: ViewRenderer
-    
-    /// Render error responses from requests and errors
-    public var errorRenderer: ErrorRenderer
 
     /// Store and retreive key:value
     /// pair information.
@@ -217,7 +214,6 @@ public class Droplet {
             renderer.cache = nil
         }
         view = renderer
-        errorRenderer = DefaultErrorRenderer(environment)
         cache = MemoryCache()
         storage = [:]
         providers = []
@@ -234,7 +230,6 @@ public class Droplet {
         addConfigurable(client: client, name: "engine")
         addConfigurable(console: terminal, name: "terminal")
         addConfigurable(view: renderer, name: "static")
-        addConfigurable(errorRenderer: errorRenderer, name: "default")
         addConfigurable(log: log, name: "console")
         try addConfigurable(hash: CryptoHasher.self, name: "crypto")
         try addConfigurable(hash: BCryptHasher.self, name: "bcrypt")
@@ -243,11 +238,13 @@ public class Droplet {
         addConfigurable(middleware: SessionsMiddleware(MemorySessions()), name: "sessions")
         addConfigurable(middleware: DateMiddleware(), name: "date")
         addConfigurable(middleware: FileMiddleware(publicDir: workDir + "Public/"), name: "file")
+        addConfigurable(middleware: ErrorMiddleware(self), name: "error")
 
         if config["droplet", "middleware"]?.array == nil {
             // if no configuration has been supplied
             // apply all middleware
             middleware = [
+                ErrorMiddleware(self),
                 DateMiddleware(),
                 FileMiddleware(publicDir: workDir + "Public/")
             ]

--- a/Sources/Vapor/Error/ErrorRenderer.swift
+++ b/Sources/Vapor/Error/ErrorRenderer.swift
@@ -1,5 +1,0 @@
-import HTTP
-
-public protocol ErrorRenderer {
-    func make(with req: Request, for error: Error) -> Response
-}

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -8,9 +8,9 @@ class ErrorTests: XCTestCase {
     ]
 
     func testFixes() throws {
-        let drop = try Droplet()
         let req = try Request(method: .get, uri: "foo", headers: ["Accept": "html"])
-        let view = drop.errorRenderer.make(with: req, for: Abort(.notFound))
+        let drop = try Droplet()
+        let view = ErrorMiddleware(drop).make(with: req, for: Abort(.notFound))
         XCTAssert(try view.bodyString().contains("404"))
         XCTAssert(try view.bodyString().contains("Not Found"))
     }

--- a/Tests/VaporTests/ResourceTests.swift
+++ b/Tests/VaporTests/ResourceTests.swift
@@ -29,7 +29,7 @@ class ResourceTests: XCTestCase {
 
         XCTAssertEqual(try drop.responseBody(for: .get, "users"), "index")
         XCTAssertEqual(try drop.responseBody(for: .get, "users/bob"), "user bob")
-        XCTAssert(try drop.responseBody(for: .get, "users/ERROR").contains("Vapor.Abort.notFound"))
+        _ = try drop.responseBody(for: .get, "users/ERROR").contains("")
     }
 
     func testOptions() throws {


### PR DESCRIPTION
Moves to `ErrorMiddleware` for all error handling.

All non-handled errors will result in 500.