### PR TITLE
[PROPOSAL] Sessions middleware improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Packages
 .DS_Store
 *.xcodeproj
 Package.pins
+DerivedData/

--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -24,18 +24,11 @@ public final class SessionsMiddleware: Middleware {
         self.cookieName = cookieName
         self.cookieFactory = cookieFactory ?? { req in
             
-            var cookie = Cookie(
+            return Cookie(
                 name: cookieName,
                 value: "",
                 httpOnly: true
             )
-            
-            if req.storage["session_expiry"] as? Bool ?? false {
-                let oneMonthTime: TimeInterval = 30 * 24 * 60 * 60
-                cookie.expires = Date().addingTimeInterval(oneMonthTime)
-            }
-            
-            return cookie
         }
     }
 

--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -21,7 +21,8 @@ public final class SessionsMiddleware: Middleware {
         self.cookieFactory = cookieFactory ?? {
             return Cookie(
                 name: "vapor-session",
-                value: ""
+                value: "",
+                httpOnly: true
             )
         }
     }

--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -1,6 +1,5 @@
 import HTTP
 import Cookies
-import Foundation
 
 /// Looks for the `vapor-session` cookie on incoming
 /// requests and attempts to initialize a Session based on the

--- a/Tests/VaporTests/SessionsTests.swift
+++ b/Tests/VaporTests/SessionsTests.swift
@@ -7,6 +7,7 @@ import Core
 class SessionsTests: XCTestCase {
     static let allTests = [
         ("testExample", testExample),
+        ("testWithExpiryDate", testWithExpiryDate),
     ]
 
     func testExample() throws {
@@ -31,6 +32,15 @@ class SessionsTests: XCTestCase {
             XCTFail("No cookie")
             return
         }
+        
+        guard let cookieIndex = res.cookies.index(of: "vapor-session") else {
+            XCTFail("No cookie")
+            return
+        }
+        
+        let cookie = res.cookies.cookies[cookieIndex]
+        
+        XCTAssertTrue(cookie.httpOnly)
 
         for s in s.sessions {
             print(s.key)
@@ -47,6 +57,10 @@ class SessionsTests: XCTestCase {
         let res2 = try drop.respond(to: req2)
 
         XCTAssertEqual(res2.body.bytes?.makeString(), "bar")
+    }
+    
+    func testWithExpiryDate() throws {
+        
     }
     
 }

--- a/Tests/VaporTests/SessionsTests.swift
+++ b/Tests/VaporTests/SessionsTests.swift
@@ -41,6 +41,8 @@ class SessionsTests: XCTestCase {
         let cookie = res.cookies.cookies[cookieIndex]
         
         XCTAssertTrue(cookie.httpOnly)
+        
+        XCTAssertEqual(cookie.path, "/")
 
         for s in s.sessions {
             print(s.key)


### PR DESCRIPTION
This is to kick off a bit of a debate, but...

This PR adds the ability to set a value in the `request.storage` to change the expiry time of the cookie set in the `SessionsMiddleware`. It also passes the request in to the `CookieFactory` so that injected `CookieFactory`'s can set different values or use different storage keys.

Be interesting to see what people think!

One thing that should definitely be taken from this PR is the setting of `httpOnly` to `true`.