### PR TITLE
Suppress log warning in test environment

### DIFF
--- a/Sources/Vapor/Cipher/Config+Cipher.swift
+++ b/Sources/Vapor/Cipher/Config+Cipher.swift
@@ -16,11 +16,13 @@ extension Config {
         ) { config in
             let log = try config.resolveLog()
 
-            let message = "The default cipher should be replaced before using in production."
-            if config.environment == .production {
-                log.error(message)
-            } else {
-                log.warning(message)
+            if config.environment != .test {
+                let message = "The default cipher should be replaced before using in production."
+                if config.environment == .production {
+                    log.error(message)
+                } else {
+                    log.warning(message)
+                }
             }
 
             return try CryptoCipher(

--- a/Sources/Vapor/Hash/Config+Hash.swift
+++ b/Sources/Vapor/Hash/Config+Hash.swift
@@ -16,12 +16,16 @@ extension Config {
         ) { config in
             let log = try config.resolveLog()
 
-            let message = "The default hash should be replaced before using in production."
-            if config.environment == .production {
-                log.error(message)
-            } else {
-                log.warning(message)
+
+            if config.environment != .test {
+                let message = "The default hash should be replaced before using in production."
+                if config.environment == .production {
+                    log.error(message)
+                } else {
+                    log.warning(message)
+                }
             }
+
 
             return CryptoHasher(hash: .sha1, encoding: .hex)
         }


### PR DESCRIPTION
Trivial PR - suppress log warnings from `Sources/Vapor/Cipher/Config+Cipher.swift` and `Sources/Vapor/Hash/Config+Hash.swift` in test environment. Avoiding noisy output in CI/local testing. That's make sense when testing providers with many cycles of `Droplet` initialization.