### PR TITLE
Added support for pipelining

### DIFF
--- a/Sources/Redis/Error.swift
+++ b/Sources/Redis/Error.swift
@@ -17,6 +17,8 @@ public struct RedisError: Debuggable, Traceable, Swift.Error, Encodable {
         
         /// A server-side error
         case serverSide(String)
+        
+        case pipelineCommandsRequired
     }
     
     /// This error's kind
@@ -35,6 +37,8 @@ public struct RedisError: Debuggable, Traceable, Swift.Error, Encodable {
             return "The server response was successfully parsed but did not match driver expectations. The result was: \(result)"
         case .serverSide(let reason):
             return reason
+        case .pipelineCommandsRequired:
+            return "Pipeline cannot be executed until commands are enqueued"
         }
     }
     
@@ -51,6 +55,8 @@ public struct RedisError: Debuggable, Traceable, Swift.Error, Encodable {
             return "Unexpected result: (\(result))"
         case .serverSide(let reason):
             return "Server error: \(reason)"
+        case .pipelineCommandsRequired:
+            return "pipelineCommandsRequired"
         }
     }
     

--- a/Sources/Redis/Pipeline.swift
+++ b/Sources/Redis/Pipeline.swift
@@ -1,0 +1,52 @@
+import Async
+import Bits
+import Foundation
+
+/// A pipeline which wraps a redis client
+public final class Pipeline<DuplexByteStream: Async.Stream> where DuplexByteStream.Input == ByteBuffer, DuplexByteStream.Output == ByteBuffer, DuplexByteStream: ClosableStream {
+    
+    public let client: RedisClient<DuplexByteStream>
+    private var commands = [RedisData]()
+    
+    
+    init(client: RedisClient<DuplexByteStream>) {
+        self.client = client
+    }
+    
+    /// Enqueues a command to be executed.  The commands will not be executed until execute() is
+    /// is called
+    @discardableResult
+    public func enqueue(command: String, arguments: [RedisData]? = nil) throws -> Pipeline<DuplexByteStream> {
+        if client.isSubscribed {
+            throw RedisError(.cannotReuseSubscribedClients)
+        }
+        
+        commands.append(RedisData.array([.bulkString(command)] + (arguments ?? [])))
+        return self
+    }
+    
+    /// Executes a series of commands and returns a future for the responses
+    @discardableResult
+    public func execute() throws -> Future<[RedisData]> {
+        defer {
+            commands = []
+        }
+        
+        guard commands.count > 0 else {
+            return Future(error: RedisError(.pipelineCommandsRequired))
+        }
+        
+        let promises = commands.map { _ in
+            Promise<RedisData>()
+        }
+        
+        client.dataParser.responseQueue.append(contentsOf: promises)
+        
+        commands.forEach(client.dataSerializer.inputStream)
+        
+        return promises
+            .map { $0.future }
+            .flatten()
+    }
+    
+}

--- a/Sources/Redis/Pipeline.swift
+++ b/Sources/Redis/Pipeline.swift
@@ -1,52 +1,23 @@
 import Async
-import Bits
-import Foundation
 
-/// A pipeline which wraps a redis client
-public final class Pipeline<DuplexByteStream: Async.Stream> where DuplexByteStream.Input == ByteBuffer, DuplexByteStream.Output == ByteBuffer, DuplexByteStream: ClosableStream {
-    
-    public let client: RedisClient<DuplexByteStream>
-    private var commands = [RedisData]()
-    
-    
-    init(client: RedisClient<DuplexByteStream>) {
-        self.client = client
-    }
-    
-    /// Enqueues a command to be executed.  The commands will not be executed until execute() is
-    /// is called
-    @discardableResult
-    public func enqueue(command: String, arguments: [RedisData]? = nil) throws -> Pipeline<DuplexByteStream> {
-        if client.isSubscribed {
-            throw RedisError(.cannotReuseSubscribedClients)
+extension RedisClient {
+    /// Accepts an array of commands, to be sent in one request.
+    public func pipeline(_ commands: () -> ([RedisData])) -> Future<[RedisData]> {
+        if isSubscribed {
+            return Future(error: RedisError(.cannotReuseSubscribedClients))
         }
         
-        commands.append(RedisData.array([.bulkString(command)] + (arguments ?? [])))
-        return self
-    }
-    
-    /// Executes a series of commands and returns a future for the responses
-    @discardableResult
-    public func execute() throws -> Future<[RedisData]> {
-        defer {
-            commands = []
-        }
-        
-        guard commands.count > 0 else {
-            return Future(error: RedisError(.pipelineCommandsRequired))
-        }
+        let commands = commands()
+        dataSerializer.inputStream(commands)
         
         let promises = commands.map { _ in
             Promise<RedisData>()
         }
         
-        client.dataParser.responseQueue.append(contentsOf: promises)
-        
-        commands.forEach(client.dataSerializer.inputStream)
+        dataParser.responseQueue.append(contentsOf: promises)
         
         return promises
             .map { $0.future }
             .flatten()
     }
-    
 }

--- a/Sources/Redis/Pipeline.swift
+++ b/Sources/Redis/Pipeline.swift
@@ -1,23 +1,53 @@
 import Async
+import Bits
+import Foundation
 
-extension RedisClient {
-    /// Accepts an array of commands, to be sent in one request.
-    public func pipeline(_ commands: () -> ([RedisData])) -> Future<[RedisData]> {
-        if isSubscribed {
-            return Future(error: RedisError(.cannotReuseSubscribedClients))
+final class Pipeline<DuplexByteStream: Async.Stream> where DuplexByteStream.Input == ByteBuffer, DuplexByteStream.Output == ByteBuffer, DuplexByteStream: ClosableStream {
+    
+    let client: RedisClient<DuplexByteStream>
+    private var commands = [RedisData]()
+    
+    init(_ client:  RedisClient<DuplexByteStream>) {
+        self.client = client
+    }
+    
+    /// Enqueues a commands.
+    @discardableResult
+    public func enqueue(command: String, arguments: [RedisData]? = nil) throws -> Pipeline<DuplexByteStream> {
+        if client.isSubscribed {
+            throw RedisError(.cannotReuseSubscribedClients)
         }
         
-        let commands = commands()
-        dataSerializer.inputStream(commands)
+        commands.append(RedisData.array([.bulkString(command)] + (arguments ?? [])))
+        return self
+    }
+    
+    /// Executes a series of commands and returns a future for the responses
+    @discardableResult
+    public func execute() throws -> Future<[RedisData]> {
+        defer {
+            commands = []
+        }
+        
+        if client.isSubscribed {
+             return Future(error: RedisError(.cannotReuseSubscribedClients))
+        }
+        
+        guard commands.count > 0 else {
+            return Future(error: RedisError(.pipelineCommandsRequired))
+        }
         
         let promises = commands.map { _ in
             Promise<RedisData>()
         }
         
-        dataParser.responseQueue.append(contentsOf: promises)
+        client.dataParser.responseQueue.append(contentsOf: promises)
+        
+        client.dataSerializer.inputStream(commands)
         
         return promises
             .map { $0.future }
             .flatten()
     }
+    
 }

--- a/Sources/Redis/Redis.swift
+++ b/Sources/Redis/Redis.swift
@@ -51,6 +51,11 @@ public final class RedisClient<DuplexByteStream: Async.Stream> where DuplexByteS
         return promise.future
     }
     
+    /// Creates a pipeline and returns it.
+    public func makePipeline() -> Pipeline<DuplexByteStream> {
+        return Pipeline(client: self)
+    }
+    
     /// Creates a new Redis client on the provided connection
     public init(socket: DuplexByteStream) {
         self.socket = socket

--- a/Sources/Redis/Redis.swift
+++ b/Sources/Redis/Redis.swift
@@ -50,6 +50,12 @@ public final class RedisClient<DuplexByteStream: Async.Stream> where DuplexByteS
         
         return promise.future
     }
+    
+    /// Creates a pipeline and returns it.
+    func makePipeline() -> Pipeline<DuplexByteStream> {
+        return Pipeline(self)
+    }
+    
     /// Creates a new Redis client on the provided connection
     public init(socket: DuplexByteStream) {
         self.socket = socket

--- a/Sources/Redis/Redis.swift
+++ b/Sources/Redis/Redis.swift
@@ -50,12 +50,6 @@ public final class RedisClient<DuplexByteStream: Async.Stream> where DuplexByteS
         
         return promise.future
     }
-    
-    /// Creates a pipeline and returns it.
-    public func makePipeline() -> Pipeline<DuplexByteStream> {
-        return Pipeline(client: self)
-    }
-    
     /// Creates a new Redis client on the provided connection
     public init(socket: DuplexByteStream) {
         self.socket = socket

--- a/Sources/Redis/Serializer.swift
+++ b/Sources/Redis/Serializer.swift
@@ -30,6 +30,23 @@ final class DataSerializer: Async.Stream {
     }
 }
 
+extension DataSerializer {
+    
+    /// Used for pipelining commands
+    /// Concatenates commands to RedisData for the outputStream
+    func inputStream(_ input: [RedisData]) {
+        var buffer = Data()
+        for item in input {
+            buffer.append(contentsOf: item.serialize())
+        }
+        buffer.withUnsafeBytes { (pointer: BytesPointer) in
+            let buffer = ByteBuffer(start: pointer, count: buffer.count)
+            outputStream?(buffer)
+        }
+    }
+    
+}
+
 /// Static "fast" route for serializing `null` values
 fileprivate let nullData = Data("$-1\r\n".utf8)
 

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -62,16 +62,29 @@ class RedisTests: XCTestCase {
     func testPipeline() throws {
         let connection = try makeClient()
         _ = try connection.delete(keys: ["*"]).blockingAwait(timeout: .seconds(1))
+        let result =  try connection.pipeline {
+            [
+                .array([.bulkString("SET"), .bulkString("hello"), .bulkString("world")]),
+                .array([.bulkString("SET"), .bulkString("hello1"), .bulkString("world")])
+            ]
+            
+            }.blockingAwait(timeout: .seconds(1))
         
-        let pipeline = connection.makePipeline()
-        let result = try pipeline
-            .enqueue(command: "SET", arguments: [RedisData(bulk: "hello"), "world"])
-            .enqueue(command: "SET", arguments: [RedisData(bulk: "hello2"), "world"])
-            .execute()
-            .blockingAwait(timeout: .seconds(1))
         XCTAssertEqual(result[0].string, "+OK\r")
         XCTAssertEqual(result[1].string, "+OK\r")
-        _ = try connection.delete(keys: ["*"]).blockingAwait(timeout: .seconds(1))
         
+        let deleted = try connection.pipeline {
+            [
+                .array([.bulkString("DEL"), .bulkString("hello")]),
+                .array([.bulkString("DEL"), .bulkString("hello1")])
+            ]
+            
+            }.blockingAwait(timeout: .seconds(1))
+        
+        XCTAssertEqual(deleted[0].int, 1)
+        XCTAssertEqual(deleted[1].int, 1)
+
     }
+    
+    
 }


### PR DESCRIPTION
This PR adds support for Redis pipelining.  It concatenates a series of commands to be executed in bulk in order to save round trip time.  

e.g
```swift
let result = try connection.pipeline {
        [
           .array([.bulkString("SET"), .bulkString("hello"), .bulkString("world")]),
           .array([.bulkString("SET"), .bulkString("hello1"), .bulkString("world")])
        ]
 }.blockingAwait(timeout: .seconds(1))
```