### PR TITLE
HTTP client improvements

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -49,6 +49,7 @@ do {
     // middlewareConfig.use(FluentMiddleware.self)
     // services.register(middlewareConfig)
 
+    
     let dir = DirectoryConfig(workDir: "/Users/tanner/dev/vapor/vapor/Sources/Development/")
     services.register(dir)
 
@@ -56,6 +57,30 @@ do {
 
     let router = try app.make(Router.self)
 
+    router.get("example") { req -> Future<Response> in
+        let client = try req.make(Client.self, for: Request.self)
+        
+        return client.send(.get, to: "http://www.zombo.com/")
+    }
+    
+    router.get("example1") { req -> Future<Response> in
+        let client = try req.make(Client.self, for: Request.self)
+        
+        return client.send(.get, to: "http://www.romansgohome.com")
+    }
+    
+    router.get("example2") { req -> Future<Response> in
+        let client = try req.make(Client.self, for: Request.self)
+        
+        return client.send(.get, to: "http://example.com")
+    }
+    
+    router.get("example3") { req -> Future<Response> in
+        let client = try req.make(Client.self, for: Request.self)
+        
+        return client.send(.get, to: "https://www.apache.org/foundation/press/kit/asf_logo.png")
+    }
+    
     router.get("hello") { req -> [User] in
         let user = User(name: "Vapor", age: 3);
         return [user]

--- a/Sources/Fluent/Migration/QueryMigrationConfig.swift
+++ b/Sources/Fluent/Migration/QueryMigrationConfig.swift
@@ -20,7 +20,7 @@ internal struct QueryMigrationConfig<Database: Fluent.Database>: MigrationRunnab
     internal func migrate(using databases: Databases, using container: Container) -> Future<Void> {
         return then {
             guard let database = databases.storage[self.database.uid] as? Database else {
-                throw "no database \(self.database.uid) was found for migrations"
+                throw FluentError(identifier: "no-migration-database", reason: "no database \(self.database.uid) was found for migrations")
             }
             
             let config = try container.make(Database.Connection.Config.self, for: Database.Connection.self)

--- a/Sources/Fluent/Migration/SchemaMigrationConfig.swift
+++ b/Sources/Fluent/Migration/SchemaMigrationConfig.swift
@@ -22,7 +22,7 @@ internal struct SchemaMigrationConfig<
     internal func migrate(using databases: Databases, using container: Container) -> Future<Void> {
         return then {
             guard let database = databases.storage[self.database.uid] as? Database else {
-                throw "no database \(self.database.uid) was found for migrations"
+                throw FluentError(identifier: "no-migration-database", reason: "no database \(self.database.uid) was found for migrations")
             }
 
             return try database.makeConnection(from: container.make(for: Database.Connection.self), on: container).then { conn in

--- a/Sources/Fluent/Model/Model.swift
+++ b/Sources/Fluent/Model/Model.swift
@@ -59,14 +59,14 @@ extension Model where ID: StringDecodable {
     /// See EphemeralWorkerFindable.find
     public static func find(identifier: String, using container: Container) throws -> Future<Self> {
         guard let id = ID.decode(from: identifier) else {
-            throw "could not convert parameter \(identifier) to type `\(ID.self)`"
+            throw FluentError(identifier: "incorrect-model-identifier", reason: "could not convert parameter \(identifier) to type `\(ID.self)`")
         }
 
         if let ephemeral = container as? EphemeralContainer {
             return ephemeral.connect(to: database).then { conn in
                 return self.find(id, on: conn).map { pet in
                     guard let pet = pet else {
-                        throw "no model id \(id) was found"
+                        throw FluentError(identifier: "entity-not-found", reason: "no model with ID \(id) was found")
                     }
 
                     return pet
@@ -76,7 +76,7 @@ extension Model where ID: StringDecodable {
             return container.withConnection(to: database) { conn in
                 return self.find(id, on: conn).map { pet in
                     guard let pet = pet else {
-                        throw "no model id \(id) was found"
+                        throw FluentError(identifier: "entity-not-found", reason: "no model with ID \(id) was found")
                     }
 
                     return pet
@@ -141,7 +141,7 @@ extension Model {
     /// Throws an error if the model doesn't have an ID.
     public func requireID() throws -> ID {
         guard let id = self.fluentID else {
-            throw "no id"
+            throw FluentError(identifier: "no-id", reason: "This model didn't have an identifier")
         }
 
         return id

--- a/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder+CRUD.swift
@@ -26,7 +26,8 @@ extension QueryBuilder {
                 case .autoincrementing: break
                 case .generated(let factory):
                     model.fluentID = factory()
-                case .supplied: throw "model id type is `supplied`, but no id was supplied"
+                case .supplied:
+                    throw FluentError(identifier: "no-id-supplied", reason: "model id type is `supplied`, but no id was supplied")
                 }
             }
 
@@ -55,7 +56,7 @@ extension QueryBuilder {
             self.query.data = model
 
             guard let id = model.fluentID else {
-                throw "id required for update"
+                throw FluentError(identifier: "missing-id", reason: "No ID was set on updated model, it is required for updating.")
             }
 
             // update record w/ matching id
@@ -96,7 +97,7 @@ extension QueryBuilder {
         return connection.then { conn in
             return try model.willDelete(on: conn).then { _ -> Future<Void> in
                 guard let id = model.fluentID else {
-                    throw "model does not have an id"
+                    throw FluentError(identifier: "missing-id", reason: "Model does not have an identifier, it is necessary for removing it")
                 }
 
                 try self.filter(Model.idKey == id)

--- a/Sources/Fluent/Query/Builder/QueryBuilder.swift
+++ b/Sources/Fluent/Query/Builder/QueryBuilder.swift
@@ -36,7 +36,7 @@ public final class QueryBuilder<Model: Fluent.Model> {
                 !self.query.withSoftDeleted
             {
                 guard let deletedAtKey = type.keyStringMap[type.anyDeletedAtKey] else {
-                    throw "no deleted at field in key map"
+                    throw FluentError(identifier: "deletedAt-field-missing", reason: "no deleted at field exists in key map")
                 }
 
                 let deletedAtField = QueryField(entity: type.entity, name: deletedAtKey)

--- a/Sources/Fluent/Query/QueryField.swift
+++ b/Sources/Fluent/Query/QueryField.swift
@@ -26,7 +26,7 @@ extension KeyPath: QueryFieldRepresentable {
     /// See QueryFieldRepresentable.makeQueryField()
     public func makeQueryField() throws -> QueryField {
         guard let model = Root.self as? AnyModel.Type else {
-            throw "`Can't create query field. \(Root.self)` does not conform to `AnyModel`."
+            throw FluentError(identifier: "invalid-root-type", reason: "`Can't create query field. \(Root.self)` does not conform to `AnyModel`.")
         }
 
         let key = try model.keyStringMap.requireString(for: self)

--- a/Sources/Fluent/Relations/Parent.swift
+++ b/Sources/Fluent/Relations/Parent.swift
@@ -40,7 +40,7 @@ public struct Parent<Child: Model, Parent: Model>
         return then {
             try self.query(on: conn).first().map { first in
                 guard let parent = first else {
-                    throw "Parent not found"
+                    throw FluentError(identifier: "parent-not-found", reason: "This parent relationship could not be resolved")
                 }
                 return parent
             }

--- a/Sources/Fluent/Schema/SchemaSupporting.swift
+++ b/Sources/Fluent/Schema/SchemaSupporting.swift
@@ -27,7 +27,7 @@ extension SchemaFieldType {
     /// Returns the schema field type for a given type or throws and error
     public static func requireSchemaFieldType<T>(for type: T.Type) throws -> Self {
         guard let type = makeSchemaFieldType(for: T.self) else {
-            throw "type for \(T.self) required"
+            throw FluentError(identifier: "scema-type-not-supported", reason: "Type for \(T.self) required, a matching database type could not be found")
         }
 
         return type

--- a/Sources/Fluent/Service/Worker+Connection.swift
+++ b/Sources/Fluent/Service/Worker+Connection.swift
@@ -32,7 +32,7 @@ extension Container {
             let databases = try self.make(Databases.self, for: Self.self)
 
             guard let db = databases.storage[database.uid] as? Database else {
-                throw "no database with id '\(database)' configured"
+                throw FluentError(identifier: "database-not-configured", reason: "no database with id '\(database)' configured")
             }
 
             return try db.makeConnection(from: self.make(for: Database.Connection.self), on: self)
@@ -184,7 +184,7 @@ internal final class ConnectionPoolCache {
             return existing
         } else {
             guard let database = databases.storage[id.uid] as? D else {
-                throw "invalid db"
+                fatalError("no database")
             }
 
             let new = try database.makeConnectionPool(max: 2, using: container.make(for: D.Connection.self), on: container)

--- a/Sources/FluentBenchmark/BenchmarkAutoincrement.swift
+++ b/Sources/FluentBenchmark/BenchmarkAutoincrement.swift
@@ -15,11 +15,11 @@ extension Benchmarker  {
 
         return message.save(on: conn).map {
             if conn.lastAutoincrementID == nil {
-                throw "The last auto increment was not set"
+                throw FluentBenchmarkError(identifier: "autoincrement", reason: "The last auto increment was not set")
             }
             
             if conn.lastAutoincrementID != message.id {
-                throw "The model ID was incorrectly set to \(message.id?.description ?? "nil") instead of \(conn.lastAutoincrementID?.description ?? "nil")"
+                throw FluentBenchmarkError(identifier: "model-autoincrement-mismatch", reason: "The model ID was incorrectly set to \(message.id?.description ?? "nil") instead of \(conn.lastAutoincrementID?.description ?? "nil")")
             }
         }
     }

--- a/Sources/FluentBenchmark/BenchmarkTransaction.swift
+++ b/Sources/FluentBenchmark/BenchmarkTransaction.swift
@@ -30,7 +30,7 @@ extension Benchmarker where Database.Connection: TransactionSupporting {
                             self.fail("count should be 101")
                         }
                         
-                        throw "rollback"
+                        throw FluentBenchmarkError(identifier: "test", reason: "rollback")
                     }
                 }
             }

--- a/Sources/FluentBenchmark/Error.swift
+++ b/Sources/FluentBenchmark/Error.swift
@@ -1,10 +1,8 @@
 import Debugging
-import Foundation
-import COperatingSystem
 
-/// Errors that can be thrown while working with Leaf.
-public struct LeafError: Traceable, Debuggable, Swift.Error, Encodable {
-    public static let readableName = "Leaf Error"
+/// Errors that can be thrown while working with Fluent Benchmarks.
+public struct FluentBenchmarkError: Traceable, Debuggable, Swift.Error, Encodable {
+    public static let readableName = "Fluent Benchmark Error"
     public let identifier: String
     public var reason: String
     public var file: String
@@ -20,14 +18,14 @@ public struct LeafError: Traceable, Debuggable, Swift.Error, Encodable {
         function: String = #function,
         line: UInt = #line,
         column: UInt = #column
-        ) {
+    ) {
         self.identifier = identifier
         self.reason = reason
         self.file = file
         self.function = function
         self.line = line
         self.column = column
-        self.stackTrace = LeafError.makeStackTrace()
+        self.stackTrace = FluentBenchmarkError.makeStackTrace()
     }
 }
 

--- a/Sources/FluentMySQL/Database.swift
+++ b/Sources/FluentMySQL/Database.swift
@@ -3,6 +3,7 @@ import Service
 import MySQL
 import Fluent
 
+/// A reference to a MySQL database
 public final class MySQLDatabase : LogSupporting {
     /// The hostname to which connections will be connected
     let hostname: String

--- a/Sources/FluentMySQL/FluentMySQLProvider.swift
+++ b/Sources/FluentMySQL/FluentMySQLProvider.swift
@@ -33,7 +33,7 @@ public final class MySQLProvider: Provider {
     public func register(_ services: inout Services) throws {
         services.register(FluentMySQLConfig())
         services.register(MySQLDatabase.self) { container -> SQLiteDatabase in
-            let database = MySQLDatabase(hostname: hostname, port: port, user: user, password: password, database: database)
+            return MySQLDatabase(hostname: hostname, port: port, user: user, password: password, database: database)
         }
     }
     

--- a/Sources/FluentMySQL/FluentMySQLProvider.swift
+++ b/Sources/FluentMySQL/FluentMySQLProvider.swift
@@ -1,5 +1,4 @@
 import Service
-import SQLite
 
 /// Registers and boots MySQL services.
 public final class MySQLProvider: Provider {
@@ -32,8 +31,14 @@ public final class MySQLProvider: Provider {
     /// See Provider.register
     public func register(_ services: inout Services) throws {
         services.register(FluentMySQLConfig())
-        services.register(MySQLDatabase.self) { container -> SQLiteDatabase in
-            return MySQLDatabase(hostname: hostname, port: port, user: user, password: password, database: database)
+        services.register(MySQLDatabase.self) { container -> MySQLDatabase in
+            return MySQLDatabase(
+                hostname: self.hostname,
+                port: self.port,
+                user: self.user,
+                password: self.password,
+                database: self.database
+            )
         }
     }
     

--- a/Sources/FluentMySQL/FluentMySQLProvider.swift
+++ b/Sources/FluentMySQL/FluentMySQLProvider.swift
@@ -1,0 +1,43 @@
+import Service
+import SQLite
+
+/// Registers and boots MySQL services.
+public final class MySQLProvider: Provider {
+    /// See Provider.repositoryName
+    public static let repositoryName = "fluent-mysql"
+    
+    /// The hostname to which connections will be connected
+    let hostname: String
+    
+    /// The port to which connections will be connected
+    let port: UInt16
+    
+    /// The username to authenticate with
+    let user: String
+    
+    /// The password to authenticate with
+    let password: String?
+    
+    /// The database to select
+    let database: String
+    
+    public init(hostname: String, port: UInt16 = 3306, user: String, password: String?, database: String) {
+        self.hostname = hostname
+        self.port = port
+        self.user = user
+        self.password = password
+        self.database = database
+    }
+    
+    /// See Provider.register
+    public func register(_ services: inout Services) throws {
+        services.register(FluentMySQLConfig())
+        services.register(MySQLDatabase.self) { container -> SQLiteDatabase in
+            let database = MySQLDatabase(hostname: hostname, port: port, user: user, password: password, database: database)
+        }
+    }
+    
+    /// See Provider.boot
+    public func boot(_ container: Container) throws {}
+}
+

--- a/Sources/FluentSQLite/Provider.swift
+++ b/Sources/FluentSQLite/Provider.swift
@@ -11,6 +11,7 @@ public final class SQLiteProvider: Provider {
 
     /// See Provider.register
     public func register(_ services: inout Services) throws {
+        services.register(SQLiteConfig())
         services.register(SQLiteDatabase.self) { container -> SQLiteDatabase in
             let storage = try container.make(SQLiteStorage.self, for: SQLiteProvider.self)
             return SQLiteDatabase(storage: storage)

--- a/Sources/FluentSQLite/QuerySupporting.swift
+++ b/Sources/FluentSQLite/QuerySupporting.swift
@@ -84,7 +84,7 @@ extension SQLiteDataEncoder {
         case .wildcard(let wildcard):
             // FIXME: fuzzy string
             guard let string = data.text else {
-                throw "could not convert value with wildcards to string: \(data)"
+                throw FluentSQLiteError(identifier: "incorrect-string", reason: "could not convert value with wildcards to string: \(data)")
             }
 
             switch wildcard {

--- a/Sources/FluentSQLite/SchemaSupporting.swift
+++ b/Sources/FluentSQLite/SchemaSupporting.swift
@@ -12,7 +12,7 @@ extension SQLiteConnection: SchemaSupporting, ReferenceSupporting {
     public func execute(schema: DatabaseSchema) -> Future<Void> {
         return then {
             guard schema.removeReferences.count <= 0 else {
-                throw "SQLite does not support deleting foreign keys"
+                throw FluentSQLiteError(identifier: "foreignkeys-unsupported", reason: "SQLite does not support deleting foreign keys")
             }
 
             let schemaQuery = schema.makeSchemaQuery()

--- a/Sources/HTTP/Message/Headers.swift
+++ b/Sources/HTTP/Message/Headers.swift
@@ -14,8 +14,12 @@ import Bits
 ///
 /// [Learn More →](https://docs.vapor.codes/3.0/http/headers/)
 public struct HTTPHeaders: Codable {
-    struct Index: CustomStringConvertible {
+    struct Index: CustomStringConvertible, CustomDebugStringConvertible {
         var description: String {
+            return ""
+        }
+        
+        var debugDescription: String {
             return ""
         }
         

--- a/Sources/HTTP/Message/Headers.swift
+++ b/Sources/HTTP/Message/Headers.swift
@@ -14,7 +14,11 @@ import Bits
 ///
 /// [Learn More →](https://docs.vapor.codes/3.0/http/headers/)
 public struct HTTPHeaders: Codable {
-    struct Index {
+    struct Index: CustomStringConvertible {
+        var description: String {
+            return ""
+        }
+        
         var nameStartIndex: Int
         
         var startIndex: Int {
@@ -179,6 +183,12 @@ public struct HTTPHeaders: Codable {
                 appendValue(value, forName: name)
             }
         }
+    }
+}
+
+extension HTTPHeaders: CustomStringConvertible {
+    public var description: String {
+        return String(data: self.storage, encoding: .utf8) ?? ""
     }
 }
 

--- a/Sources/HTTP/Parser/CParseResults.swift
+++ b/Sources/HTTP/Parser/CParseResults.swift
@@ -21,8 +21,15 @@ internal final class CParseResults {
     var headersIndexes: [HTTPHeaders.Index]
     var headersData = Data()
     
+    var currentSize: Int = 0
+    var maxSize: Int
+    
     var headers: HTTPHeaders?
-    var body: HTTPBody?
+    var bodyData = Data()
+    
+    var body: HTTPBody {
+        return HTTPBody(bodyData)
+    }
     
     var url = Data()
 
@@ -33,6 +40,7 @@ internal final class CParseResults {
         headersData.reserveCapacity(4096)
         headersIndexes.reserveCapacity(64)
         url.reserveCapacity(128)
+        self.maxSize = maxSize
         
         self.headerState = .none
     }

--- a/Sources/HTTP/Parser/CParseResults.swift
+++ b/Sources/HTTP/Parser/CParseResults.swift
@@ -20,7 +20,10 @@ internal final class CParseResults {
     var version: HTTPVersion?
     var headersIndexes: [HTTPHeaders.Index]
     var headersData = Data()
-    var body = Data()
+    
+    var headers: HTTPHeaders?
+    var body: HTTPBody?
+    
     var url = Data()
 
     /// Creates a new results object
@@ -29,7 +32,6 @@ internal final class CParseResults {
         self.headersIndexes = []
         headersData.reserveCapacity(4096)
         headersIndexes.reserveCapacity(64)
-        body.reserveCapacity(4096)
         url.reserveCapacity(128)
         
         self.headerState = .none

--- a/Sources/HTTP/Parser/CParser.swift
+++ b/Sources/HTTP/Parser/CParser.swift
@@ -247,6 +247,10 @@ extension CParser {
             let major = Int(parser.pointee.http_major)
             let minor = Int(parser.pointee.http_minor)
             results.version = HTTPVersion(major: major, minor: minor)
+            
+            if results.body == nil {
+                results.body = HTTPBody()
+            }
 
             return 0
         }

--- a/Sources/HTTP/Parser/RequestParser.swift
+++ b/Sources/HTTP/Parser/RequestParser.swift
@@ -136,21 +136,8 @@ public final class RequestParser: CParser {
 
     /// Parses a Request from the stream.
     public func parse(from buffer: ByteBuffer) throws -> HTTPRequest? {
-        let results: CParseResults
-
-        switch state {
-        case .ready:
-            // create a new results object and set
-            // a reference to it on the parser
-            let newResults = CParseResults.set(on: &parser, maxSize: maxSize)
-            results = newResults
-            state = .parsing
-        case .parsing:
-            // get the current parse results object
-            guard let existingResults = CParseResults.get(from: &parser) else {
-                return nil
-            }
-            results = existingResults
+        guard let results = getResults() else {
+            return nil
         }
 
         results.currentSize += buffer.count

--- a/Sources/HTTP/Parser/RequestParser.swift
+++ b/Sources/HTTP/Parser/RequestParser.swift
@@ -82,10 +82,9 @@ public final class RequestParser: CParser {
         }
     }
     
-    func makeRequest() throws -> HTTPRequest {
+    func makeRequest(from results: CParseResults) throws -> HTTPRequest {
         // require a version to have been parsed
         guard
-            let results = getResults(),
             let version = results.version,
             let headers = results.headers,
             let body = results.body
@@ -115,8 +114,8 @@ public final class RequestParser: CParser {
             guard
                 let pointer = http_method_str(http_method(parser.method)),
                 let string = String(validatingUTF8: pointer)
-                else {
-                    throw HTTPError.invalidMessage()
+            else {
+                throw HTTPError.invalidMessage()
             }
             method = HTTPMethod(string)
         }
@@ -133,7 +132,12 @@ public final class RequestParser: CParser {
         
         // create the request
         return HTTPRequest(
-            method: method, uri: uri, version: version, headers: headers, body: body)
+            method: method,
+            uri: uri,
+            version: version,
+            headers: headers,
+            body: body
+        )
     }
 
     /// Parses a Request from the stream.
@@ -173,7 +177,7 @@ public final class RequestParser: CParser {
         state = .ready
         CParseResults.remove(from: &parser)
         
-        return try makeRequest()
+        return try makeRequest(from: results)
     }
 }
 

--- a/Sources/HTTP/Parser/ResponseParser.swift
+++ b/Sources/HTTP/Parser/ResponseParser.swift
@@ -109,6 +109,9 @@ public final class ResponseParser: CParser, Async.Stream, ClosableStream {
             throw HTTPError.invalidMessage()
         }
         
+        /// get response status
+        let status = HTTPStatus(code: Int(parser.status_code))
+        
         currentSize = 0
         
         // create the request
@@ -143,9 +146,6 @@ public final class ResponseParser: CParser, Async.Stream, ClosableStream {
         // for a new request to come in
         state = .ready
         CParseResults.remove(from: &parser)
-
-        /// get response status
-        let status = HTTPStatus(code: Int(parser.status_code))
         
         return try makeResponse()
     }

--- a/Sources/HTTP/Parser/ResponseParser.swift
+++ b/Sources/HTTP/Parser/ResponseParser.swift
@@ -98,10 +98,9 @@ public final class ResponseParser: CParser, Async.Stream, ClosableStream {
         }
     }
     
-    func makeResponse() throws -> HTTPResponse {
+    func makeResponse(from results: CParseResults) throws -> HTTPResponse {
         // require a version to have been parsed
         guard
-            let results = getResults(),
             let version = results.version,
             let headers = results.headers,
             let body = results.body
@@ -147,7 +146,7 @@ public final class ResponseParser: CParser, Async.Stream, ClosableStream {
         state = .ready
         CParseResults.remove(from: &parser)
         
-        return try makeResponse()
+        return try makeResponse(from: results)
     }
 }
 

--- a/Sources/HTTP/Serializer/RequestSerializer.swift
+++ b/Sources/HTTP/Serializer/RequestSerializer.swift
@@ -36,7 +36,13 @@ public final class RequestSerializer: Serializer {
         serialized.reserveCapacity(request.headers.storage.count + 256)
         
         serialized.append(.space)
+        
+        if request.uri.pathBytes.first != .forwardSlash {
+            serialized.append(.forwardSlash)
+        }
+        
         serialized.append(contentsOf: request.uri.pathBytes)
+        
         serialized.append(contentsOf: http1newLine)
         
         var headers = request.headers

--- a/Sources/Leaf/Data/LeafDataEncoder.swift
+++ b/Sources/Leaf/Data/LeafDataEncoder.swift
@@ -61,7 +61,7 @@ extension _LeafEncoder: FutureEncoder {
     func encodeFuture<E>(_ future: Future<E>) throws {
         let future: Future<LeafData> = future.map { any in
             guard let encodable = any as? Encodable else {
-                throw "not encodable!"
+                throw LeafError(identifier: "not-encodable", reason: "The future found in data provided to Leaf's for rendering was not Encodable")
             }
 
             let encoder = _LeafEncoder(

--- a/Sources/Leaf/Utilities/LeafError.swift
+++ b/Sources/Leaf/Utilities/LeafError.swift
@@ -1,0 +1,33 @@
+import Debugging
+import Foundation
+import COperatingSystem
+
+/// Errors that can be thrown while working with Fluent.
+public struct LeafError: Traceable, Debuggable, Swift.Error, Encodable {
+    public static let readableName = "Leaf Error"
+    public let identifier: String
+    public var reason: String
+    public var file: String
+    public var function: String
+    public var line: UInt
+    public var column: UInt
+    public var stackTrace: [String]
+    
+    init(
+        identifier: String,
+        reason: String,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        column: UInt = #column
+        ) {
+        self.identifier = identifier
+        self.reason = reason
+        self.file = file
+        self.function = function
+        self.line = line
+        self.column = column
+        self.stackTrace = FluentError.makeStackTrace()
+    }
+}
+

--- a/Sources/MySQL/Connection/Connection.swift
+++ b/Sources/MySQL/Connection/Connection.swift
@@ -104,7 +104,6 @@ public final class MySQLConnection {
         self.authenticated = Promise<Void>()
         
         let socket = try TCPClient(on: eventLoop)
-        try socket.connect(hostname: hostname, port: port)
         socket.stream(to: parser)
         
         self.socket = socket
@@ -119,6 +118,8 @@ public final class MySQLConnection {
         self.database = database
         self.packetStream = .init()
         self.eventLoop = eventLoop
+        
+        try socket.connect(hostname: hostname, port: port).catch(authenticated.fail)
         
         self.parser.drain(onInput: self.handlePacket).catch { error in
             /// close the packet stream

--- a/Sources/Redis/Redis.swift
+++ b/Sources/Redis/Redis.swift
@@ -127,9 +127,10 @@ extension RedisClient {
         hostname: String = "localhost",
         port: UInt16 = 6379,
         on eventLoop: EventLoop
-    ) throws -> RedisClient {
+    ) throws -> Future<RedisClient> {
         let client = try TCPClient(on: eventLoop)
-        try client.connect(hostname: hostname, port: port)
-        return RedisClient(socket: client)
+        return try client.connect(hostname: hostname, port: port).map {
+            return RedisClient(socket: client)
+        }
     }
 }

--- a/Sources/SQLite/Data/DataDecodingContainer.swift
+++ b/Sources/SQLite/Data/DataDecodingContainer.swift
@@ -18,7 +18,7 @@ internal final class DataDecodingContainer: SingleValueDecodingContainer {
 
     func decode(_ type: Int.Type) throws -> Int {
         guard let int = decoder.data.fuzzyInt else {
-            throw "could not get itn"
+            fatalError("todo")
         }
         return int
     }
@@ -65,14 +65,14 @@ internal final class DataDecodingContainer: SingleValueDecodingContainer {
 
     func decode(_ type: Double.Type) throws -> Double {
         guard let double = decoder.data.fuzzyDouble else {
-            throw "could not get double"
+            fatalError("todo")
         }
         return double
     }
 
     func decode(_ type: String.Type) throws -> String {
         guard let string = decoder.data.fuzzyString else {
-            throw "could not get string"
+            fatalError("todo")
         }
         return string
     }

--- a/Sources/SQLite/Database/Error.swift
+++ b/Sources/SQLite/Database/Error.swift
@@ -2,7 +2,7 @@ import CSQLite
 import Debugging
 
 /// Errors that can be thrown while using SQLite
-public struct SQLiteError: Swift.Error, Debuggable, Traceable {
+struct SQLiteError: Swift.Error, Debuggable, Traceable {
     let problem: Problem
     public let reason: String
     public var file: String

--- a/Sources/SQLite/Row/DecodingContainer.swift
+++ b/Sources/SQLite/Row/DecodingContainer.swift
@@ -45,7 +45,7 @@ internal final class DecodingContainer<K: CodingKey>:
 
     func decode(_ type: Int.Type, forKey key: K) throws -> Int {
         guard let int = decoder.row[key.stringValue]?.fuzzyInt else {
-            throw "No int found at key `\(key.stringValue)`"
+            fatalError("No int found at key `\(key.stringValue)`")
         }
 
         return int
@@ -93,7 +93,7 @@ internal final class DecodingContainer<K: CodingKey>:
 
     func decode(_ type: Double.Type, forKey key: K) throws -> Double {
         guard let double = decoder.row[key.stringValue]?.fuzzyDouble else {
-            throw "No double found at key `\(key.stringValue)`"
+            fatalError("No double found at key `\(key.stringValue)`")
         }
 
         return double
@@ -101,7 +101,7 @@ internal final class DecodingContainer<K: CodingKey>:
 
     func decode(_ type: String.Type, forKey key: K) throws -> String {
         guard let string = decoder.row[key.stringValue]?.fuzzyString else {
-            throw "No string found at key `\(key.stringValue)`"
+            fatalError("No string found at key `\(key.stringValue)`")
         }
 
         return string
@@ -109,7 +109,7 @@ internal final class DecodingContainer<K: CodingKey>:
 
     func decode<T: Decodable>(_ type: T.Type, forKey key: K) throws -> T {
         guard let data = decoder.row[key.stringValue] else {
-            throw "no data at key"
+            fatalError("no data at key")
         }
 
         let d = SQLiteDataDecoder(data: data)

--- a/Sources/SQLite/Row/RowDecoder.swift
+++ b/Sources/SQLite/Row/RowDecoder.swift
@@ -16,7 +16,7 @@ public final class SQLiteRowDecoder: Decoder {
     }
 
     public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        throw "not supported"
+        fatalError("unsupported")
     }
 
     public func singleValueContainer() throws -> SingleValueDecodingContainer {

--- a/Sources/Service/Config.swift
+++ b/Sources/Service/Config.swift
@@ -1,5 +1,3 @@
-extension String: Error { }
-
 /// Types conforming to this protocol can be used by
 /// the service container to disambiguate situations where
 /// multiple services are available for a given `.make()` request.
@@ -44,7 +42,7 @@ public struct Config {
         let specific = ServiceIdentifier(interface: interface, client: client)
         let all = ServiceIdentifier(interface: interface, client: nil)
         guard let preference = preferences[specific] ?? preferences[all] else {
-            throw "Please choose which \(interface) you prefer, multiple are available: \(available.readable)"
+            throw ServiceError(.other(identifier: "invalid-interface", reason: "Please choose which \(interface) you prefer, multiple are available: \(available.readable)"))
         }
 
         let chosen = available.filter { factory in
@@ -59,9 +57,9 @@ public struct Config {
 
         guard chosen.count == 1 else {
             if chosen.count < 1 {
-                throw "No service \(preference.type) (\(preference.tag ?? "*")) has been registered for \(interface)."
+                throw ServiceError(.other(identifier: "invalid-tag", reason: "No service \(preference.type) (\(preference.tag ?? "*")) has been registered for \(interface)."))
             } else {
-                throw "Too many services were found"
+                throw ServiceError(.other(identifier: "multiple-matching-tag", reason: "Too many services were found mathcing this tag"))
             }
 
         }
@@ -82,12 +80,12 @@ public struct Config {
         }
 
         guard requirement.type == chosen.serviceType else {
-            throw "\(interface) \(chosen.serviceType) is not required type \(requirement.type)."
+            throw ServiceError(.other(identifier: "type-not-required", reason: "\(interface) \(chosen.serviceType) is not required type \(requirement.type)."))
         }
 
         if let tag = requirement.tag {
             guard chosen.serviceTag == tag else {
-                throw "\(chosen.serviceType) tag \(chosen.serviceTag ?? "none") does not equal \(tag)"
+                throw ServiceError(.other(identifier: "tag-not-matching", reason: "\(chosen.serviceType) tag \(chosen.serviceTag ?? "none") does not equal \(tag)"))
             }
         }
     }

--- a/Sources/Service/Container+Service.swift
+++ b/Sources/Service/Container+Service.swift
@@ -55,7 +55,7 @@ extension Container {
         } else if available.count == 0 {
             // no services are available matching
             // the type requested.
-            throw ServiceError.noneAvailable(type: interface)
+            throw ServiceError(.noneAvailable(type: interface))
         } else {
             // only one service matches, no need to disambiguate.
             // let's use it!

--- a/Sources/Service/ServiceError.swift
+++ b/Sources/Service/ServiceError.swift
@@ -1,29 +1,40 @@
 import Debugging
 
-public enum ServiceError: Error, Debuggable, Encodable {
-    case multipleInstances(
-        type: Any.Type
-    )
-    case disambiguationRequired(
-        key: String,
-        available: [String],
-        type: Any.Type
-    )
-    case unknownService(
-        available: [String],
-        type: Any.Type
-    )
-    case incorrectType(
-        type: Any.Type,
-        desired: Any.Type
-    )
-    case noneAvailable(type: Any.Type)
-    case unknown(Error)
+public struct ServiceError: Error, Debuggable, Encodable {
+    var problem: Problem
+    
+    init(_ problem: Problem) {
+        self.problem = problem
+    }
+    
+    enum Problem {
+        case other(identifier: String, reason: String)
+        case multipleInstances(
+            type: Any.Type
+        )
+        case disambiguationRequired(
+            key: String,
+            available: [String],
+            type: Any.Type
+        )
+        case unknownService(
+            available: [String],
+            type: Any.Type
+        )
+        case incorrectType(
+            type: Any.Type,
+            desired: Any.Type
+        )
+        case noneAvailable(type: Any.Type)
+        case unknown(Error)
+    }
 }
 
 extension ServiceError {
     public var reason: String {
-        switch self {
+        switch self.problem {
+        case .other(_, let reason):
+            return reason
         case .multipleInstances(let type):
             return "Multiple instances available for '\(type)'. Unable to disambiguate."
         case .noneAvailable(let type):
@@ -40,7 +51,9 @@ extension ServiceError {
     }
 
     public var identifier: String {
-        switch self {
+        switch self.problem {
+        case .other(let identifier, _):
+            return identifier
         case .multipleInstances:
             return "multipleInstances"
         case .noneAvailable:
@@ -57,7 +70,9 @@ extension ServiceError {
     }
 
     public var possibleCauses: [String] {
-        switch self {
+        switch self.problem {
+        case .other(_):
+            return []
         case .multipleInstances:
             return []
         case .noneAvailable:
@@ -76,7 +91,9 @@ extension ServiceError {
     }
 
     public var suggestedFixes: [String] {
-        switch self {
+        switch self.problem {
+        case .other(_):
+            return []
         case .multipleInstances:
             return [
                 "Register instances as service types instead, so they can be disambiguated using config."

--- a/Sources/Vapor/Commands/CommandConfig.swift
+++ b/Sources/Vapor/Commands/CommandConfig.swift
@@ -69,7 +69,7 @@ public struct CommandConfig {
             if let lazy = self.defaultRunnable {
                 try lazy(container).run(using: console, with: input)
             } else {
-                throw "No default command"
+                throw VaporError(identifier: "no-default-command", reason: "There is no default command in Vapor")
             }
         }
     }

--- a/Sources/Vapor/Content/ContentConfig.swift
+++ b/Sources/Vapor/Content/ContentConfig.swift
@@ -28,7 +28,7 @@ public struct ContentConfig {
     /// Returns an encoder for the specified media type or throws an error.
     func requireEncoder(for mediaType: MediaType) throws -> BodyEncoder {
         guard let encoder = encoders[mediaType] else {
-            throw "no encoder for \(mediaType)"
+            throw VaporError(identifier: "encoder-missing", reason: "There is no known encoder for \(mediaType)")
         }
 
         return encoder
@@ -37,7 +37,7 @@ public struct ContentConfig {
     /// Returns a decoder for the specified media type or throws an error.
     func requireDecoder(for mediaType: MediaType) throws -> BodyDecoder {
         guard let decoder = decoders[mediaType] else {
-            throw "no decoder for \(mediaType)"
+            throw VaporError(identifier: "encoder-missing", reason: "There is no known decoder for \(mediaType)")
         }
 
         return decoder

--- a/Sources/Vapor/Content/HTMLEncoder.swift
+++ b/Sources/Vapor/Content/HTMLEncoder.swift
@@ -17,7 +17,7 @@ public final class DataEncoder {
     {
         try encodable.encode(to: encoder)
         guard let data = encoder.data else {
-            throw "no data"
+            throw VaporError(identifier: "encoding-failed", reason: "An unknown error caused the data not to be encoded")
         }
         return data
     }

--- a/Sources/Vapor/Content/Message+Content.swift
+++ b/Sources/Vapor/Content/Message+Content.swift
@@ -41,7 +41,7 @@ extension ContentContainer {
     private func requireDecoder() throws -> BodyDecoder {
         let coders = try container.superContainer.make(ContentConfig.self, for: ContentContainer.self)
         guard let mediaType = mediaType else {
-            throw "no media type"
+            throw VaporError(identifier: "no-media-type", reason: "Cannot decode content without mediatype")
         }
         return try coders.requireDecoder(for: mediaType)
     }

--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -1,3 +1,5 @@
+import HTTP
+
 /// Responds to HTTP requests.
 public protocol Client: Responder {
     /// The container to use for creating requests.
@@ -8,25 +10,84 @@ public protocol Client: Responder {
 
 extension Client {
     /// Sends an HTTP request from the client using the method and url.
-    public func send(_ method: HTTPMethod, to url: String) -> Future<Response> {
+    public func send(
+        _ method: HTTPMethod,
+        headers: HTTPHeaders = [:],
+        to url: URI
+    ) -> Future<Response> {
         return then {
             let req = Request(using: self.container)
             req.http.method = method
-            req.http.uri = URIParser().parse(data: url.data(using: .utf8)!)
+            req.http.uri = url
             return try self.respond(to: req)
         }
     }
 
     /// Sends an HTTP request from the client using the method, url, and content.
-    public func send<C>(_ method: HTTPMethod, to url: String, content: C) -> Future<Response>
-        where C: Content
-    {
+    public func send<C: Content>(
+        _ method: HTTPMethod,
+        headers: HTTPHeaders = [:],
+        to url: URI,
+        content: C
+    ) -> Future<Response> {
         return then {
             let req = Request(using: self.container)
             try req.content.encode(content)
             req.http.method = method
-            req.http.uri = URIParser().parse(data: url.data(using: .utf8)!)
+            req.http.uri = url
             return try self.respond(to: req)
         }
+    }
+}
+
+extension Client {
+    /// Sends a GET request without body
+    public func get(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+        return send(.get, headers: headers, to: url)
+    }
+    
+    /// Sends a GET request with body
+    public func get<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+        return send(.get, headers: headers, to: url, content: content)
+    }
+    
+    /// Sends a PUT request without body
+    public func put(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+        return send(.put, headers: headers, to: url)
+    }
+    
+    /// Sends a GET request with body
+    public func put<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+        return send(.put, headers: headers, to: url, content: content)
+    }
+    
+    /// Sends a PUT request without body
+    public func post(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+        return send(.post, headers: headers, to: url)
+    }
+    
+    /// Sends a POST request with body
+    public func post<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+        return send(.post, headers: headers, to: url, content: content)
+    }
+    
+    /// Sends a POST request without body
+    public func delete(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+        return send(.delete, headers: headers, to: url)
+    }
+    
+    /// Sends a POST request with body
+    public func delete<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+        return send(.delete, headers: headers, to: url, content: content)
+    }
+    
+    /// Sends a PATCH request without body
+    public func patch(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+        return send(.patch, headers: headers, to: url)
+    }
+    
+    /// Sends a PATCH request with body
+    public func patch<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+        return send(.patch, headers: headers, to: url, content: content)
     }
 }

--- a/Tests/LeafTests/Utilities.swift
+++ b/Tests/LeafTests/Utilities.swift
@@ -74,3 +74,5 @@ final class PreloadedFiles: FileReader, FileCache {
         return false
     }
 }
+
+extension String: Error {}

--- a/Tests/LeafTests/Utilities.swift
+++ b/Tests/LeafTests/Utilities.swift
@@ -43,7 +43,7 @@ final class TestFiles: FileReader, FileCache {
     }
 }
 
-final class PreloadedFiles: FileReader, FileCache {†
+final class PreloadedFiles: FileReader, FileCache {
     var files: [String: Data]
     init() {
         files = [:]
@@ -72,7 +72,7 @@ final class PreloadedFiles: FileReader, FileCache {†
 
     func fileExists(at path: String) -> Bool {
         return false
-    }∂
+    }
 }
 
 extension String: Error {}

--- a/Tests/LeafTests/Utilities.swift
+++ b/Tests/LeafTests/Utilities.swift
@@ -43,7 +43,7 @@ final class TestFiles: FileReader, FileCache {
     }
 }
 
-final class PreloadedFiles: FileReader, FileCache {
+final class PreloadedFiles: FileReader, FileCache {†
     var files: [String: Data]
     init() {
         files = [:]
@@ -72,7 +72,7 @@ final class PreloadedFiles: FileReader, FileCache {
 
     func fileExists(at path: String) -> Bool {
         return false
-    }
+    }∂
 }
 
 extension String: Error {}

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -14,7 +14,7 @@ class RedisTests: XCTestCase {
     
     var clientCount = 0
     
-    func makeClient() throws -> RedisClient {
+    func makeClient() throws -> Future<RedisClient> {
         let queue = DispatchQueue(label: "test.kaas.\(clientCount)")
         clientCount += 1
         return try RedisClient.connect(

--- a/Tests/RedisTests/RedisTests.swift
+++ b/Tests/RedisTests/RedisTests.swift
@@ -24,7 +24,7 @@ class RedisTests: XCTestCase {
     }
     
     func testCRUD() throws {
-        let connection = try makeClient()
+        let connection = try makeClient().blockingAwait()
       
         _ = try! connection.delete(keys: ["*"]).blockingAwait(timeout: .seconds(2))
         
@@ -42,13 +42,13 @@ class RedisTests: XCTestCase {
     func testPubSub() throws {
         let promise = Promise<RedisData>()
         
-        let listener = try makeClient()
+        let listener = try makeClient().blockingAwait()
         
         listener.subscribe(to: ["test", "test2"]).drain { data in
             promise.complete(data.message)
         }.catch(onError: promise.fail)
         
-        let publisher = try makeClient()
+        let publisher = try makeClient().blockingAwait()
         let listeners = try publisher.publish("hello", to: "test").blockingAwait(timeout: .seconds(1))
         
         XCTAssertEqual(listeners, 1)
@@ -62,7 +62,7 @@ class RedisTests: XCTestCase {
     }
     
     func testPipeline() throws {
-        let connection = try makeClient()
+        let connection = try makeClient().blockingAwait()
         _ = try connection.delete(keys: ["*"]).blockingAwait(timeout: .seconds(1))
         
         let pipeline = connection.makePipeline()


### PR DESCRIPTION
Done

- Removes the Strings as Error type
- Cleans up the HTTP parser
- Sends the "Host" header in EngineClient

TODO: 

- Can work with connections that close to indicate an end of Body
- Can work with streaming (chunked) bodies
- Can work with octet streams