### PR TITLE
Unsigned int validation

### DIFF
--- a/Sources/Validation/ValidationData.swift
+++ b/Sources/Validation/ValidationData.swift
@@ -42,10 +42,66 @@ extension Int: ValidationDataRepresentable {
     }
 }
 
+extension Int8: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .int(Int(self))
+    }
+}
+
+extension Int16: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .int(Int(self))
+    }
+}
+
+extension Int32: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .int(Int(self))
+    }
+}
+
+extension Int64: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .int(Int(self))
+    }
+}
+
 extension UInt: ValidationDataRepresentable {
     /// See ValidationDataRepresentable.makeValidationData
     public func makeValidationData() -> ValidationData {
         return .uint(self)
+    }
+}
+
+extension UInt8: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .uint(UInt(self))
+    }
+}
+
+extension UInt16: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .uint(UInt(self))
+    }
+}
+
+extension UInt32: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .uint(UInt(self))
+    }
+}
+
+extension UInt64: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .uint(UInt(self))
     }
 }
 

--- a/Sources/Validation/ValidationData.swift
+++ b/Sources/Validation/ValidationData.swift
@@ -7,6 +7,7 @@ public enum ValidationData {
     case uint(UInt)
     case bool(Bool)
     case data(Data)
+    case date(Date)
     case double(Double)
     case array([ValidationData])
     case dictionary([String: ValidationData])
@@ -116,6 +117,13 @@ extension Data: ValidationDataRepresentable {
     /// See ValidationDataRepresentable.makeValidationData
     public func makeValidationData() -> ValidationData {
         return .data(self)
+    }
+}
+
+extension Date: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .date(self)
     }
 }
 

--- a/Sources/Validation/ValidationData.swift
+++ b/Sources/Validation/ValidationData.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum ValidationData {
     case string(String)
     case int(Int)
+    case uint(UInt)
     case bool(Bool)
     case data(Data)
     case double(Double)
@@ -38,6 +39,13 @@ extension Int: ValidationDataRepresentable {
     /// See ValidationDataRepresentable.makeValidationData
     public func makeValidationData() -> ValidationData {
         return .int(self)
+    }
+}
+
+extension UInt: ValidationDataRepresentable {
+    /// See ValidationDataRepresentable.makeValidationData
+    public func makeValidationData() -> ValidationData {
+        return .uint(self)
     }
 }
 

--- a/Sources/Validation/Validators/IsCount.swift
+++ b/Sources/Validation/Validators/IsCount.swift
@@ -1,6 +1,8 @@
+import Foundation
+
 /// Validates whether the data is within a supplied int range.
-/// note: strings have length checked, while integers have their values checked
-public struct IsCount<T>: Validator where T: BinaryInteger {
+/// note: strings have length checked, while integers, doubles, and dates have their values checked
+public struct IsCount<T>: Validator where T: Comparable {
     /// See Validator.inverseMessage
     public var inverseMessage: String {
         if let min = self.min, let max = self.max {
@@ -24,7 +26,7 @@ public struct IsCount<T>: Validator where T: BinaryInteger {
 
     /// creates an is count validator using a predefined int range
     ///     1...5
-    public init(_ range: Range<T>) {
+    public init(_ range: ClosedRange<T>) {
         self.min = range.lowerBound
         self.max = range.upperBound
     }
@@ -36,67 +38,114 @@ public struct IsCount<T>: Validator where T: BinaryInteger {
         self.min = nil
     }
 
-    /// creates an is count validator using a partial range up to
-    ///     ..<5
-    public init(_ range: PartialRangeUpTo<T>) {
-        self.max = range.upperBound - 1
-        self.min = nil
-    }
-
     /// creates an is count validator using a partial range from
     ///     5...
     public init(_ range: PartialRangeFrom<T>) {
         self.max = nil
         self.min = range.lowerBound
     }
-
+    
     /// See Validator.validate
     public func validate(_ data: ValidationData) throws {
         switch data {
         case .string(let s):
-            if let min = self.min {
+            if let min = self.min as? Int {
                 guard s.count >= min else {
                     throw BasicValidationError("is not at least \(min) characters")
                 }
+            } else if let min = self.min as? String {
+                guard s >= min else {
+                    throw BasicValidationError("is not alphabetically equal to or later than \(min) characters")
+                }
             }
-            if let max = self.max {
+
+            if let max = self.max as? Int {
                 guard s.count <= max else {
                     throw BasicValidationError("is more than \(max) characters")
                 }
+            } else if let max = self.max as? String {
+                guard s <= max else {
+                    throw BasicValidationError("is not alphabetically equal to or before \(max) characters")
+                }
             }
         case .int(let int):
-            if let min = self.min {
+            if let min = self.min as? Int {
+                guard int >= min else {
+                    throw BasicValidationError("is not larger than \(min)")
+                }
+            } else if let min = self.min as? UInt {
                 guard int >= min else {
                     throw BasicValidationError("is not larger than \(min)")
                 }
             }
-            if let max = self.max {
+            if let max = self.max as? Int {
+                guard int <= max else {
+                    throw BasicValidationError("is larger than \(max)")
+                }
+            } else if let max = self.max as? UInt {
                 guard int <= max else {
                     throw BasicValidationError("is larger than \(max)")
                 }
             }
         case .uint(let uint):
-            if let min = self.min {
+            if let min = self.min as? Int {
+                guard uint >= min else {
+                    throw BasicValidationError("is not larger than \(min)")
+                }
+            } else if let min = self.min as? UInt {
                 guard uint >= min else {
                     throw BasicValidationError("is not larger than \(min)")
                 }
             }
-            if let max = self.max {
+            if let max = self.max as? Int {
+                guard uint <= max else {
+                    throw BasicValidationError("is larger than \(max)")
+                }
+            } else if let max = self.max as? UInt {
                 guard uint <= max else {
                     throw BasicValidationError("is larger than \(max)")
                 }
             }
+        case .double(let double):
+            if let min = self.min as? Double {
+                guard double >= min else {
+                    throw BasicValidationError("is not larger than \(min)")
+                }
+            }
+            if let max = self.max as? Double {
+                guard double <= max else {
+                    throw BasicValidationError("is larger than \(max)")
+                }
+            }
+        case .date(let date):
+            if let earliest = self.min as? Date {
+                guard date >= earliest else {
+                    throw BasicValidationError("is not equal to or later than \(earliest)")
+                }
+            }
+            if let latest = self.max as? Date {
+                guard date <= latest else {
+                    throw BasicValidationError("is not equal to or earlier than \(latest)")
+                }
+            }
+            break
         default:
             throw BasicValidationError("is invalid")
         }
     }
 }
 
-extension IsCount where T.Stride: SignedInteger {
+/// - TODO: The conditional conformance here would not be necessary if the
+/// validator instead tracked whether the range it was created with was closed
+/// or open, and chose whether to use `<` and `>` or `<=` and `>=` on that
+/// basis. That would be the most correct and flexible solution. However, the
+/// vast majority of ranges are `Strideable` so this lazy solution is used to
+/// avoid making the validator's code _considerably_ more complicated, for now.
+extension IsCount where T: Strideable {
     /// creates an is count validator using a predefined int range
-    ///     1...5
-    public init(_ range: CountableClosedRange<T>) {
+    ///     1..<5
+    public init(_ range: Range<T>) {
         self.min = range.lowerBound
-        self.max = range.upperBound
+        self.max = range.upperBound.advanced(by: -1)
     }
 }

--- a/Sources/Validation/Validators/IsCount.swift
+++ b/Sources/Validation/Validators/IsCount.swift
@@ -1,6 +1,6 @@
 /// Validates whether the data is within a supplied int range.
 /// note: strings have length checked, while integers have their values checked
-public struct IsCount: Validator {
+public struct IsCount<T>: Validator where T: BinaryInteger {
     /// See Validator.inverseMessage
     public var inverseMessage: String {
         if let min = self.min, let max = self.max {
@@ -16,36 +16,36 @@ public struct IsCount: Validator {
 
     /// the minimum possible value, if nil, not checked
     /// note: inclusive
-    public let min: Int?
+    public let min: T?
 
     /// the maximum possible value, if nil, not checked
     /// note: inclusive
-    public let max: Int?
+    public let max: T?
 
     /// creates an is count validator using a predefined int range
     ///     1...5
-    public init(_ range: Range<Int>) {
+    public init(_ range: Range<T>) {
         self.min = range.lowerBound
         self.max = range.upperBound
     }
 
     /// creates an is count validator using a partial range through
     ///     ...5
-    public init(_ range: PartialRangeThrough<Int>) {
+    public init(_ range: PartialRangeThrough<T>) {
         self.max = range.upperBound
         self.min = nil
     }
 
     /// creates an is count validator using a partial range up to
     ///     ..<5
-    public init(_ range: PartialRangeUpTo<Int>) {
+    public init(_ range: PartialRangeUpTo<T>) {
         self.max = range.upperBound - 1
         self.min = nil
     }
 
-    /// creates an is coutn validator using a partial range from
+    /// creates an is count validator using a partial range from
     ///     5...
-    public init(_ range: PartialRangeFrom<Int>) {
+    public init(_ range: PartialRangeFrom<T>) {
         self.max = nil
         self.min = range.lowerBound
     }
@@ -75,8 +75,28 @@ public struct IsCount: Validator {
                     throw BasicValidationError("is larger than \(max)")
                 }
             }
+        case .uint(let uint):
+            if let min = self.min {
+                guard uint >= min else {
+                    throw BasicValidationError("is not larger than \(min)")
+                }
+            }
+            if let max = self.max {
+                guard uint <= max else {
+                    throw BasicValidationError("is larger than \(max)")
+                }
+            }
         default:
             throw BasicValidationError("is invalid")
         }
+    }
+}
+
+extension IsCount where T.Stride: SignedInteger {
+    /// creates an is count validator using a predefined int range
+    ///     1...5
+    public init(_ range: CountableClosedRange<T>) {
+        self.min = range.lowerBound
+        self.max = range.upperBound
     }
 }

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -5,48 +5,45 @@ class ValidationTests: XCTestCase {
     func testValidate() throws {
         let user = User(name: "Tanner", age: 23)
         user.child = User(name: "Zizek Pulaski", age: 3)
-        do {
-            try user.validate()
-        } catch {
-            XCTFail("\(error)")
-        }
+        try user.validate()
     }
 
     func testASCII() throws {
         try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))
-        do {
-            try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQR🤠STUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))
-            XCTFail()
-        } catch is ValidationError {
-            // pass
+        XCTAssertThrowsError(try IsASCII().validate(.string("ABCDEFGHIJKLMNOPQR🤠STUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))) {
+            XCTAssert($0 is ValidationError)
         }
     }
 
     func testAlphanumeric() throws {
         try IsAlphanumeric().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
-        do {
-            try IsAlphanumeric().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))
-            XCTFail()
-        } catch is ValidationError {
-            // pass
+        XCTAssertThrowsError(try IsAlphanumeric().validate(.string("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"))) {
+            XCTAssert($0 is ValidationError)
         }
     }
 
     func testEmail() throws {
         try IsEmail().validate(.string("tanner@vapor.codes"))
-        do {
-            try IsEmail().validate(.string("asdf"))
-            XCTFail()
-        } catch is ValidationError {
-            // pass
-        }
+        XCTAssertThrowsError(try IsEmail().validate(.string("asdf"))) { XCTAssert($0 is ValidationError) }
     }
+    
+    func testCount() throws {
+        try IsCount(-5...5).validate(.int(4))
+        XCTAssertThrowsError(try IsCount(-5...5).validate(.int(6))) { XCTAssert($0 is ValidationError) }
+        
+        try IsCount(5...).validate(.uint(UInt.max))
+        try IsCount(...(UInt.max - 100)).validate(.int(Int.min))
 
+        try IsCount(-5...5).validate(.uint(4))
+        XCTAssertThrowsError(try IsCount(-5...5).validate(.uint(6))) { XCTAssert($0 is ValidationError) }
+    }
+    
     static var allTests = [
         ("testValidate", testValidate),
         ("testASCII", testASCII),
         ("testAlphanumeric", testAlphanumeric),
         ("testEmail", testEmail),
+        ("testCount", testCount),
     ]
 }
 

--- a/Tests/ValidationTests/ValidationTests.swift
+++ b/Tests/ValidationTests/ValidationTests.swift
@@ -29,13 +29,24 @@ class ValidationTests: XCTestCase {
     
     func testCount() throws {
         try IsCount(-5...5).validate(.int(4))
+        try IsCount(-5...5).validate(.int(5))
+        try IsCount(-5...5).validate(.int(-5))
         XCTAssertThrowsError(try IsCount(-5...5).validate(.int(6))) { XCTAssert($0 is ValidationError) }
-        
+        XCTAssertThrowsError(try IsCount(-5...5).validate(.int(-6))) { XCTAssert($0 is ValidationError) }
+
         try IsCount(5...).validate(.uint(UInt.max))
         try IsCount(...(UInt.max - 100)).validate(.int(Int.min))
+        
+        XCTAssertThrowsError(try IsCount(...Int.max).validate(.uint(UInt.max))) { XCTAssert($0 is ValidationError) }
 
         try IsCount(-5...5).validate(.uint(4))
         XCTAssertThrowsError(try IsCount(-5...5).validate(.uint(6))) { XCTAssert($0 is ValidationError) }
+        
+        try IsCount(-5..<6).validate(.int(-5))
+        try IsCount(-5..<6).validate(.int(-4))
+        try IsCount(-5..<6).validate(.int(5))
+        XCTAssertThrowsError(try IsCount(-5..<6).validate(.int(-6))) { XCTAssert($0 is ValidationError) }
+        XCTAssertThrowsError(try IsCount(-5..<6).validate(.int(6))) { XCTAssert($0 is ValidationError) }
     }
     
     static var allTests = [


### PR DESCRIPTION
Add explicit validation for unsigned integers (supporting the full range of unsigned values instead of forcing it to be limited to signed ranges)

Also fixes an issue where creating an `IsCount()` validator with a closed range (e.g. `1...5`) didn't work because the compiler won't convert `ClosedCountableRange<T>` to `Range<T>`