### PR TITLE
Fix reason message when file was not found in FileMiddleware

### DIFF
--- a/Sources/Vapor/File/FileMiddleware.swift
+++ b/Sources/Vapor/File/FileMiddleware.swift
@@ -28,7 +28,13 @@ public final class FileMiddleware: Middleware {
             }
             let filePath = publicDir + path
             let ifNoneMatch = request.headers["If-None-Match"]
-            return try Response(filePath: filePath, ifNoneMatch: ifNoneMatch, chunkSize: chunkSize)
+
+            do {
+                return try Response(filePath: filePath, ifNoneMatch: ifNoneMatch, chunkSize: chunkSize)
+            } catch let newError as AbortError where newError.status == .notFound {
+                // throw original error, so custom reason is passed to client
+                throw error
+            }
         }
     }
 }

--- a/Tests/VaporTests/FileMiddlewareTests.swift
+++ b/Tests/VaporTests/FileMiddlewareTests.swift
@@ -57,6 +57,23 @@ class FileMiddlewareTests: XCTestCase {
         XCTAssertEqual(response.status, .notFound, "Status code is not 404 for nonexisting file.")
     }
 
+    func testCorrectMessageForNotFoundFromOriginalResponse() throws {
+        let path = "/existing_path"
+        let drop = try Droplet()
+        drop.get(path) { _ in
+            throw Abort(.notFound, reason: "Some important message")
+        }
+
+        let response = try drop.respond(to: Request(method: .get, path: path))
+
+        guard let json = response.json else {
+            XCTFail("response is not json")
+            return
+        }
+
+        XCTAssertEqual(try json.get("reason") as String, "Some important message")
+    }
+
     func testThrowsOnRelativePath() throws {
         let file = "/../foo/bar/"
         let drop = try Droplet()


### PR DESCRIPTION
Hi, I've found bug when custom route throws AbortError with .notFound status, FileMiddleware does not pass the reason message and returns own one. This PR is fixing this bug. Also, there is test for that case.