### PR TITLE
add proxy support

### DIFF
--- a/Sources/Vapor/Engine/Client/ClientFactory.swift
+++ b/Sources/Vapor/Engine/Client/ClientFactory.swift
@@ -17,13 +17,13 @@ public final class ClientFactory<C: ClientProtocol>: ClientFactoryProtocol {
     public func makeClient(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer,
+        securityLayer: SecurityLayer,
         proxy: Proxy? = nil
     ) throws -> ClientProtocol {
         return try C(
             hostname: hostname,
             port: port,
-            securityLayer,
+            securityLayer: securityLayer,
             proxy: proxy ?? defaultProxy
         )
     }

--- a/Sources/Vapor/Engine/Client/ClientFactory.swift
+++ b/Sources/Vapor/Engine/Client/ClientFactory.swift
@@ -6,19 +6,25 @@ import TLS
 /// TCP and TLS clients from engine
 /// wrapped to conform to ClientProtocol.
 public final class ClientFactory<C: ClientProtocol>: ClientFactoryProtocol {
+    public let defaultProxy: Proxy?
+    
     /// Create a new ClientFactory
-    public init() {}
+    public init(defaultProxy: Proxy? = nil) {
+        self.defaultProxy = defaultProxy
+    }
     
     /// Creates a new client with the supplied connection info
     public func makeClient(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer
+        _ securityLayer: SecurityLayer,
+        proxy: Proxy? = nil
     ) throws -> ClientProtocol {
         return try C(
             hostname: hostname,
             port: port,
-            securityLayer
+            securityLayer,
+            proxy: proxy ?? defaultProxy
         )
     }
     
@@ -30,6 +36,39 @@ public final class ClientFactory<C: ClientProtocol>: ClientFactoryProtocol {
 
 extension ClientFactory: ConfigInitializable {
     public convenience init(config: Configs.Config) throws {
-        self.init()
+        let proxy: Proxy?
+        
+        if let proxyConfig = config["client", "proxy"]?.object {
+            guard let hostname = proxyConfig["hostname"]?.string else {
+                throw ConfigError.missing(
+                    key: ["proxy", "hostname"],
+                    file: "client",
+                    desiredType: String.self
+                )
+            }
+            
+            guard let port = proxyConfig["port"]?.int?.port else {
+                throw ConfigError.missing(
+                    key: ["proxy", "port"],
+                    file: "client",
+                    desiredType: Port.self
+                )
+            }
+            
+            let securityLayer = try config.makeSecurityLayer(
+                serverConfig: Config(proxyConfig),
+                file: "client"
+            )
+            
+            proxy = Proxy(
+                hostname: hostname,
+                port: port,
+                securityLayer: securityLayer
+            )
+        } else {
+            proxy = nil
+        }
+        
+        self.init(defaultProxy: proxy)
     }
 }

--- a/Sources/Vapor/Engine/Client/ClientFactoryProtocol.swift
+++ b/Sources/Vapor/Engine/Client/ClientFactoryProtocol.swift
@@ -9,7 +9,8 @@ public protocol ClientFactoryProtocol: Responder {
     func makeClient(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer
+        _ securityLayer: SecurityLayer,
+        proxy: Proxy?
     ) throws -> ClientProtocol
 }
 
@@ -17,6 +18,18 @@ public protocol ClientFactoryProtocol: Responder {
 // MARK: Convenience
 
 extension ClientFactoryProtocol {
+    public func makeClient(
+        hostname: String,
+        port: Port,
+        _ securityLayer: SecurityLayer
+    ) throws -> ClientProtocol {
+        return try makeClient(
+            hostname: hostname,
+            port: port,
+            securityLayer,
+            proxy: nil
+        )
+    }
     /// Creates a client connected to the server specified
     /// by the supplied request.
     func makeClient(for req: Request, using s: SecurityLayer? = nil) throws -> ClientProtocol {

--- a/Sources/Vapor/Engine/Client/ClientFactoryProtocol.swift
+++ b/Sources/Vapor/Engine/Client/ClientFactoryProtocol.swift
@@ -9,7 +9,7 @@ public protocol ClientFactoryProtocol: Responder {
     func makeClient(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer,
+        securityLayer: SecurityLayer,
         proxy: Proxy?
     ) throws -> ClientProtocol
 }
@@ -21,12 +21,12 @@ extension ClientFactoryProtocol {
     public func makeClient(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer
+        securityLayer: SecurityLayer
     ) throws -> ClientProtocol {
         return try makeClient(
             hostname: hostname,
             port: port,
-            securityLayer,
+            securityLayer: securityLayer,
             proxy: nil
         )
     }
@@ -47,7 +47,7 @@ extension ClientFactoryProtocol {
         return try makeClient(
             hostname: req.uri.hostname,
             port: req.uri.port ?? req.uri.scheme.port,
-            securityLayer
+            securityLayer: securityLayer
         )
     }
 }

--- a/Sources/Vapor/Engine/Client/ClientProtocol.swift
+++ b/Sources/Vapor/Engine/Client/ClientProtocol.swift
@@ -8,7 +8,7 @@ public protocol ClientProtocol: Responder {
     init(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer,
+        securityLayer: SecurityLayer,
         proxy: Proxy?
     ) throws
 }
@@ -28,12 +28,12 @@ extension ClientProtocol {
     public init(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer
+        securityLayer: SecurityLayer
     ) throws {
         try self.init(
             hostname: hostname,
             port: port,
-            securityLayer,
+            securityLayer: securityLayer,
             proxy: nil
         )
     }

--- a/Sources/Vapor/Engine/Client/ClientProtocol.swift
+++ b/Sources/Vapor/Engine/Client/ClientProtocol.swift
@@ -8,6 +8,34 @@ public protocol ClientProtocol: Responder {
     init(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer
+        _ securityLayer: SecurityLayer,
+        proxy: Proxy?
     ) throws
 }
+
+// MARK: Proxy
+
+public struct Proxy {
+    var hostname: String
+    var port: Port
+    var securityLayer: SecurityLayer
+}
+
+
+// MARK: Convenience
+
+extension ClientProtocol {
+    public init(
+        hostname: String,
+        port: Port,
+        _ securityLayer: SecurityLayer
+    ) throws {
+        try self.init(
+            hostname: hostname,
+            port: port,
+            securityLayer,
+            proxy: nil
+        )
+    }
+}
+

--- a/Sources/Vapor/Engine/Client/EngineClient.swift
+++ b/Sources/Vapor/Engine/Client/EngineClient.swift
@@ -46,7 +46,14 @@ public final class EngineClient: ClientProtocol {
     
     public func respond(to request: Request) throws -> Response {
         if proxy != nil {
-            request.uri.path = "http://\(hostname):\(port)" + request.uri.path
+            let scheme: String
+            switch securityLayer {
+            case .none:
+                scheme = "http"
+            case .tls:
+                scheme = "https"
+            }
+            request.uri.path = "\(scheme)://\(hostname):\(port)" + request.uri.path
         }
         return try client.respond(to: request)
     }

--- a/Sources/Vapor/Engine/Client/EngineClient.swift
+++ b/Sources/Vapor/Engine/Client/EngineClient.swift
@@ -21,7 +21,7 @@ public final class EngineClient: ClientProtocol {
     public init(
         hostname: String,
         port: Port,
-        _ securityLayer: SecurityLayer,
+        securityLayer: SecurityLayer,
         proxy: Proxy?
     ) throws {
         self.hostname = hostname

--- a/Sources/Vapor/Engine/Client/EngineClient.swift
+++ b/Sources/Vapor/Engine/Client/EngineClient.swift
@@ -2,37 +2,84 @@ import HTTP
 import Transport
 import Sockets
 import TLS
+import Dispatch
 
 /// TCP and TLS client from Engine package.
 public final class EngineClient: ClientProtocol {
     public static let factory = EngineClientFactory()
     
+    /// The connected HTTP client
     public let client: HTTP.Client
     
+    /// Settings
+    let hostname: String
+    let port: Port
+    let securityLayer: SecurityLayer
+    let proxy: Proxy?
+    
     /// Creates a new Engine client
-    public init(hostname: String, port: Port, _ securityLayer: SecurityLayer) throws {
-        switch securityLayer {
-        case .none:
-            let socket = try TCPInternetSocket(
-                scheme: "http",
-                hostname: hostname,
-                port: port
+    public init(
+        hostname: String,
+        port: Port,
+        _ securityLayer: SecurityLayer,
+        proxy: Proxy?
+    ) throws {
+        self.hostname = hostname
+        self.port = port
+        self.securityLayer = securityLayer
+        self.proxy = proxy
+        
+        if let proxy = proxy {
+            client = try makeClient(
+                hostname: proxy.hostname,
+                port: proxy.port,
+                securityLayer: proxy.securityLayer
             )
-            client = try TCPClient(socket)
-        case .tls(let context):
-            let socket = try TCPInternetSocket(
-                scheme: "https",
+        } else {
+            client = try makeClient(
                 hostname: hostname,
-                port: port
+                port: port,
+                securityLayer: securityLayer
             )
-            let tlsSocket = TLS.InternetSocket(socket, context)
-            client = try TLSClient(tlsSocket)
         }
     }
     
     public func respond(to request: Request) throws -> Response {
+        if proxy != nil {
+            request.uri.path = "http://\(hostname):\(port)" + request.uri.path
+        }
         return try client.respond(to: request)
     }
 }
 
 public typealias EngineClientFactory = ClientFactory<EngineClient>
+
+// MARK: Private
+
+private func makeClient(
+    hostname: String,
+    port: Port,
+    securityLayer: SecurityLayer
+) throws -> HTTP.Client {
+    let client: HTTP.Client
+    
+    switch securityLayer {
+    case .none:
+        let socket = try TCPInternetSocket(
+            scheme: "http",
+            hostname: hostname,
+            port: port
+        )
+        client = try TCPClient(socket)
+    case .tls(let context):
+        let socket = try TCPInternetSocket(
+            scheme: "https",
+            hostname: hostname,
+            port: port
+        )
+        let tlsSocket = TLS.InternetSocket(socket, context)
+        client = try TLSClient(tlsSocket)
+    }
+    
+    return client
+}

--- a/Sources/Vapor/Mail/Mailgun.swift
+++ b/Sources/Vapor/Mail/Mailgun.swift
@@ -93,7 +93,7 @@ public final class Mailgun: MailProtocol {
         let client = try clientFactory.makeClient(
             hostname: apiURI.hostname,
             port: apiURI.port ?? 443,
-            .tls(EngineClient.defaultTLSContext())
+            securityLayer: .tls(EngineClient.defaultTLSContext())
         )
         let res = try client.respond(to: req)
         guard res.status.statusCode < 400 else {

--- a/Sources/Vapor/Serve/Config+ServerConfig.swift
+++ b/Sources/Vapor/Serve/Config+ServerConfig.swift
@@ -6,11 +6,14 @@ extension Configs.Config {
         let serverConfig = self["server"]
         let port = serverConfig?["port"]?.int?.port ?? 8080
         let hostname = serverConfig?["hostname"]?.string ?? "0.0.0.0"
-        let securityLayer = try makeSecurityLayer(serverConfig: serverConfig)
+        let securityLayer = try makeSecurityLayer(serverConfig: serverConfig, file: "server")
         return ServerConfig(hostname: hostname, port: port, securityLayer)
     }
     
-    private func makeSecurityLayer(serverConfig: Configs.Config?) throws -> SecurityLayer {
+    internal func makeSecurityLayer(
+        serverConfig: Configs.Config?,
+        file: String
+    ) throws -> SecurityLayer {
         let serverConfig = serverConfig?.converted(to: Node.self)
         let security = serverConfig?["securityLayer"]?.string ?? "none"
         let securityLayer: SecurityLayer
@@ -29,7 +32,7 @@ extension Configs.Config {
             throw ConfigError.unsupported(
                 value: security,
                 key: ["securityLayer"],
-                file: "server"
+                file: file
             )
         }
         

--- a/Sources/Vapor/Serve/Config+ServerConfig.swift
+++ b/Sources/Vapor/Serve/Config+ServerConfig.swift
@@ -6,7 +6,10 @@ extension Configs.Config {
         let serverConfig = self["server"]
         let port = serverConfig?["port"]?.int?.port ?? 8080
         let hostname = serverConfig?["hostname"]?.string ?? "0.0.0.0"
-        let securityLayer = try makeSecurityLayer(serverConfig: serverConfig, file: "server")
+        let securityLayer = try makeSecurityLayer(
+            serverConfig: serverConfig,
+            file: "server"
+        )
         return ServerConfig(hostname: hostname, port: port, securityLayer)
     }
     

--- a/Tests/VaporTests/DropletTests.swift
+++ b/Tests/VaporTests/DropletTests.swift
@@ -129,7 +129,7 @@ class DropletTests: XCTestCase {
         let client = try EngineClient(
             hostname: "52.211.86.161",
             port: 80,
-            .none,
+            securityLayer: .none,
             proxy: proxy
         )
         
@@ -146,7 +146,7 @@ class DropletTests: XCTestCase {
         try config.set("client.proxy.port", 8888)
         try config.set("client.proxy.securityLayer", "none")
         
-        let drop = try! Droplet(config)
+        let drop = try Droplet(config)
         
         let res = try drop.client.get("http://52.211.86.161")
         try XCTAssertEqual(res.bodyString(), "It works!!!\n")

--- a/Tests/VaporTests/DropletTests.swift
+++ b/Tests/VaporTests/DropletTests.swift
@@ -117,4 +117,38 @@ class DropletTests: XCTestCase {
         let drop = try Droplet(config)
         try drop.runCommands()
     }
+    
+    func testProxy() throws {
+        Node.fuzzy = [Node.self]
+        
+        let proxy = Proxy(
+            hostname: "52.214.224.81",
+            port: 8888,
+            securityLayer: .none
+        )
+        let client = try EngineClient(
+            hostname: "52.211.86.161",
+            port: 80,
+            .none,
+            proxy: proxy
+        )
+        
+        let req = Request(method: .get, path: "/")
+        let res = try! client.respond(to: req)
+        try XCTAssertEqual(res.bodyString(), "It works!!!\n")
+    }
+    
+    func testDropletProxy() throws {
+        Node.fuzzy = [Node.self]
+        
+        var config = Config([:])
+        try config.set("client.proxy.hostname", "52.214.224.81")
+        try config.set("client.proxy.port", 8888)
+        try config.set("client.proxy.securityLayer", "none")
+        
+        let drop = try! Droplet(config)
+        
+        let res = try drop.client.get("http://52.211.86.161")
+        try XCTAssertEqual(res.bodyString(), "It works!!!\n")
+    }
 }


### PR DESCRIPTION
Fixes #999 

Allows a default proxy to be configured through `Config/client.json`

```json
{
    "proxy": {
        "hostname": "google.com", 
        "port": 80,
        "securityLayer": "none"
    }
}
```

For the above example, all requests sent to `drop.client.get(...)` would be proxied through google.com.