### PR TITLE
routing updates

### DIFF
--- a/Sources/Vapor/Error/error.html
+++ b/Sources/Vapor/Error/error.html
@@ -50,7 +50,7 @@
     </head>
     <body>
         <div class="container">
-            <h1 class="code">500</h1>
+            <h1 class="code">#(code)</h1>
             <p class="message">#(message)</p>
         </div>
     </body>

--- a/Sources/Vapor/Routing/Droplet+Routing.swift
+++ b/Sources/Vapor/Routing/Droplet+Routing.swift
@@ -9,3 +9,11 @@ extension Droplet: RouteBuilder {
     }
 }
 
+extension Int {
+    public init?(_ string: String) {
+        guard let int = string.int else {
+            return nil
+        }
+        self = int
+    }
+}

--- a/Sources/Vapor/Routing/RouteCollection.swift
+++ b/Sources/Vapor/Routing/RouteCollection.swift
@@ -1,0 +1,20 @@
+import Routing
+
+/// Objects conforming to this protocol can be used
+/// to add collections of rotues to a route builder.
+public protocol RouteCollection {
+    func build(_ builder: RouteBuilder) throws
+}
+
+extension RouteBuilder {
+    /// Adds the collection of routes
+    func collection<C: RouteCollection>(_ c: C) throws {
+        try c.build(self)
+    }
+    
+    /// Adds the collection of routes
+    func collection<C: RouteCollection & EmptyInitializable>(_ c: C.Type) throws {
+        let c = C()
+        try c.build(self)
+    }
+}

--- a/Sources/Vapor/Routing/RouteCollection.swift
+++ b/Sources/Vapor/Routing/RouteCollection.swift
@@ -8,12 +8,12 @@ public protocol RouteCollection {
 
 extension RouteBuilder {
     /// Adds the collection of routes
-    func collection<C: RouteCollection>(_ c: C) throws {
+    public func collection<C: RouteCollection>(_ c: C) throws {
         try c.build(self)
     }
     
     /// Adds the collection of routes
-    func collection<C: RouteCollection & EmptyInitializable>(_ c: C.Type) throws {
+    public func collection<C: RouteCollection & EmptyInitializable>(_ c: C.Type) throws {
         let c = C()
         try c.build(self)
     }

--- a/Tests/VaporTests/RoutingTests.swift
+++ b/Tests/VaporTests/RoutingTests.swift
@@ -23,10 +23,36 @@ class RoutingTests: XCTestCase {
         XCTAssertEqual(try drop.responseBody(for: .get, "/foo"), "get")
         XCTAssertEqual(try drop.responseBody(for: .post, "/foo"), "post")
     }
+    
+    func testCollections() throws {
+        let drop = try Droplet()
+        XCTAssertEqual(drop.router.routes.count, 0)
+        try drop.collection(TestCollectionA.self)
+        XCTAssertEqual(drop.router.routes.count, 1)
+        try drop.collection(TestCollectionB())
+        XCTAssertEqual(drop.router.routes.count, 2)
+        
+    }
 }
 
 private final class TestMiddleware: Middleware {
     func respond(to request: Request, chainingTo next: Responder) throws -> Response {
         return try next.respond(to: request)
+    }
+}
+
+fileprivate final class TestCollectionA: RouteCollection, EmptyInitializable {
+    func build(_ builder: RouteBuilder) {
+        builder.get("foo") { req in
+            return "bar"
+        }
+    }
+}
+
+fileprivate final class TestCollectionB: RouteCollection {
+    func build(_ builder: RouteBuilder) {
+        builder.get("baz") { req in
+            return "bar"
+        }
     }
 }


### PR DESCRIPTION
- fixes `drop.get(..., Int.init)`
- adds back route collections