### PR TITLE
session fixes

### DIFF
--- a/Sources/Sessions/Request+Session.swift
+++ b/Sources/Sessions/Request+Session.swift
@@ -1,18 +1,19 @@
 import HTTP
 
-private let sessionKey = "session"
+private let sessionKey = "sessions:session"
 
 extension Request {
     /// Server stored information related from session cookie.
-    public func session() throws -> Session {
-        guard let session = storage[sessionKey] as? Session else {
+    public func assertSession() throws -> Session {
+        guard let session = self.session else {
             throw SessionsError.notConfigured
         }
 
         return session
     }
-
-    internal func set(_ session: Session) {
-        storage[sessionKey] = session
+    
+    public var session: Session? {
+        get { return storage[sessionKey] as? Session }
+        set { storage[sessionKey] = newValue }
     }
 }

--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -31,7 +31,7 @@ public final class SessionsMiddleware: Middleware {
             session = Session(identifier: try sessions.makeIdentifier())
         }
         
-        request.set(session)
+        request.session = session
 
 
         let response = try chain.respond(to: request)

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -235,8 +235,8 @@ public class Droplet {
         try addConfigurable(hash: BCryptHasher.self, name: "bcrypt")
         try addConfigurable(cipher: CryptoCipher.self, name: "crypto")
         addConfigurable(cache: MemoryCache(), name: "memory")
-        addConfigurable(middleware: SessionsMiddleware(MemorySessions()), name: "sessions")
         addConfigurable(middleware: ErrorMiddleware(self), name: "error")
+        addConfigurable(middleware: SessionsMiddleware(MemorySessions()), name: "sessions")
         addConfigurable(middleware: DateMiddleware(), name: "date")
         addConfigurable(middleware: FileMiddleware(publicDir: workDir + "Public/"), name: "file")
 

--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -236,9 +236,9 @@ public class Droplet {
         try addConfigurable(cipher: CryptoCipher.self, name: "crypto")
         addConfigurable(cache: MemoryCache(), name: "memory")
         addConfigurable(middleware: SessionsMiddleware(MemorySessions()), name: "sessions")
+        addConfigurable(middleware: ErrorMiddleware(self), name: "error")
         addConfigurable(middleware: DateMiddleware(), name: "date")
         addConfigurable(middleware: FileMiddleware(publicDir: workDir + "Public/"), name: "file")
-        addConfigurable(middleware: ErrorMiddleware(self), name: "error")
 
         if config["droplet", "middleware"]?.array == nil {
             // if no configuration has been supplied

--- a/Sources/Vapor/HTTP/HTTP+Node.swift
+++ b/Sources/Vapor/HTTP/HTTP+Node.swift
@@ -24,7 +24,7 @@ extension Request: NodeRepresentable {
         }
 
         var node = Node(context)
-        try node.set("session", try session())
+        try node.set("session", session)
         try node.set("storage", nodeStorage)
         try node.set("method", method.description)
         try node.set("version", version)

--- a/Sources/Vapor/View/ViewRenderer+Request.swift
+++ b/Sources/Vapor/View/ViewRenderer+Request.swift
@@ -9,9 +9,8 @@ extension ViewRenderer {
     /// Data from the `Request` is available in the
     /// view under the key "request".
     public func make(_ path: String, for request: Request) throws -> View {
-        let context = try Node(node: [
-            "request": request.makeNode(in: nil)
-        ])
+        var context = Node(ViewContext.shared)
+        try context.set("request", request)
         return try make(path, context)
     }
     
@@ -23,56 +22,8 @@ extension ViewRenderer {
     /// Data from the `Request` is available in the
     /// view under the key "request".
     public func make(_ path: String, _ context: NodeRepresentable, for request: Request) throws -> View {
-        let node: Node
-        
-        if var nodeObject = try context.makeNode(in: nil).object {
-            nodeObject["request"] = try request.makeNode(in: nil)
-            node = Node.object(nodeObject)
-        } else {
-            node = try context.makeNode(in: nil)
-        }
-        
-        return try make(path, node)
-    }
-    
-    /// Creates a view at the given path
-    /// using a `NodeRepresentable` dictionary
-    /// that will be merged with the given `Request`
-    /// and supplied as the data to the view.
-    ///
-    /// Data from the `Request` is available in the
-    /// view under the key "request".
-    public func make(_ path: String, _ context: [String: NodeRepresentable], for request: Request) throws -> View {
-        var context = context
-        
-        context["request"] = try request.makeNode(in: nil)
-        
-        return try make(path, try context.makeNode(in: nil))
-    }
-}
-
-extension Request {
-    fileprivate func makeNode() throws -> Node {
-        var nodeStorage: [String: Node] = [:]
-        
-        for (key, val) in storage {
-            if let node = val as? NodeRepresentable {
-                nodeStorage[key] = try node.makeNode(in: nil)
-            }
-        }
-        
-        return try Node(node: [
-            "session": Node(node: [
-                "data": try session().data,
-                "identifier": try session().identifier
-            ]),
-            "storage": Node.object(nodeStorage),
-            "method": method.description,
-            "uri": Node(node: [
-                "path": uri.path,
-                "host": uri.hostname,
-                "scheme": uri.scheme
-            ])
-        ])
+        var context = try context.makeNode(in: ViewContext.shared)
+        try context.set("request", request)
+        return try make(path, context)
     }
 }

--- a/Tests/SessionsTests/SessionTests.swift
+++ b/Tests/SessionsTests/SessionTests.swift
@@ -15,7 +15,7 @@ class SessionTests: XCTestCase {
         let request = try Request(method: .get, uri: "http://vapor.codes")
 
         do {
-            _ = try request.session()
+            _ = try request.assertSession()
             XCTFail("Should have errored.")
         } catch SessionsError.notConfigured {
             //
@@ -23,9 +23,9 @@ class SessionTests: XCTestCase {
             XCTFail("Wrong error: \(error)")
         }
 
-        request.storage["session"] = s
+        request.session = s
 
-        let rs = try request.session()
+        let rs = try request.assertSession()
         XCTAssert(s === rs)
     }
 

--- a/Tests/VaporTests/SessionsTests.swift
+++ b/Tests/VaporTests/SessionsTests.swift
@@ -17,13 +17,13 @@ class SessionsTests: XCTestCase {
         drop.middleware = [m]
 
         drop.get("set") { req in
-            try req.session().data["foo"] = "bar"
-            try req.session().data["bar"] = "baz"
+            try req.assertSession().data["foo"] = "bar"
+            try req.assertSession().data["bar"] = "baz"
             return "set"
         }
 
         drop.get("get") { req in
-            return try req.session().data["foo"]?.string ?? "fail"
+            return try req.assertSession().data["foo"]?.string ?? "fail"
         }
 
         let req = Request(method: .get, path: "set")


### PR DESCRIPTION
- adds optional `session` property moving throwing method to `assertSession()`
- cleans up session makeNode and redundant function
- fixes bug where making a view w/ a request fails if not using sessions
- namespaces the session key under the module name