### PR TITLE
temporarily disable proxy tests

### DIFF
--- a/Tests/VaporTests/DropletTests.swift
+++ b/Tests/VaporTests/DropletTests.swift
@@ -125,6 +125,8 @@ class DropletTests: XCTestCase {
     }
     
     func testProxy() throws {
+        // FIXME: find a reliable proxy server
+        /*
         let proxy = Proxy(
             hostname: "52.213.26.87",
             port: 8888,
@@ -140,9 +142,12 @@ class DropletTests: XCTestCase {
         let req = Request(method: .get, path: "/")
         let res = try client.respond(to: req)
         try XCTAssertEqual(res.bodyString(), "It works!!!\n")
+        */
     }
     
     func testDropletProxy() throws {
+        // FIXME: find a reliable proxy server
+        /*
         var config = Config([:])
         try config.set("droplet.client", "engine")
         try config.set("client.proxy.hostname", "52.213.26.87")
@@ -153,6 +158,7 @@ class DropletTests: XCTestCase {
         
         let res = try drop.client.get("http://34.248.148.23")
         try XCTAssertEqual(res.bodyString(), "It works!!!\n")
+        */
     }
     
     func testWebsockets() throws {


### PR DESCRIPTION
proxy server is no logner available, causing all PRs to fail. 