### PR TITLE
simplify db access

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,8 @@ let package = Package(
         .testTarget(name: "DebuggingTests", dependencies: ["Debugging"]),
 
         // Fluent
-        .target(name: "Fluent", dependencies: ["Async", "Core", "Service"]),
+        // FIXME: FluentRouting and FluentHTTP packages?
+        .target(name: "Fluent", dependencies: ["Async", "Core", "HTTP", "Routing", "Service"]),
         .target(name: "FluentBenchmark", dependencies: ["Fluent"]),
         .target(name: "FluentSQL", dependencies: ["Fluent", "SQL"]),
         .target(name: "FluentSQLite", dependencies: ["Fluent", "FluentSQL", "SQLite"]),

--- a/Sources/Development/Models/Pet+Toy.swift
+++ b/Sources/Development/Models/Pet+Toy.swift
@@ -12,6 +12,7 @@ final class PetToyPivot: ModifiablePivot {
     static let idKey = \PetToyPivot.id
     static let leftIDKey = \PetToyPivot.petID
     static var rightIDKey = \PetToyPivot.toyID
+    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),

--- a/Sources/Development/Models/Pet+Toy.swift
+++ b/Sources/Development/Models/Pet+Toy.swift
@@ -5,14 +5,13 @@ import SQLite
 import FluentSQLite
 
 final class PetToyPivot: ModifiablePivot {
-    typealias Database = SQLiteDatabase
     typealias Left = Pet
     typealias Right = Toy
 
     static let idKey = \PetToyPivot.id
     static let leftIDKey = \PetToyPivot.petID
     static var rightIDKey = \PetToyPivot.toyID
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),

--- a/Sources/Development/Models/Pet.swift
+++ b/Sources/Development/Models/Pet.swift
@@ -3,24 +3,20 @@ import Foundation
 import Vapor
 
 final class Pet: Model {
-
-    typealias Database = SQLiteDatabase
-    typealias ID = UUID
-
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),
         key(\.name): field("name"),
         key(\.ownerID): field("ownerID")
     ]
 
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
     static let idKey = \Pet.id
 
     var id: UUID?
     var name: String
     var ownerID: User.ID
 
-    init(id: ID? = nil, name: String, ownerID: User.ID) {
+    init(id: UUID? = nil, name: String, ownerID: User.ID) {
         self.id = id
         self.name = name
         self.ownerID = ownerID

--- a/Sources/Development/Models/Pet.swift
+++ b/Sources/Development/Models/Pet.swift
@@ -1,11 +1,9 @@
-import Async
-import HTTP
-import Fluent
+import FluentSQLite
 import Foundation
-import Routing
-import SQLite
+import Vapor
 
 final class Pet: Model {
+
     typealias Database = SQLiteDatabase
     typealias ID = UUID
 
@@ -15,13 +13,14 @@ final class Pet: Model {
         key(\.ownerID): field("ownerID")
     ]
 
+    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
     static let idKey = \Pet.id
 
     var id: UUID?
     var name: String
-    var ownerID: UUID
+    var ownerID: User.ID
 
-    init(id: ID? = nil, name: String, ownerID: UUID) {
+    init(id: ID? = nil, name: String, ownerID: User.ID) {
         self.id = id
         self.name = name
         self.ownerID = ownerID
@@ -36,29 +35,7 @@ final class Pet: Model {
     }
 }
 
-// FIXME: find way to include this in fluent
-extension Pet: Parameter {
-    static var uniqueSlug: String {
-        return "pet"
-    }
-
-    static func make(for parameter: String, in req: Request) throws -> Future<Pet> {
-        guard let uuid = UUID(uuidString: parameter) else {
-            throw "not a uuid"
-        }
-
-        return req.database(.beta) { conn in
-            return Pet.find(uuid, on: conn).map { pet in
-                guard let pet = pet else {
-                    throw "no pet w/ that id was found"
-                }
-
-                return pet
-            }
-        }
-    }
-}
-
+extension Pet: Parameter {}
 
 extension Pet: Migration {
     static func prepare(on connection: SQLiteConnection) -> Future<Void> {

--- a/Sources/Development/Models/Toy.swift
+++ b/Sources/Development/Models/Toy.swift
@@ -4,9 +4,7 @@ import Foundation
 import SQLite
 
 final class Toy: Model {
-    typealias Database = SQLiteDatabase
-    typealias ID = UUID
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),

--- a/Sources/Development/Models/Toy.swift
+++ b/Sources/Development/Models/Toy.swift
@@ -6,6 +6,7 @@ import SQLite
 final class Toy: Model {
     typealias Database = SQLiteDatabase
     typealias ID = UUID
+    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),

--- a/Sources/Development/Models/User.swift
+++ b/Sources/Development/Models/User.swift
@@ -15,16 +15,11 @@ final class TestUser: Codable {
 }
 
 extension TestUser: Model {
-    /// See Model.ID
-    typealias ID = UUID
-
     /// Database ID
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     /// See Model.idKey
-    static var idKey: IDKey {
-        return \.id
-    }
+    static var idKey = \TestUser.id
 
     /// See Model.keyFieldMap
     static var keyFieldMap: KeyFieldMap {
@@ -77,23 +72,15 @@ struct TestSiblings: Migration {
 }
 
 final class User: Model, Content {
-    static let defaultMediaType: MediaType = .json
-
-    typealias Database = SQLiteDatabase
-    typealias ID = Int
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
-
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),
         key(\.name): field("name"),
         key(\.age): field("age"),
     ]
+    static var idKey = \User.id
 
-    static var idKey: IDKey {
-        return \.id
-    }
-
-    var id: ID?
+    var id: Int?
     var name: String
     var age: Double
 //    var child: User?

--- a/Sources/Development/Models/User.swift
+++ b/Sources/Development/Models/User.swift
@@ -15,11 +15,11 @@ final class TestUser: Codable {
 }
 
 extension TestUser: Model {
-    /// See Model.Database
-    typealias Database = SQLiteDatabase
-
     /// See Model.ID
     typealias ID = UUID
+
+    /// Database ID
+    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     /// See Model.idKey
     static var idKey: IDKey {
@@ -80,7 +80,8 @@ final class User: Model, Content {
     static let defaultMediaType: MediaType = .json
 
     typealias Database = SQLiteDatabase
-    typealias ID = UUID
+    typealias ID = Int
+    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
 
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),
@@ -92,7 +93,7 @@ final class User: Model, Content {
         return \.id
     }
 
-    var id: UUID?
+    var id: ID?
     var name: String
     var age: Double
 //    var child: User?

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -123,15 +123,13 @@ let controller = FooController()
 router.post("login", use: controller.foo)
 
 final class Message: Model {
-    typealias Database = SQLiteDatabase
-    
     static let keyFieldMap: KeyFieldMap = [
         key(\.id): field("id"),
         key(\.text): field("text"),
         key(\.time): field("customtime"),
     ]
 
-    static let dbID: DatabaseIdentifier<SQLiteDatabase> = .beta
+    static let database: DatabaseIdentifier<SQLiteDatabase> = .beta
     static let idKey = \Message.id
 
     var id: String?

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -61,7 +61,7 @@ services.register(middlewareConfig)
 
 let app = try Application(services: services)
 
-let foo = try app.withDatabase(.alpha) { alpha in
+let foo = try app.withConnection(to: .alpha) { alpha in
     return try alpha.query(string: "select sqlite_version();").all()
 }.blockingAwait()
 print(foo)
@@ -113,7 +113,7 @@ router.get("leaf") { req -> Future<View> in
 
 final class FooController {
     func foo(_ req: Request) -> Future<Response> {
-        return req.withDatabase(.alpha) { db in
+        return req.withConnection(to: .alpha) { db in
             return Response(status: .ok)
         }
     }
@@ -176,7 +176,7 @@ router.get("builder") { req -> Future<[User]> in
 
 
 router.get("transaction") { req -> Future<String> in
-    return req.withDatabase(.beta) { db in
+    return req.withConnection(to: .beta) { db in
         db.transaction { db in
             let user = User(name: "NO SAVE", age: 500)
             let message = Message(id: nil, text: "asdf", time: 42)
@@ -229,10 +229,8 @@ router.get("first") { req -> Future<User> in
 
 router.get("asyncusers") { req -> Future<User> in
     let user = User(name: "Bob", age: 1)
-    return req.withDatabase(.beta) { db -> Future<User> in
-        return user.save(on: db).map {
-            return user
-        }
+    return user.save(on: req).map {
+        return user
     }
 }
 

--- a/Sources/Fluent/Database/Database.swift
+++ b/Sources/Fluent/Database/Database.swift
@@ -22,4 +22,3 @@ extension Database {
         return DatabaseConnectionPool(max: max, database: self, worker: worker)
     }
 }
-

--- a/Sources/Fluent/Database/DatabaseConnection.swift
+++ b/Sources/Fluent/Database/DatabaseConnection.swift
@@ -10,3 +10,12 @@ public protocol ConnectionRepresentable {
     /// Create a database connection for the supplied dbid.
     func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection>
 }
+
+extension Connection {
+    /// Create a query for the specified model using this connection.
+    public func query<M>(_ model: M.Type) -> QueryBuilder<M>
+        where M.Database.Connection == Self
+    {
+        return QueryBuilder(M.self, on: Future(self))
+    }
+}

--- a/Sources/Fluent/Database/DatabaseConnection.swift
+++ b/Sources/Fluent/Database/DatabaseConnection.swift
@@ -8,7 +8,7 @@ public protocol Connection: QuerySupporting, ConnectionRepresentable {}
 /// for the supplied identifier.
 public protocol ConnectionRepresentable {
     /// Create a database connection for the supplied dbid.
-    func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection>
+    func makeConnection<D>(to database: DatabaseIdentifier<D>) -> Future<D.Connection>
 }
 
 extension Connection {

--- a/Sources/Fluent/Database/DatabaseConnection.swift
+++ b/Sources/Fluent/Database/DatabaseConnection.swift
@@ -1,3 +1,12 @@
+import Async
+
 /// Types conforming to this protocol can be used
 /// as a Fluent database connection for executing queries.
-public protocol Connection: QuerySupporting {}
+public protocol Connection: QuerySupporting, ConnectionRepresentable {}
+
+/// Capable of being represented as a database connection
+/// for the supplied identifier.
+public protocol ConnectionRepresentable {
+    /// Create a database connection for the supplied dbid.
+    func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection>
+}

--- a/Sources/Fluent/Error.swift
+++ b/Sources/Fluent/Error.swift
@@ -1,0 +1,32 @@
+import Debugging
+import Foundation
+import libc
+
+/// Errors that can be thrown while working with Fluent.
+public struct FluentError: Traceable, Debuggable, Swift.Error, Encodable {
+    public static let readableName = "Fluent Error"
+    public let identifier: String
+    public var reason: String
+    public var file: String
+    public var function: String
+    public var line: UInt
+    public var column: UInt
+    public var stackTrace: [String]
+
+    init(
+        identifier: String,
+        reason: String,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        column: UInt = #column
+    ) {
+        self.identifier = identifier
+        self.reason = reason
+        self.file = file
+        self.function = function
+        self.line = line
+        self.column = column
+        self.stackTrace = FluentError.makeStackTrace()
+    }
+}

--- a/Sources/Fluent/Migration/MigrationContainer.swift
+++ b/Sources/Fluent/Migration/MigrationContainer.swift
@@ -38,7 +38,8 @@ internal struct MigrationContainer<D: Database> {
                 return self.prepare(connection).then {
                     // create the migration log
                     let log = MigrationLog<Database>(name: self.name, batch: batch)
-                    return log.save(on: connection)
+                    return QueryBuilder(MigrationLog<Database>.self, on: Future(connection))
+                        .save(log)
                 }
             }
         }
@@ -51,7 +52,7 @@ internal struct MigrationContainer<D: Database> {
             if hasPrepared {
                 return self.revert(connection).then {
                     // delete the migration log
-                    return try connection.query(MigrationLog<Database>.self)
+                    return try QueryBuilder(MigrationLog<Database>.self, on: Future(connection))
                         .filter(\MigrationLog<Database>.name == self.name)
                         .delete()
                 }
@@ -64,7 +65,7 @@ internal struct MigrationContainer<D: Database> {
     /// returns true if the migration has already been prepared.
     internal func hasPrepared(on connection: Database.Connection) -> Future<Bool> {
         return then {
-            return try connection.query(MigrationLog<Database>.self)
+            return try QueryBuilder(MigrationLog<Database>.self, on: Future(connection))
                 .filter(\MigrationLog<Database>.name == self.name)
                 .first()
                 .map { $0 != nil }

--- a/Sources/Fluent/Model/Identifier.swift
+++ b/Sources/Fluent/Model/Identifier.swift
@@ -30,3 +30,32 @@ extension String: ID {
         return .supplied
     }
 }
+
+/// MARK: String
+
+/// Capable of being decoded from a string.
+public protocol StringDecodable {
+    /// Decode self from a string.
+    static func decode(from string: String) -> Self?
+}
+
+extension Int: StringDecodable {
+    /// See StringDecodable.decode
+    public static func decode(from string: String) -> Int? {
+        return Int(string)
+    }
+}
+
+extension UUID: StringDecodable {
+    /// See StringDecodable.decode
+    public static func decode(from string: String) -> UUID? {
+        return UUID(uuidString: string)
+    }
+}
+
+extension String: StringDecodable {
+    /// See StringDecodable.decode
+    public static func decode(from string: String) -> String? {
+        return string
+    }
+}

--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -23,7 +23,7 @@ public protocol Model: class, Codable, KeyFieldMappable {
     typealias IDKey = ReferenceWritableKeyPath<Self, ID?>
 
     /// This model's database
-    static var dbID: DatabaseIdentifier<Database> { get }
+    static var database: DatabaseIdentifier<Database> { get }
 
     /// This model's id key.
     /// note: If this is not `id`, you
@@ -53,12 +53,12 @@ public protocol Model: class, Codable, KeyFieldMappable {
 extension Model {
     /// Creates a query for this model on the supplied connection.
     public func query(on conn: ConnectionRepresentable) -> QueryBuilder<Self> {
-        return .init(on: conn.makeConnection(Self.dbID))
+        return .init(on: conn.makeConnection(Self.database))
     }
 
     /// Creates a query for this model on the supplied connection.
     public static func query(on conn: ConnectionRepresentable) -> QueryBuilder<Self> {
-        return .init(on: conn.makeConnection(dbID))
+        return .init(on: conn.makeConnection(database))
     }
 }
 

--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -53,12 +53,12 @@ public protocol Model: class, Codable, KeyFieldMappable {
 extension Model {
     /// Creates a query for this model on the supplied connection.
     public func query(on conn: ConnectionRepresentable) -> QueryBuilder<Self> {
-        return .init(on: conn.makeConnection(Self.database))
+        return .init(on: conn.makeConnection(to: Self.database))
     }
 
     /// Creates a query for this model on the supplied connection.
     public static func query(on conn: ConnectionRepresentable) -> QueryBuilder<Self> {
-        return .init(on: conn.makeConnection(database))
+        return .init(on: conn.makeConnection(to: database))
     }
 }
 

--- a/Sources/Fluent/Model/SoftDeletable.swift
+++ b/Sources/Fluent/Model/SoftDeletable.swift
@@ -27,17 +27,17 @@ extension SoftDeletable {
 extension Model where Self: SoftDeletable {
     /// Permanently deletes a soft deletable model.
     public func forceDelete(
-        on connection: Self.Database.Connection
+        on conn: ConnectionRepresentable
     ) -> Future<Void> {
-        return connection.query(Self.self)._delete(self)
+        return query(on: conn)._delete(self)
     }
 
     /// Restores a soft deleted model.
     public func restore(
-        on connection: Self.Database.Connection
+        on connection: ConnectionRepresentable
     ) -> Future<Void> {
         fluentDeletedAt = nil
-        return self.update(on: connection)
+        return update(on: connection)
     }
 }
 

--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -17,7 +17,7 @@ extension QueryBuilder {
     /// Saves this model as a new item in the database.
     /// This method can auto-generate an ID depending on ID type.
     public func create(_ model: Model) -> Future<Void> {
-        return then {
+        return connection.then { conn in
             self.query.data = model
             self.query.action = .create
 
@@ -38,16 +38,20 @@ extension QueryBuilder {
                 timestampable.createdAt = now
             }
 
-            return try model.willCreate(on: self.connection)
-                .then(self.run)
-                .then { try model.didCreate(on: self.connection) }
+            return try model.willCreate(on: conn)
+                .then {
+                    return self.run().map {
+                        try model.parseID(from: conn)
+                    }
+                }
+                .then { try model.didCreate(on: conn) }
         }
     }
 
     /// Updates the model. This requires that
     /// the model has its ID set.
     public func update(_ model: Model) -> Future<Void> {
-        return then {
+        return connection.then { conn in
             self.query.data = model
 
             guard let id = model.fluentID else {
@@ -64,9 +68,9 @@ extension QueryBuilder {
             }
 
 
-            return try model.willUpdate(on: self.connection)
+            return try model.willUpdate(on: conn)
                 .then(self.run)
-                .then { try model.didUpdate(on: self.connection) }
+                .then { try model.didUpdate(on: conn) }
         }
     }
 
@@ -89,15 +93,15 @@ extension QueryBuilder {
     /// Throws an error if the mdoel did not have an id.
     /// note: does NOT respect soft deletable.
     internal func _delete(_ model: Model) -> Future<Void> {
-        return then {
-            return try model.willDelete(on: self.connection).then {
+        return connection.then { conn in
+            return try model.willDelete(on: conn).then {
                 guard let id = model.fluentID else {
                     throw "model does not have an id"
                 }
 
                 try self.filter(Model.idKey == id)
                 self.query.action = .delete
-                return self.run().then { try model.didDelete(on: self.connection) }
+                return self.run().then { try model.didDelete(on: conn) }
             }
         }
     }

--- a/Sources/Fluent/Query/QuerySupporting.swift
+++ b/Sources/Fluent/Query/QuerySupporting.swift
@@ -21,10 +21,11 @@ public protocol QuerySupporting {
 /// connection pool and cached to the request.
 ///
 /// Subsequent calls to this function will use the same connection.
-extension Connection {
-    public func query<Model>(_ type: Model.Type = Model.self) -> QueryBuilder<Model>
-        where Model.Database.Connection == Self
-    {
-        return QueryBuilder(on: self)
-    }
-}
+//extension Connection {
+//    public func query<Model>(_ type: Model.Type = Model.self) -> QueryBuilder<Model>
+//        where Model.Database.Connection == Self
+//    {
+//        return QueryBuilder(on: self)
+//    }
+//}
+

--- a/Sources/Fluent/Relations/Children.swift
+++ b/Sources/Fluent/Relations/Children.swift
@@ -24,9 +24,9 @@ public struct Children<Parent: Model, Child: Model>
     }
 
     /// Create a query for all children.
-    public func query(on connection: Parent.Database.Connection) throws -> QueryBuilder<Child> {
-        let builder = connection.query(Child.self)
-        return try builder.filter(parentForeignIDKey.makeQueryField() == parent.requireID())
+    public func query(on conn: ConnectionRepresentable) throws -> QueryBuilder<Child> {
+        return try Child.query(on: conn)
+            .filter(parentForeignIDKey.makeQueryField() == parent.requireID())
     }
 }
 

--- a/Sources/Fluent/Relations/Parent.swift
+++ b/Sources/Fluent/Relations/Parent.swift
@@ -27,18 +27,18 @@ public struct Parent<Child: Model, Parent: Model>
 
     /// Create a query for the parent.
     public func query(
-        on connection: Child.Database.Connection
+        on conn: ConnectionRepresentable
     ) throws -> QueryBuilder<Parent> {
-        let builder = connection.query(Parent.self)
-        return try builder.filter(Parent.idKey == child[keyPath: parentForeignIDKey])
+        return try Parent.query(on: conn)
+            .filter(Parent.idKey == child[keyPath: parentForeignIDKey])
     }
 
     /// Convenience for getting the parent.
     public func get(
-        on connection: Child.Database.Connection
+        on conn: ConnectionRepresentable
     ) -> Future<Parent> {
         return then {
-            try self.query(on: connection).first().map { first in
+            try self.query(on: conn).first().map { first in
                 guard let parent = first else {
                     throw "Parent not found"
                 }

--- a/Sources/Fluent/Relations/Siblings.swift
+++ b/Sources/Fluent/Relations/Siblings.swift
@@ -69,8 +69,8 @@ public struct Siblings<Base: Model, Related: Model, Through: Pivot>
     }
 
     /// Create a query for the parent.
-    public func query(on executor: Through.Database.Connection) throws -> QueryBuilder<Related> {
-        return try executor.query(Related.self)
+    public func query(on conn: ConnectionRepresentable) throws -> QueryBuilder<Related> {
+        return try Related.query(on: conn)
             .join(field: relatedPivotField)
             .filter(basePivotField == base.requireID())
     }
@@ -83,9 +83,9 @@ extension Siblings {
     /// to this relationship.
     public func isAttached(
         _ model: Related,
-        on connection: Through.Database.Connection
+        on conn: ConnectionRepresentable
     ) throws -> Future<Bool> {
-        return try connection.query(Through.self)
+        return try Through.query(on: conn)
             .filter(basePivotField == base.requireID())
             .filter(relatedPivotField == model.requireID())
             .first()
@@ -96,9 +96,9 @@ extension Siblings {
     /// if it was attached.
     public func detach(
         _ model: Related,
-        on connection: Through.Database.Connection
+        on conn: ConnectionRepresentable
     ) throws -> Future<Void> {
-        return try connection.query(Through.self)
+        return try Through.query(on: conn)
             .filter(basePivotField == base.requireID())
             .filter(relatedPivotField == model.requireID())
             .delete()
@@ -110,11 +110,11 @@ extension Siblings where Through: ModifiablePivot, Through.Left == Base, Through
     /// Attaches the model to this relationship.
     public func attach(
         _ model: Related,
-        on connection: Through.Database.Connection
+        on conn: ConnectionRepresentable
     ) -> Future<Void> {
         do {
             let pivot = try Through(base, model)
-            return pivot.save(on: connection)
+            return pivot.save(on: conn)
         } catch {
             return Future(error: error)
         }
@@ -126,11 +126,11 @@ extension Siblings where Through: ModifiablePivot, Through.Left == Related, Thro
     /// Attaches the model to this relationship.
     public func attach(
         _ model: Related,
-        on connection: Through.Database.Connection
+        on conn: ConnectionRepresentable
     ) -> Future<Void> {
         do {
             let pivot = try Through(model, base)
-            return pivot.save(on: connection)
+            return pivot.save(on: conn)
         } catch {
             return Future(error: error)
         }

--- a/Sources/Fluent/Routing/Parameter.swift
+++ b/Sources/Fluent/Routing/Parameter.swift
@@ -1,0 +1,43 @@
+import Async
+import HTTP
+import Routing
+
+extension Model where Self: Parameter, ID: StringDecodable {
+    /// See Parameter.uniqueSlug
+    public static var uniqueSlug: String {
+        return "pet"
+    }
+
+    /// See Parameter.make
+    public static func make(for parameter: String, in req: Request) throws -> Future<Self> {
+        guard let id = ID.decode(from: parameter) else {
+            throw "could not convert parameter \(parameter) to type `\(ID.self)`"
+        }
+        return Self.find(id, on: req).map { pet in
+            guard let pet = pet else {
+                throw "no pet w/ that id was found"
+            }
+
+            return pet
+        }
+    }
+}
+
+/// MARK: HTTP
+
+extension Request: ConnectionRepresentable { }
+
+/// Middleware required for certain Fluent features to work correctly.
+/// Make sure to add this middleware to your app's MiddlewareConfig.
+public final class FluentMiddleware: Middleware {
+    /// Creates a new Fluent middleware.
+    public init() {}
+
+    /// See Middleware.respond
+    public func respond(to req: Request, chainingTo next: Responder) throws -> Future<Response> {
+        return try next.respond(to: req).map { res in
+            try req.releaseConnections()
+            return res
+        }
+    }
+}

--- a/Sources/Fluent/Service/Provider.swift
+++ b/Sources/Fluent/Service/Provider.swift
@@ -44,5 +44,8 @@ public final class FluentProvider: Provider {
         }.syncFlatten().blockingAwait()
 
         print("Migrations complete")
+
+        // verify middleware
+        // let middleware = MiddlewareConfig()
     }
 }

--- a/Sources/Fluent/Service/Request+Database.swift
+++ b/Sources/Fluent/Service/Request+Database.swift
@@ -7,10 +7,10 @@ extension Worker where Self: HasContainer {
     /// The database connection will be cached on this worker.
     /// The same database connection will always be returned for
     /// a given worker.
-    public func database<Database, F, T>(
+    public func database<Database, F>(
         _ database: DatabaseIdentifier<Database>,
         closure: @escaping (Database.Connection) throws -> F
-    ) -> Future<T> where F: FutureType, T == F.Expectation  {
+    ) -> Future<F.Expectation> where F: FutureType {
         return then {
             let pool: DatabaseConnectionPool<Database>
 

--- a/Sources/Fluent/Service/Request+Database.swift
+++ b/Sources/Fluent/Service/Request+Database.swift
@@ -7,7 +7,7 @@ extension Worker where Self: HasContainer {
     /// The database connection will be cached on this worker.
     /// The same database connection will always be returned for
     /// a given worker.
-    public func database<Database, F>(
+    public func withDatabase<Database, F>(
         _ database: DatabaseIdentifier<Database>,
         closure: @escaping (Database.Connection) throws -> F
     ) -> Future<F.Expectation> where F: FutureType {
@@ -38,4 +38,90 @@ extension Worker where Self: HasContainer {
             }
         }
     }
+
+    /// Requests a connection to the database.
+    /// important: you must be sure to call `.releaseConnection`
+    public func requestConnection<Database>(
+        _ database: DatabaseIdentifier<Database>
+    ) -> Future<Database.Connection> {
+        print("REQUEST \(database)")
+        return then {
+            let pool: DatabaseConnectionPool<Database>
+
+            /// this is the first attempt to connect to this
+            /// db for this request
+            if let existing = self.eventLoop.getConnectionPool(database: database) {
+                pool = existing
+            } else {
+                if let container = self.container {
+                    pool = try self.eventLoop.makeConnectionPool(
+                        database: database,
+                        using: container.make(Databases.self, for: Self.self)
+                    )
+                } else {
+                    throw "no container to create databases for connection pools"
+                }
+            }
+
+            /// request a connection from the pool
+            return pool.requestConnection()
+        }
+    }
+
+    /// Releases a connection back to the pool.
+    /// important: make sure to return connections called by `requestConnection`
+    /// to this function.
+    public func releaseConnection<Database>(
+        _ database: DatabaseIdentifier<Database>,
+        _ conn: Database.Connection
+    ) throws {
+        print("RELEASE \(database)")
+        /// this is the first attempt to connect to this
+        /// db for this request
+        guard let pool = self.eventLoop.getConnectionPool(database: database) else {
+            throw "no existing pool to release connection"
+        }
+        pool.releaseConnection(conn)
+    }
+}
+
+/// MARK:  ConnectionRepresentable
+
+extension Extendable where Self: HasContainer, Self: Worker {
+    /// See ConnectionRepresentable.makeConnection
+    /// important: make sure to release this connection later.
+    public func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection> {
+        if let active = connections[database.uid]?.connection as? Future<D.Connection> {
+            return active
+        }
+
+        return requestConnection(database).map { conn in
+            self.connections[database.uid] = ActiveConnection(connection: conn) {
+                try self.releaseConnection(database, conn)
+            }
+
+            return conn
+        }
+    }
+
+    /// Releases all active connections.
+    public func releaseConnections() throws {
+        let conns = connections
+        connections = [:]
+        for (_, conn) in conns {
+            try conn.release()
+        }
+    }
+
+    /// This worker's active connections.
+    fileprivate var connections: [String: ActiveConnection] {
+        get { return extend["fluent:connections"] as? [String: ActiveConnection] ?? [:] }
+        set { return extend["fluent:connections"] = newValue }
+    }
+}
+
+/// Represents an active connection.
+fileprivate struct ActiveConnection {
+    var connection: Any
+    var release: () throws -> ()
 }

--- a/Sources/FluentBenchmark/Foo.swift
+++ b/Sources/FluentBenchmark/Foo.swift
@@ -24,6 +24,11 @@ internal final class Foo<D: Database>: Model {
         ]
     }
 
+    /// See Model.database
+    public static var database: DatabaseIdentifier<D> {
+        return .init("test")
+    }
+
     /// Foo's identifier
     var id: UUID?
 

--- a/Sources/FluentBenchmark/KitchenSinkSchema.swift
+++ b/Sources/FluentBenchmark/KitchenSinkSchema.swift
@@ -2,9 +2,6 @@ import Async
 import Fluent
 
 final class KitchenSink<D: Database>: Model {
-    /// See Model.Database
-    typealias Database = D
-
     /// See Model.ID
     typealias ID = String
 
@@ -15,6 +12,9 @@ final class KitchenSink<D: Database>: Model {
 
     /// See Model.idKey
     static var idKey: IDKey { return \.id }
+
+    /// See Model.database
+    static var database: DatabaseIdentifier<D> { return .init("kitchenSink") }
 
     /// KitchenSink's identifier
     var id: String?

--- a/Sources/FluentBenchmark/Pet+Toy.swift
+++ b/Sources/FluentBenchmark/Pet+Toy.swift
@@ -34,6 +34,11 @@ public final class PetToy<D: Database>: ModifiablePivot {
         ]
     }
 
+    /// See Model.database
+    public static var database: DatabaseIdentifier<D> {
+        return .init("test")
+    }
+
     /// PetToy's identifier
     var id: UUID?
 

--- a/Sources/FluentBenchmark/Pet.swift
+++ b/Sources/FluentBenchmark/Pet.swift
@@ -26,6 +26,11 @@ public final class Pet<D: Database>: Model {
         ]
     }
 
+    /// See Model.database
+    public static var database: DatabaseIdentifier<D> {
+        return .init("test")
+    }
+
     /// Foo's identifier
     var id: ID?
 

--- a/Sources/FluentBenchmark/Toy.swift
+++ b/Sources/FluentBenchmark/Toy.swift
@@ -25,6 +25,11 @@ public final class Toy<D: Database>: Model {
         ]
     }
 
+    /// See Model.database
+    public static var database: DatabaseIdentifier<D> {
+        return .init("test")
+    }
+
     /// Foo's identifier
     var id: ID?
 

--- a/Sources/FluentBenchmark/User.swift
+++ b/Sources/FluentBenchmark/User.swift
@@ -28,6 +28,11 @@ public final class User<D: Database>: Model, Timestampable {
         ]
     }
 
+    /// See Model.database
+    public static var database: DatabaseIdentifier<D> {
+        return .init("test")
+    }
+
     /// Foo's identifier
     var id: UUID?
 

--- a/Sources/FluentSQLite/Database.swift
+++ b/Sources/FluentSQLite/Database.swift
@@ -4,7 +4,17 @@ import SQLite
 
 extension SQLiteDatabase: Database { }
 
-extension SQLiteConnection: Connection { }
+extension SQLiteConnection: Connection {
+    public func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection> {
+        return then {
+            guard let sqlite = self as? D.Connection else {
+                throw "invalid connection type"
+            }
+
+            return Future(sqlite)
+        }
+    }
+}
 
 extension SQLiteDatabase: LogSupporting {
     /// See SupportsLogging.enableLogging

--- a/Sources/FluentSQLite/Database.swift
+++ b/Sources/FluentSQLite/Database.swift
@@ -5,7 +5,7 @@ import SQLite
 extension SQLiteDatabase: Database { }
 
 extension SQLiteConnection: Connection {
-    public func makeConnection<D>(_ database: DatabaseIdentifier<D>) -> Future<D.Connection> {
+    public func makeConnection<D>(to database: DatabaseIdentifier<D>) -> Future<D.Connection> {
         return then {
             guard let sqlite = self as? D.Connection else {
                 throw "invalid connection type"

--- a/Sources/Routing/ParameterBag.swift
+++ b/Sources/Routing/ParameterBag.swift
@@ -46,6 +46,13 @@ public struct ParameterBag {
         parameters = Array(parameters.dropFirst())
         return item
     }
+
+    /// Infer requested type where the resolved parameter is the parameter type.
+    public mutating func next<P>() throws -> P
+        where P: Parameter, P.ResolvedParameter == P
+    {
+        return try self.next(P.self)
+    }
 }
 
 /// A parameter and its resolved value.

--- a/Sources/SQLite/Row/DecodingContainer.swift
+++ b/Sources/SQLite/Row/DecodingContainer.swift
@@ -92,7 +92,11 @@ internal final class DecodingContainer<K: CodingKey>:
     }
 
     func decode(_ type: Double.Type, forKey key: K) throws -> Double {
-        fatalError("unimplemented")
+        guard let double = decoder.row[key.stringValue]?.fuzzyDouble else {
+            throw "No double found at key `\(key.stringValue)`"
+        }
+
+        return double
     }
 
     func decode(_ type: String.Type, forKey key: K) throws -> String {


### PR DESCRIPTION
This PR simplifies accessing a database connection in route closures.

improvements:

- using `withDatabase` closure is now optional (renamed `.database` -> `.withDatabase` but still a valid way to make connections)
- `Request` can be used anywhere a database connection could be previously
- one connection per request:
    - a single `Request` will capture, then cache, a single db connection for its lifetime upon the first usage of the database (lazy)
    - active database connections will be released once the request passes through the `FluentMiddleware` at the end of its life
- fixed some issues with auto-incremented IDs not being set
- `Parameter` conformance will be automatically implemented for model's whose IDs are `StringDecodable`

caveats:
- connections captured via this new mechanism will not be released if someone forgets to add `FluentMiddleware`. perhaps we can verify they've added this at runtime? (requires importing Vapor)

### Current

```swift
router.get("users", UUID.self, "posts", Int.self) { req in
    return req.database(.foo) { db in
        let user = db.query(User.self).find(req.parameters.next())
        let post = db.query(Post.self).find(req.parameters.next())
        return then(user, post) { user, post in
            return "User \(user.id) post \(post.id)"
        }
    }
}
```

### Updated

```swift
router.get("users", UUID.self, "posts", Int.self) { req in
    let user = try req.parameters.next(User.self)
    let post = try req.parameters.next(Post.self)
    return then(user, post) { user, post in
        return "User \(user.id) post \(post.id)"
    }
}
```