### PR TITLE
Made UUID conform to Parameter.

### DIFF
--- a/Sources/Routing/Parameter.swift
+++ b/Sources/Routing/Parameter.swift
@@ -156,3 +156,14 @@ extension UInt64: Parameter {
     }
 }
 
+extension UUID: Parameter {
+    /// Attempts to read the parameter into a `UUID`
+    public static func make(for parameter: String, using container: Container) throws -> UUID {
+        guard let uuid = UUID(uuidString: parameter) else {
+            throw RoutingError(identifier: "parameterNotAUUID", reason: "The parameter was not convertible to a UUID")
+        }
+
+        return uuid
+    }
+}
+


### PR DESCRIPTION
Working with `UUID` is important because Fluent likes them as keys, but it's annoying for two very small reasons. First, this is not possible:

    router.get("polls", UUID.parameter) { req in

Second, even if you use a string in that route, you still can't write this:

    let id = try req.parameter(UUID.self)

Making `UUID` conform to `Parameter` resolves these problems neatly.