### PR TITLE
Fix FileMiddleware serving 0 byte responses

### DIFF
--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -61,18 +61,19 @@ public final class FileMiddleware: Middleware {
             guard let file = fopen(filePath, "r") else {
                 throw Abort.notFound
             }
-            defer {
-                fclose(file)
-            }
 
             // make copy of size for closure
             let chunkSize = self.chunkSize
 
             // return chunked response
             return Response(status: .ok, headers: headers, chunked: { stream in
-                var buffer = Array(repeating: 0, count: chunkSize)
+                defer {
+                    fclose(file)
+                }
 
+                var buffer = Array(repeating: 0, count: chunkSize)
                 var bytesRead: size_t = 0
+
                 repeat {
                     bytesRead = fread(&buffer, 1, chunkSize, file)
                     if bytesRead > 0 {

--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -56,7 +56,7 @@ public final class FileMiddleware: Middleware {
                 headers["Content-Type"] = type
             }
 
-            // Try to open the file for reading.
+            // Try to open the file for reading, keeping it open until the chunking finishes.
             // This is the last chance to report a Not Found error to the client.
             guard let file = fopen(filePath, "r") else {
                 throw Abort.notFound
@@ -67,6 +67,8 @@ public final class FileMiddleware: Middleware {
 
             // return chunked response
             return Response(status: .ok, headers: headers, chunked: { stream in
+                // the deferred fclose call must stay inside the chunking closure,
+                // so the file does not get prematurely closed.
                 defer {
                     fclose(file)
                 }


### PR DESCRIPTION
In the current state, the final version of FileMiddleware is completely broken, always serving 0 length files, as the file is closed before the first read operation.

Having the `defer { fclose(...) }` block inside the Response closure was not a mistake in my original PR. This PR moves it back where it belongs.