### PR TITLE
Vapor 3 Middleware not Configurable #1371

### DIFF
--- a/Sources/Vapor/Middleware/MiddlewareConfig.swift
+++ b/Sources/Vapor/Middleware/MiddlewareConfig.swift
@@ -37,8 +37,10 @@ public struct MiddlewareConfig {
 extension MiddlewareConfig {
     /// Resolves the desired middleware for a given container
     internal func resolve(for container: Container) throws -> [Middleware] {
-        return try storage.map { lazy in
+        let r = try storage.map { lazy in
             return try lazy(container)
         }
+        print(r)
+        return r
     }
 }

--- a/Sources/Vapor/Middleware/MiddlewareConfig.swift
+++ b/Sources/Vapor/Middleware/MiddlewareConfig.swift
@@ -37,10 +37,8 @@ public struct MiddlewareConfig {
 extension MiddlewareConfig {
     /// Resolves the desired middleware for a given container
     internal func resolve(for container: Container) throws -> [Middleware] {
-        let r = try storage.map { lazy in
+        return try storage.map { lazy in
             return try lazy(container)
         }
-        print(r)
-        return r
     }
 }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -109,22 +109,23 @@ extension Services {
         services.register(Console.self) { container in
             return Terminal()
         }
-        services.register(Responder.self) { container in
-            return try RouterResponder(
+        services.register(Responder.self) { container -> Responder in
+            let middleware = try container
+                .make(MiddlewareConfig.self, for: ServeCommand.self)
+                .resolve(for: container)
+
+            let router = try RouterResponder(
                 router: container.make(for: Responder.self)
             )
+            return middleware.makeResponder(chainedto: router)
         }
 
         services.register { worker -> ServeCommand in
             let responder = try worker.make(Responder.self, for: ServeCommand.self)
 
-            let middleware = try worker
-                .make(MiddlewareConfig.self, for: ServeCommand.self)
-                .resolve(for: worker)
-
             return try ServeCommand(
                 server: worker.make(for: ServeCommand.self),
-                responder: middleware.makeResponder(chainedto: responder)
+                responder: responder
             )
         }
         services.register { container -> CommandConfig in

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -1,127 +1,31 @@
-import Async
-import Bits
-import Dispatch
-import HTTP
-import TCP
 import Vapor
 import XCTest
 
 class MiddlewareTests : XCTestCase {
-    func testMiddleware() throws {
-//        let server = EmitterStream<Request>()
-//
-//        let group = DispatchGroup()
-//        group.enter()
-//        let closure = TestApp { req in
-//            XCTAssertEqual(req.http.headers["foo"], "bar")
-//            group.leave()
-//        }
-//
-//        let app = try Application()
-//
-//        let middlewares = [TestMiddleware(), TestMiddleware()]
-//        let r = middlewares
-//            .makeResponder(chainedto: closure)
-//        let responder = ResponderStream(responder: r, on: app, using: app)
-//
-//        group.enter()
-//        server.stream(to: responder).drain { res in
-//            XCTAssertEqual(res.headers["baz"], "bar")
-//            group.leave()
-//        }.catch { XCTFail("\($0)") }
-//
-//        let req = Request(on: app, using: app)
-//        server.emit(req)
-//        group.wait()
-    }
+    // https://github.com/vapor/vapor/issues/1371
+    func testNotConfigurable() throws {
+        final class MyMiddleware: Middleware {
+            var flag = false
+            func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
+                flag = true
+                return try next.respond(to: request)
+            }
+        }
 
-    func testClientServer() throws {
-//        let responder = HelloWorldResponder()
-//
-//        let serverSocket = try TCPServer()
-//        let server = HTTPServer(socket: serverSocket)
-//        server.drain { peer in
-//            let parser = HTTP.RequestParser(on: peer.tcp.worker, maxSize: 100_000)
-//
-//            let responderStream = responder.makeStream()
-//            let serializer = HTTP.ResponseSerializer()
-//
-//            peer.stream(to: parser)
-//                .stream(to: responderStream)
-//                .stream(to: serializer)
-//                .stream(to: peer)
-//
-//            peer.tcp.start()
-//        }.catch { XCTFail("\($0)") }
-//
-//        try serverSocket.start(port: 1234)
-//
-//        var socket = try TCPSocket()
-//        try socket.connect(hostname: "0.0.0.0", port: 1234)
-//
-//        let tcpClient = TCPClient.init(socket: socket, worker: Worker(queue: .global()))
-//        let client = HTTPClient(socket: tcpClient)
-//        tcpClient.start()
-//
-//        let response = try client.send(request: Request()).blockingAwait(timeout: .seconds(3))
-//
-//        try response.body.withUnsafeBytes { (pointer: BytesPointer) in
-//            let buffer = ByteBuffer(start: pointer, count: response.body.count ?? 0)
-//            XCTAssertEqual(Data(buffer), Data(responder.response.utf8))
-//        }
+        let myMiddleware = MyMiddleware()
+        var services = Services.default()
+        var middlewareConfig = MiddlewareConfig()
+        middlewareConfig.use(myMiddleware)
+        services.instance(middlewareConfig)
+
+        let app = try Application(services: services)
+
+        let req = Request(http: .init(), using: app)
+        _ = try app.make(Responder.self).respond(to: req).blockingAwait()
+        XCTAssert(myMiddleware.flag == true)
     }
 
     static let allTests = [
-        ("testMiddleware", testMiddleware),
-        ("testClientServer", testClientServer)
+        ("testNotConfigurable", testNotConfigurable),
     ]
 }
-
-///// Test application that passes all incoming
-///// requests through a closure for testing
-//final class TestApp: Responder {
-//    let closure: (Request) -> ()
-//
-//    init(closure: @escaping (Request) -> ()) {
-//        self.closure = closure
-//    }
-//
-//    func respond(to req: Request) throws -> Future<Response> {
-//        closure(req)
-//        return Future(Response())
-//    }
-//}
-
-/// Test middleware that sets req and res headers.
-//final class TestMiddleware: Middleware {
-//    func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
-//        request.headers["foo"] = "bar"
-//
-//        let promise = Promise<Response>()
-//
-//        try next.respond(to: request).do { res in
-//            res.headers["baz"] = "bar"
-//            promise.complete(res)
-//        }.catch { error in
-//            promise.fail(error)
-//        }
-//
-//        return promise.future
-//    }
-//}
-//struct HelloWorldResponder: Responder, ExpressibleByStringLiteral {
-//    init(stringLiteral value: String) {
-//        self.response = value
-//    }
-//    
-//    init() {}
-//    
-//    var response = "Hello world"
-//    
-//    func respond(to req: Request) throws -> Future<Response> {
-//        let response = try Response(body: self.response)
-//        
-//        return Future(response)
-//    }
-//}
-


### PR DESCRIPTION
adds a test case for #1371. this issue appears to have been resolved already. likely due to removing overloads of `service.register` to `service.instance` and `service.provider`

this pr also moves middleware chaining to calls to make `Responder` instead of `ServeCommand` which makes more sense.