### PR TITLE
fix cookie name

### DIFF
--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -14,6 +14,11 @@ public final class SessionsMiddleware: Middleware {
     
     public typealias CookieFactory = (_ request: Request) throws -> Cookie
 
+    /// Creates a new SessionsMiddleware.
+    /// Note: The `name` and `value` properties of cookies
+    /// created by the optional `cookieFactory` will be overwritten.
+    /// To change the cookie's name, you must set the `cookieName` option
+    /// in this init method. The cookie's value will always be the session id.
     public init(
         _ sessions: SessionsProtocol,
         cookieName: String = "vapor-session",

--- a/Sources/Sessions/SessionsMiddleware.swift
+++ b/Sources/Sessions/SessionsMiddleware.swift
@@ -22,7 +22,6 @@ public final class SessionsMiddleware: Middleware {
         self.sessions = sessions
         self.cookieName = cookieName
         self.cookieFactory = cookieFactory ?? { req in
-            
             return Cookie(
                 name: cookieName,
                 value: "",
@@ -48,6 +47,10 @@ public final class SessionsMiddleware: Middleware {
         let response = try chain.respond(to: request)
         
         var cookie = try cookieFactory(request)
+        if cookie.name != cookieName {
+            // FIXME: future version of API should disallow this
+            cookie.name = cookieName
+        }
         cookie.value = session.identifier
 
         if session.shouldDestroy {


### PR DESCRIPTION
- Fixes https://github.com/vapor/vapor/issues/1026
- Simply overwrites the cookie name similar to how cookie value is overwritten. 