### PR TITLE
Use chunked transfer for serving static files

### DIFF
--- a/Sources/Vapor/Droplet/Droplet.swift
+++ b/Sources/Vapor/Droplet/Droplet.swift
@@ -6,7 +6,7 @@ import Crypto
 import Transport
 import Sockets
 
-public let VERSION = "2.0.2"
+public let VERSION = "2.0.3"
 
 public final class Droplet {
     /// Provides access to config settings.

--- a/Sources/Vapor/Middleware/Config+Middleware.swift
+++ b/Sources/Vapor/Middleware/Config+Middleware.swift
@@ -41,6 +41,9 @@ extension DateMiddleware: ConfigInitializable {
 
 extension FileMiddleware: ConfigInitializable {
     public convenience init(config: Config) throws {
-        self.init(publicDir: config.publicDir)
+        try self.init(
+            publicDir: config.publicDir,
+            chunkSize: config.get("file.chunkSize")
+        )
     }
 }

--- a/Tests/VaporTests/DropletTests.swift
+++ b/Tests/VaporTests/DropletTests.swift
@@ -196,6 +196,7 @@ class DropletTests: XCTestCase {
                 }
             } catch {
                 XCTFail("\(error)")
+                group.leave()
             }
         }
         group.wait()

--- a/Tests/VaporTests/FileMiddlewareTests.swift
+++ b/Tests/VaporTests/FileMiddlewareTests.swift
@@ -26,7 +26,10 @@ class FileMiddlewareTests: XCTestCase {
         // First make sure it returns data with 200
         let response = try drop.respond(to: Request(method: .get, path: file))
         XCTAssertEqual(response.status, .ok, "Status code is not OK ( 200 ) for existing file.")
-        XCTAssertTrue(response.body.bytes!.count > 0, "File content body IS NOT provided for existing file.")
+        guard case .chunked = response.body else {
+            XCTFail("Not chunked response")
+            return
+        }
 
         if let ETag = response.headers["ETag"] {
             headers["If-None-Match"] = ETag

--- a/Tests/VaporTests/HashTests.swift
+++ b/Tests/VaporTests/HashTests.swift
@@ -60,15 +60,15 @@ class HashTests: XCTestCase {
 
         let hash: HashProtocol = BCryptHasher(cost: workFactor)
 
-        let digest1 = try hash.make(password).makeString()
-        let digest2 = try hash.make(password).makeString()
+        let digest1 = try! hash.make(password).makeString()
+        let digest2 = try! hash.make(password).makeString()
         let digest3 = "$2a$05$LCgyKIaj2Mv1uDZZB6DMT.zruhilEevoFkyToS8CIwpSecp/2dg3u" // foo from online
 
         XCTAssert(digest1.contains("$0\(workFactor)$"))
         XCTAssert(digest1 != digest2)
-        XCTAssert(try hash.check(password, matchesHash: digest1))
-        XCTAssert(try hash.check(password, matchesHash: digest2))
-        XCTAssert(try hash.check(password, matchesHash: digest3))
+        XCTAssert(try! hash.check(password, matchesHash: digest1))
+        XCTAssert(try! hash.check(password, matchesHash: digest2))
+        XCTAssert(try! hash.check(password, matchesHash: digest3))
     }
 
     func testDropletBCrypt() throws {


### PR DESCRIPTION
The current implementation of FileMiddleware loads the complete file into memory and writes it to the stream in one step. For large files (e.g. uploaded photos), this means that if the clients request a few in parallel, the server can quickly run out of memory (and start swapping or worse).

Vapor currently doesn't expose a lower level interface where the middleware could write to the stream block by block, so this PR uses the chunked transfer encoding as a workaround, and reads/writes the file in 32KiB blocks.