### PR TITLE
Connection pool retain is discardableResult

### DIFF
--- a/Sources/MySQL/Connection/ConnectionPool.swift
+++ b/Sources/MySQL/Connection/ConnectionPool.swift
@@ -79,6 +79,7 @@ public final class MySQLConnectionPool {
     /// Retained connections can only be used for a single query at a time
     ///
     ///
+    @discardableResult
     public func retain<T>(_ handler: @escaping ((MySQLConnection) -> Future<T>)) -> Future<T> {
         let promise = Promise<ConnectionPair>()
         


### PR DESCRIPTION
allows me to do:
```Swift
worker.pool.retain { connection in
        connection.administrativeQuery("DROP TABLE users")
}
```
without warning on `let _ = worker.pool`