### PR TITLE
[vapor 3] A model with at least 17 fields is not able to generate keyStringMap from dictionary literal.

### DIFF
--- a/Sources/JunkDrawer/Key/KeyStringMap.swift
+++ b/Sources/JunkDrawer/Key/KeyStringMap.swift
@@ -11,6 +11,27 @@ public struct KeyStringMap: ExpressibleByDictionaryLiteral {
 
     /// See ExpressibleByDictionaryLiteral
     public init(dictionaryLiteral elements: (Key, String)...) {
+        self.init(keys: elements)
+    }
+
+    /// When there are too much keys, Swift won't be able to infer dictionary literal as KeyStringMap.
+    ///
+    /// When Swift fails to infer it, the error looks like:
+    /// "Expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions"
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// static var keyStringMap: KeyStringMap {
+    ///   let keys: [(Key, String)] = [
+    ///       (key(\.id), "id"),
+    ///       // ... other keys
+    ///   ]
+    ///
+    ///   return KeyStringMap(keys: keys)
+    /// }
+    /// ```
+    public init(keys elements: [(Key, String)]) {
         self.storage = [:]
         for (key, string) in elements {
             storage[key.path] = KeyString(key: key, string: string)


### PR DESCRIPTION
I was having a problem where Swift couldn't infer the dictionary because it was taking too long.
Adding another init method so I'm able to construct KeyStringMap without relying on Swift's inference.