### PR TITLE
Add convenience methods for using Codable with Vapor 2

### DIFF
--- a/Sources/Vapor/JSON/HTTP/Message+Codable.swift
+++ b/Sources/Vapor/JSON/HTTP/Message+Codable.swift
@@ -1,0 +1,20 @@
+import HTTP
+import Foundation
+
+#if swift(>=4.0)
+public extension HTTP.Message {
+    public func encodeJSONBody<T: Encodable>(_ body: T, using encoder: JSONEncoder = JSONEncoder()) throws {
+        let data = try encoder.encode(body)
+
+        // Clear out fields set by Message+JSON extensions
+        json = nil
+
+        self.body = Body.data(data.makeBytes())
+        headers[.contentType] = "application/json; charset=utf-8"
+    }
+
+    public func decodeJSONBody<T: Decodable>(using decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        return try decoder.decode(T.self, from: Data(bytes: body.bytes ?? []))
+    }
+}
+#endif

--- a/Sources/Vapor/JSON/HTTP/Response+Codable.swift
+++ b/Sources/Vapor/JSON/HTTP/Response+Codable.swift
@@ -1,0 +1,19 @@
+import Foundation
+import HTTP
+
+#if swift(>=4.0)
+public extension Encodable {
+    public func makeResponse(using encoder: JSONEncoder = JSONEncoder(),
+                      status: Status = .ok,
+                      headers: [HeaderKey: String] = [:]) throws -> Response {
+        let response = Response(status: status)
+        try response.encodeJSONBody(self, using: encoder)
+
+        headers.forEach { (key, value) in
+            response.headers[key] = value
+        }
+
+        return response
+    }
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -25,6 +25,7 @@ XCTMain([
     // Vapor
     testCase(ConfigIntegrationTests.allTests),
     testCase(VaporTests.ConfigTests.allTests),
+    testCase(CodableTests.allTests),
     testCase(ConsoleTests.allTests),
     testCase(ContentTests.allTests),
     testCase(CORSMiddlewareTests.allTests),

--- a/Tests/VaporTests/CodableTests.swift
+++ b/Tests/VaporTests/CodableTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+import Vapor
+import Foundation
+import HTTP
+
+class CodableTests: XCTestCase {
+    #if swift(>=4.0)
+    private class TestModel: Codable {
+        let foo: String
+        let baz: Int
+        let opt: String?
+        let bomb: Int64?
+
+        init(foo: String, baz: Int, opt: String? = nil, bomb: Int64? = nil) {
+            self.foo = foo
+            self.baz = baz
+            self.opt = opt
+            self.bomb = bomb
+        }
+    }
+
+    func testDecodeJSONBodyRaw() throws {
+        let request = Request(method: .post, path: "/")
+        let rawJSON = "{ \"foo\": \"qux\", \"baz\": 4237846, \"opt\": \"test\" }".makeBytes()
+
+        request.body = Body.data(rawJSON)
+        let model: TestModel = try request.decodeJSONBody()
+        XCTAssertEqual(model.foo, "qux")
+        XCTAssertEqual(model.baz, 4237846)
+        XCTAssertEqual(model.opt, "test")
+    }
+
+    func testDecodeJSONBodyInterop() throws {
+        let request = Request(method: .post, path: "/")
+        request.json = ["foo": "bar", "baz": 123]
+
+        let model: TestModel = try request.decodeJSONBody()
+        XCTAssertEqual(model.foo, "bar")
+        XCTAssertEqual(model.baz, 123)
+        XCTAssertNil(model.opt)
+    }
+
+    func testDecodeFailsWithMissingField() throws {
+        let request = Request(method: .post, path: "/")
+        let rawJSON = "{ \"foo\": \"qux\", \"opt\": \"test\" }".makeBytes()
+
+        request.body = Body.data(rawJSON)
+
+        do {
+            let _: TestModel = try request.decodeJSONBody()
+            XCTFail("Parsing should have failed as 'baz' was not set in JSON and is not optional")
+        } catch {
+        }
+    }
+
+    func testInt64OverflowThrowsNotCrashes() throws {
+        let request = Request(method: .post, path: "/")
+        let rawJSON = """
+            {
+                "foo": "abc",
+                "baz": 123,
+                "bomb": 10000000000000000000000000000000000000
+            }
+            """.makeBytes()
+        request.body = Body.data(rawJSON)
+
+        do {
+            let _: TestModel = try request.decodeJSONBody()
+            XCTFail("Parsing should have failed as 'bomb' overflows Int64")
+        } catch {
+        }
+    }
+
+    func testEncodeJSONBodyInterop() throws {
+        let model = TestModel(foo: "bar", baz: 321)
+        let request = Request(method: .post, path: "/")
+        try request.encodeJSONBody(model)
+
+        guard let json = request.json else {
+            XCTFail("Could not parse JSON body set by encodeJSONBody")
+            return
+        }
+
+        XCTAssertEqual("bar", try json.get("foo"))
+        XCTAssertEqual(321, try json.get("baz"))
+        XCTAssertNil(try json.get("opt"))
+    }
+
+    func testMakeResponse() throws {
+        let model = TestModel(foo: "fedcba", baz: 33123, opt: "test", bomb: 123456787654321)
+        let response = try model.makeResponse()
+        XCTAssertEqual(response.status, .ok)
+
+        guard let json = response.json else {
+            XCTFail("Could not parse JSON body set by makeResponse")
+            return
+        }
+
+        XCTAssertEqual("fedcba", try json.get("foo"))
+        XCTAssertEqual(33123, try json.get("baz"))
+        XCTAssertEqual("test", try json.get("opt"))
+        XCTAssertEqual(123456787654321, try json.get("bomb"))
+    }
+
+    static let allTests: [(String, (CodableTests) -> () throws -> ())] = [
+        ("testDecodeJSONBodyRaw", testDecodeJSONBodyRaw),
+        ("testDecodeJSONBodyInterop", testDecodeJSONBodyInterop),
+        ("testDecodeFailsWithMissingField", testDecodeFailsWithMissingField),
+        ("testInt64OverflowThrowsNotCrashes", testInt64OverflowThrowsNotCrashes),
+        ("testEncodeJSONBodyInterop", testEncodeJSONBodyInterop),
+        ("testMakeResponse", testMakeResponse),
+    ]
+    #else
+    static let allTests: [(String, (CodableTests) -> () throws -> ())] = [
+    ]
+    #endif
+}
+

--- a/Tests/VaporTests/CodableTests.swift
+++ b/Tests/VaporTests/CodableTests.swift
@@ -9,13 +9,11 @@ class CodableTests: XCTestCase {
         let foo: String
         let baz: Int
         let opt: String?
-        let bomb: Int64?
 
-        init(foo: String, baz: Int, opt: String? = nil, bomb: Int64? = nil) {
+        init(foo: String, baz: Int, opt: String? = nil) {
             self.foo = foo
             self.baz = baz
             self.opt = opt
-            self.bomb = bomb
         }
     }
 
@@ -53,24 +51,6 @@ class CodableTests: XCTestCase {
         }
     }
 
-    func testInt64OverflowThrowsNotCrashes() throws {
-        let request = Request(method: .post, path: "/")
-        let rawJSON = """
-            {
-                "foo": "abc",
-                "baz": 123,
-                "bomb": 10000000000000000000000000000000000000
-            }
-            """.makeBytes()
-        request.body = Body.data(rawJSON)
-
-        do {
-            let _: TestModel = try request.decodeJSONBody()
-            XCTFail("Parsing should have failed as 'bomb' overflows Int64")
-        } catch {
-        }
-    }
-
     func testEncodeJSONBodyInterop() throws {
         let model = TestModel(foo: "bar", baz: 321)
         let request = Request(method: .post, path: "/")
@@ -87,7 +67,7 @@ class CodableTests: XCTestCase {
     }
 
     func testMakeResponse() throws {
-        let model = TestModel(foo: "fedcba", baz: 33123, opt: "test", bomb: 123456787654321)
+        let model = TestModel(foo: "fedcba", baz: 33123, opt: "test")
         let response = try model.makeResponse()
         XCTAssertEqual(response.status, .ok)
 
@@ -99,14 +79,12 @@ class CodableTests: XCTestCase {
         XCTAssertEqual("fedcba", try json.get("foo"))
         XCTAssertEqual(33123, try json.get("baz"))
         XCTAssertEqual("test", try json.get("opt"))
-        XCTAssertEqual(123456787654321, try json.get("bomb"))
     }
 
     static let allTests: [(String, (CodableTests) -> () throws -> ())] = [
         ("testDecodeJSONBodyRaw", testDecodeJSONBodyRaw),
         ("testDecodeJSONBodyInterop", testDecodeJSONBodyInterop),
         ("testDecodeFailsWithMissingField", testDecodeFailsWithMissingField),
-        ("testInt64OverflowThrowsNotCrashes", testInt64OverflowThrowsNotCrashes),
         ("testEncodeJSONBodyInterop", testEncodeJSONBodyInterop),
         ("testMakeResponse", testMakeResponse),
     ]


### PR DESCRIPTION
Included are three functions that make it easy to replace Node-based JSON processing with Codable. I've been sharing the included functions on Slack through Gist lately, and I think it would make sense to include them in a new minor version.