### PR TITLE
Added assertBody(equals: String...)

### DIFF
--- a/Sources/Testing/Response.swift
+++ b/Sources/Testing/Response.swift
@@ -32,16 +32,16 @@ extension Response {
     /// a desired string.
     @discardableResult
     public func assertBody(
-        equals desired: String,
+        equals expectation: String,
         _ message: String? = nil,
         file: StaticString = #file,
         line: UInt = #line
     ) throws -> Response {
         let body = try testBody(file: file, line: line)
         
-        if body.makeString() != desired {
+        if body.makeString() != expectation {
             onFail(
-                message ?? "Body assertion failed. '\(body.makeString())' does not equal '\(desired)'",
+                message ?? "Body assertion failed. '\(body.makeString())' does not equal '\(expectation)'",
                 file,
                 line
             )

--- a/Sources/Testing/Response.swift
+++ b/Sources/Testing/Response.swift
@@ -28,6 +28,27 @@ extension Response {
         return self
     }
     
+    /// Asserts the response body equals
+    /// a desired string.
+    @discardableResult
+    public func assertBody(
+        equals desired: String,
+        _ message: String? = nil,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> Response {
+        let body = try testBody(file: file, line: line)
+        
+        if body.makeString() != desired {
+            onFail(
+                message ?? "Body assertion failed. '\(body.makeString())' does not equal '\(desired)'",
+                file,
+                line
+            )
+        }
+        return self
+    }
+    
     /// Asserts the response body contains a
     /// desired byte array.
     @discardableResult


### PR DESCRIPTION
I added this because the only `assetBody` method was just to test if the body contained something. This makes it easy to check if the body is a specific string value.

I apologize this was forked off of my brach for this PR #1063, if necessary I can separate this change out, but it sounds like that PR will be accepted so if good this could be accepted right after.