### PR TITLE
[WIP] - Add support for autocomplete

### DIFF
--- a/Sources/Command/Autocomplete.swift
+++ b/Sources/Command/Autocomplete.swift
@@ -1,0 +1,49 @@
+import Console
+
+extension OutputConsole {
+    /// Outputs autocomplete for a command.
+    public func outputAutocomplete(for runnable: Runnable, executable: String) throws {
+        var names = runnable.options.map { $0.name }
+        if let group = runnable as? Group {
+            names += group.commands.keys
+        }
+        if let command = runnable as? Command {
+            names += command.arguments.map { $0.name }
+        }
+        
+        if let command = runnable as? Command {
+            if command.arguments.count > 0 {
+                for arg in command.arguments {
+                    outputAutocompleteListItem(
+                        name: arg.name,
+                        prefix: ""
+                    )
+                }
+            }
+        }
+        
+        if let group = runnable as? Group {
+            if group.commands.count > 0 {
+                for (key, runnable) in group.commands {
+                    outputAutocompleteListItem(
+                        name: key,
+                        prefix: ""
+                    )
+                }
+            }
+        }
+        
+        if runnable.options.count > 0 {
+            for opt in runnable.options {
+                outputAutocompleteListItem(
+                    name: opt.name,
+                    prefix: "--"
+                )
+            }
+        }
+    }
+    
+    private func outputAutocompleteListItem(name: String, prefix: String) {
+        output(prefix + name + " ", style: .plain, newLine: false)
+    }
+}

--- a/Sources/Command/Command.swift
+++ b/Sources/Command/Command.swift
@@ -24,7 +24,7 @@ public protocol Runnable {
 
     /// Text that will be displayed when `--help` is passed.
     var help: [String] { get }
-
+    
     /// Runs the command against the supplied input.
     func run(using console: Console, with input: Input) throws
 }

--- a/Sources/Command/Run.swift
+++ b/Sources/Command/Run.swift
@@ -28,6 +28,8 @@ extension Console {
 
         if input.options["help"]?.bool == true {
             try outputHelp(for: runnable, executable: input.executable)
+        } else if input.options["autocomplete"]?.bool == true {
+            try outputAutocomplete(for: runnable, executable: input.executable)
         } else {
             let arguments: [Argument]
             if let command = runnable as? Command {

--- a/Sources/Command/Signature.swift
+++ b/Sources/Command/Signature.swift
@@ -26,7 +26,7 @@ public struct Option {
 
     /// The option's help text when `--help` is passed.
     public let help: [String]
-
+    
     /// The option's default value, if supplied
     public let `default`: String?
 

--- a/Tests/CommandTests/CommandTests.swift
+++ b/Tests/CommandTests/CommandTests.swift
@@ -9,6 +9,15 @@ class CommandTests: XCTestCase {
 
         try! console.run(group, arguments: ["vapor", "sub", "test", "--help"])
         print(console.output)
+        
+        try! console.run(group, arguments: ["vapor", "--autocomplete"])
+        print(console.output)
+        
+        try! console.run(group, arguments: ["vapor", "sub", "--autocomplete"])
+        print(console.output)
+        
+        try! console.run(group, arguments: ["vapor", "sub", "test", "--autocomplete"])
+        print(console.output)
     }
 
     static var allTests = [


### PR DESCRIPTION
Adding support for `--autocomplete`

This command will output one string with commands, arguments and options in one line to support Bash and zsh autocomplete

Todo:

- [X] Implement autocomplete
- [X] Unit tests
- [ ] Test in a real life example
- [ ] Include Bash autocomplete example
- [ ] Include zsh autocomplete example