### PR TITLE
Add Ubuntu 17.04 (zesty) support

### DIFF
--- a/Utilities/apt.sh
+++ b/Utilities/apt.sh
@@ -1,9 +1,9 @@
 function add_vapor_apt() {
     eval "$(cat /etc/lsb-release)"
 
-    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" ]];
+    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" && "$DISTRIB_CODENAME" != "zesty"]];
     then
-        echo "Only Ubuntu 14.04, 16.04, and 16.10 are supported."
+        echo "Only Ubuntu 14.04, 16.04, 16.10, and 17.04 are supported."
         echo "You are running $DISTRIB_RELEASE ($DISTRIB_CODENAME) [`uname`]"
         return 1;
     fi


### PR DESCRIPTION
According to Vapor APT repository (https://repo.vapor.codes/), it looks like Ubuntu 17.04 is supported but this script file rejects it. If Ubuntu 17.04 is still not officially supported (or there are other reasons), please feel free to reject and close this pull request.