### PR TITLE
Fixed request query accessor storing bytes instead of node in Request

### DIFF
--- a/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
+++ b/Sources/Vapor/FormURLEncoded/Request+FormURLEncoded.swift
@@ -53,7 +53,7 @@ extension Request {
         set(data) {
             if let data = data, let query = try? data.formURLEncoded(), !query.isEmpty {
                 uri.query = query.makeString()
-                storage["query"] = query
+                storage["query"] = data
             } else {
                 storage["query"] = nil
                 uri.query = nil

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -7,6 +7,7 @@ class QueryTests: XCTestCase {
         ("testPercentEncodedValues", testPercentEncodedValues),
         ("testQueryWithoutParameter", testQueryWithoutParameter),
         ("testClientQueryNotNill", testClientQueryNotNill),
+        ("testQuerySetAndGet", testQuerySetAndGet),
     ]
     
     func testPercentEncodedValues() {
@@ -34,5 +35,14 @@ class QueryTests: XCTestCase {
         let drop = try Droplet()
         let req = try drop.client.makeRequest(.get, "https://api.spotify.com/v1/search?type=artist&q=test")
         XCTAssertNotNil(req.query)
+    }
+    
+    func testQuerySetAndGet() throws {
+        let drop = try Droplet()
+        let req = try drop.client.makeRequest(.get, "https://google.com")
+        req.query = Node(["q": "swift vapor"])
+        let query = req.query
+        XCTAssertNotNil(query)
+        XCTAssertEqual(query?["q"]?.string, "swift vapor")
     }
 }


### PR DESCRIPTION
This was causing the query getter always returning nil if the query has been set with a node.