### PR TITLE
add file and line info to abort error

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -44,6 +44,7 @@ public struct Abort: AbortError, Debuggable {
     public let column: Int
     
     /// The function in which the error was thrown
+    /// TODO: waiting on https://bugs.swift.org/browse/SR-5380
     public let function: String
 
     public init(
@@ -60,6 +61,7 @@ public struct Abort: AbortError, Debuggable {
         file: String = #file,
         line: Int = #line,
         column: Int = #column,
+        /// See TODO in property decl
         function: String = #function
     ) {
         self.status = status
@@ -73,6 +75,8 @@ public struct Abort: AbortError, Debuggable {
         self.gitHubIssues = gitHubIssues ?? []
         self.file = file
         self.line = line
+        self.column = column
+        self.function = function
     }
 
     // most common

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -39,6 +39,12 @@ public struct Abort: AbortError, Debuggable {
     
     /// Line number at which the error was thrown
     public let line: Int
+    
+    /// The column at which the error was thrown
+    public let column: Int
+    
+    /// The function in which the error was thrown
+    public let function: String
 
     public init(
         _ status: Status,
@@ -52,7 +58,9 @@ public struct Abort: AbortError, Debuggable {
         stackOverflowQuestions: [String]? = nil,
         gitHubIssues: [String]? = nil,
         file: String = #file,
-        line: Int = #line
+        line: Int = #line,
+        column: Int = #column,
+        function: String = #function
     ) {
         self.status = status
         self.metadata = metadata

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -33,7 +33,12 @@ public struct Abort: AbortError, Debuggable {
 
     /// See Debuggable.gitHubIssues
     public let gitHubIssues: [String]
-
+    
+    /// File in which the error was thrown
+    public let file: String
+    
+    /// Line number at which the error was thrown
+    public let line: Int
 
     public init(
         _ status: Status,
@@ -45,7 +50,9 @@ public struct Abort: AbortError, Debuggable {
         suggestedFixes: [String]? = nil,
         documentationLinks: [String]? = nil,
         stackOverflowQuestions: [String]? = nil,
-        gitHubIssues: [String]? = nil
+        gitHubIssues: [String]? = nil,
+        file: String = #file,
+        line: Int = #line
     ) {
         self.status = status
         self.metadata = metadata
@@ -56,6 +63,8 @@ public struct Abort: AbortError, Debuggable {
         self.documentationLinks = documentationLinks ?? []
         self.stackOverflowQuestions = stackOverflowQuestions ?? []
         self.gitHubIssues = gitHubIssues ?? []
+        self.file = file
+        self.line = line
     }
 
     // most common

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -45,7 +45,7 @@ public struct Abort: AbortError, Debuggable {
     
     /// The function in which the error was thrown
     /// TODO: waiting on https://bugs.swift.org/browse/SR-5380
-    public let function: String
+    /// public let function: String
 
     public init(
         _ status: Status,
@@ -60,9 +60,9 @@ public struct Abort: AbortError, Debuggable {
         gitHubIssues: [String]? = nil,
         file: String = #file,
         line: Int = #line,
-        column: Int = #column,
+        column: Int = #column
         /// See TODO in property decl
-        function: String = #function
+        /// function: String = #function
     ) {
         self.status = status
         self.metadata = metadata
@@ -76,7 +76,8 @@ public struct Abort: AbortError, Debuggable {
         self.file = file
         self.line = line
         self.column = column
-        self.function = function
+        /// See TODO in property decl
+        /// self.function = function
     }
 
     // most common


### PR DESCRIPTION
Adds file information to the abort error. This will make it easier to track down where the error is being thrown.

- [ ] discuss whether adding this to `Debuggable` would be beneficial