### PR TITLE
Fix Int.random on Linux

### DIFF
--- a/Sources/Vapor/Hash/Int+Random.swift
+++ b/Sources/Vapor/Hash/Int+Random.swift
@@ -1,11 +1,20 @@
+import Foundation
 import libc
 
 extension Int {
     /// Generates a random number between (and inclusive of)
-    /// the given minimum and maxiumum.
+    /// the given minimum and maximum.
+    static private var randomInitialized: Bool = false
+
     public static func random(min: Int, max: Int) -> Int {
         let top = max - min + 1
         #if os(Linux)
+            if !Int.randomInitialized {
+                let current = Date().timeIntervalSinceReferenceDate
+                let salt = current.truncatingRemainder(dividingBy: 1) * 100000000
+                libc.srand(UInt32(current + salt))
+                Int.randomInitialized = true
+            }
             return Int(libc.random() % top) + min
         #else
             return Int(arc4random_uniform(UInt32(top))) + min

--- a/Sources/Vapor/Hash/Int+Random.swift
+++ b/Sources/Vapor/Hash/Int+Random.swift
@@ -4,6 +4,7 @@ import libc
 extension Int {
     /// Generates a random number between (and inclusive of)
     /// the given minimum and maximum.
+    #if os(Linux)
     static private var randomInitialized: Bool = {
         /// This stylized initializer is used to work around dispatch_once
         /// not existing and still guarantee thread safety
@@ -12,6 +13,7 @@ extension Int {
         libc.srand(UInt32(current + salt))
         return true
     }()
+    #endif
 
     public static func random(min: Int, max: Int) -> Int {
         let top = max - min + 1


### PR DESCRIPTION
Important, on Linux `libc.random`:
> By default, this function always generates the same sequence of numbers each time you run the program. (This is usually desirable when debugging, or when comparing two different runs.) If you need to produce a different sequence on every run, you must seed rand by calling srand (see section srand) before the first call to rand, and make sure to use a different argument to srand each time.

And we should seed rand before.

The same issue in `Random` module: `Sources/Random/OSRandom.swift`.

Review, merge and modify `Random` module too :)