### PR TITLE
Allow empty strings as fallback in configuration

### DIFF
--- a/Sources/Configs/Env/String+Env.swift
+++ b/Sources/Configs/Env/String+Env.swift
@@ -12,7 +12,7 @@ extension String {
         guard hasPrefix("$") else { return self }
         let components = self.makeBytes()
             .dropFirst()
-            .split(separator: .colon, maxSplits: 1, omittingEmptySubsequences: true)
+            .split(separator: .colon, maxSplits: 1, omittingEmptySubsequences: false)
             .map({ $0.makeString() })
 
         return components.first.flatMap(Env.get)

--- a/Tests/ConfigsTests/EnvTests.swift
+++ b/Tests/ConfigsTests/EnvTests.swift
@@ -7,6 +7,7 @@ class EnvTests: XCTestCase {
         ("testEnv", testEnv),
         ("testBasicEnv", testBasicEnv),
         ("testDefaults", testDefaults),
+        ("testEmptyDefault", testEmptyDefault),
         ("testNoEnv", testNoEnv),
         ("testEmpty", testEmpty),
         ("testEnvArray", testEnvArray),
@@ -54,6 +55,17 @@ class EnvTests: XCTestCase {
         ]
         let expectation: Node = [
             "port": "8080"
+        ]
+
+        XCTAssertEqual(node.hydratedEnv(), expectation)
+    }
+
+    func testEmptyDefault() {
+        let node: Node = [
+            "port": "$NO_EXIST:"
+        ]
+        let expectation: Node = [
+            "port": ""
         ]
 
         XCTAssertEqual(node.hydratedEnv(), expectation)


### PR DESCRIPTION
The proposed change allows falling back to empty strings in JSON configuration files.

Consider the following config snippet (eg. from `mysql.json`) that specifies:
`"password": "$DATABASE_PASSWORD:"`
The current fallback behavior is that password is not set at all when the environment variable is not set. This is the same as omitting the ":".

The proposed change would allow it to fall back to empty string (which happens to be the default root mysql password). The old behavior can still be achieved by omitting the ":".