### PR TITLE
response disambiguation helper

### DIFF
--- a/Sources/Vapor/AnyResponse.swift
+++ b/Sources/Vapor/AnyResponse.swift
@@ -36,4 +36,11 @@ public struct AnyResponse: FutureType {
     public init<F: FutureType>(future encodable: F) where F.Expectation : ResponseEncodable {
         wrapped = encodable.map(AnyResponseType.init)
     }
+    
+    /// Wraps a future response encodable type
+    public init<F: FutureType, RE>(future encodable: F, or other: ResponseEncodable) where F.Expectation == Optional<RE>, RE: ResponseEncodable {
+        wrapped = encodable.map { encodable in
+            AnyResponseType(encodable: encodable ?? other)
+        }
+    }
 }

--- a/Sources/Vapor/AnyResponse.swift
+++ b/Sources/Vapor/AnyResponse.swift
@@ -1,0 +1,27 @@
+import Async
+
+/// A wrapper that helps disambiguate multiple response types within a single route
+public struct AnyResponse: FutureType {
+    /// AnyResponse represents any `ResponseEncodable`
+    public typealias Expectation = ResponseEncodable
+    
+    /// The wrapped entity
+    var wrapped: Future<ResponseEncodable>
+    
+    /// Locked method for adding an awaiter
+    ///
+    /// [Learn More →](https://docs.vapor.codes/3.0/async/advanced-futures/#adding-awaiters-to-all-results)
+    public func addAwaiter(callback: @escaping (FutureResult<ResponseEncodable>) -> ()) {
+        wrapped.addAwaiter(callback: callback)
+    }
+    
+    /// Wraps a non-futuretype response
+    public init(_ encodable: ResponseEncodable) {
+        wrapped = Future(encodable)
+    }
+    
+    /// Wraps a future response encodable type
+    public init<F: FutureType>(future encodable: F) where F.Expectation : ResponseEncodable {
+        wrapped = encodable.map { $0 }
+    }
+}

--- a/Sources/Vapor/AnyResponse.swift
+++ b/Sources/Vapor/AnyResponse.swift
@@ -1,27 +1,39 @@
 import Async
+import HTTP
 
 /// A wrapper that helps disambiguate multiple response types within a single route
 public struct AnyResponse: FutureType {
     /// AnyResponse represents any `ResponseEncodable`
-    public typealias Expectation = ResponseEncodable
+    public typealias Expectation = AnyResponseType
+    
+    /// A wrapper around a `ResponseEncodable`
+    public struct AnyResponseType: ResponseEncodable {
+        /// The wrapped type
+        var encodable: ResponseEncodable
+        
+        /// Encodes the response
+        public func encode(to res: inout Response, for req: Request) throws -> Future<Void> {
+            return try encodable.encode(to: &res, for: req)
+        }
+    }
     
     /// The wrapped entity
-    var wrapped: Future<ResponseEncodable>
+    var wrapped: Future<AnyResponseType>
     
     /// Locked method for adding an awaiter
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/async/advanced-futures/#adding-awaiters-to-all-results)
-    public func addAwaiter(callback: @escaping (FutureResult<ResponseEncodable>) -> ()) {
+    public func addAwaiter(callback: @escaping (FutureResult<AnyResponseType>) -> ()) {
         wrapped.addAwaiter(callback: callback)
     }
     
     /// Wraps a non-futuretype response
     public init(_ encodable: ResponseEncodable) {
-        wrapped = Future(encodable)
+        wrapped = Future(AnyResponseType(encodable: encodable))
     }
     
     /// Wraps a future response encodable type
     public init<F: FutureType>(future encodable: F) where F.Expectation : ResponseEncodable {
-        wrapped = encodable.map { $0 }
+        wrapped = encodable.map(AnyResponseType.init)
     }
 }


### PR DESCRIPTION
When working with routes that respond in different types, this helper should simplify the return type