### PR TITLE
Add explicit type parameter to decodeJSONBody

### DIFF
--- a/Sources/Vapor/JSON/HTTP/Message+Codable.swift
+++ b/Sources/Vapor/JSON/HTTP/Message+Codable.swift
@@ -13,8 +13,8 @@ public extension HTTP.Message {
         headers[.contentType] = "application/json; charset=utf-8"
     }
 
-    public func decodeJSONBody<T: Decodable>(using decoder: JSONDecoder = JSONDecoder()) throws -> T {
-        return try decoder.decode(T.self, from: Data(bytes: body.bytes ?? []))
+    public func decodeJSONBody<T: Decodable>(_ type: T.Type = T.self, using decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        return try decoder.decode(type, from: Data(bytes: body.bytes ?? []))
     }
 }
 #endif

--- a/Tests/VaporTests/CodableTests.swift
+++ b/Tests/VaporTests/CodableTests.swift
@@ -28,6 +28,17 @@ class CodableTests: XCTestCase {
         XCTAssertEqual(model.opt, "test")
     }
 
+    func testDecodeJSONBodyWithExplicitType() throws {
+        let request = Request(method: .post, path: "/")
+        let rawJSON = "{ \"foo\": \"qux\", \"baz\": 4237846, \"opt\": \"test\" }".makeBytes()
+
+        request.body = Body.data(rawJSON)
+        let model = try request.decodeJSONBody(TestModel.self)
+        XCTAssertEqual(model.foo, "qux")
+        XCTAssertEqual(model.baz, 4237846)
+        XCTAssertEqual(model.opt, "test")
+    }
+
     func testDecodeJSONBodyInterop() throws {
         let request = Request(method: .post, path: "/")
         request.json = ["foo": "bar", "baz": 123]
@@ -83,6 +94,7 @@ class CodableTests: XCTestCase {
 
     static let allTests: [(String, (CodableTests) -> () throws -> ())] = [
         ("testDecodeJSONBodyRaw", testDecodeJSONBodyRaw),
+        ("testDecodeJSONBodyWithExplicitType", testDecodeJSONBodyWithExplicitType),
         ("testDecodeJSONBodyInterop", testDecodeJSONBodyInterop),
         ("testDecodeFailsWithMissingField", testDecodeFailsWithMissingField),
         ("testEncodeJSONBodyInterop", testEncodeJSONBodyInterop),


### PR DESCRIPTION
I felt like I was forgetting something when making the Codable extensions. Now I figured it out.

This PR adds a new `type` parameter to decodeJSONBody, which makes it possible to simply specify the target type instead of abusing the compiler's inference (for example, specifying the local variable's type everywhere). This style is more natural and can be found in Foundation already.

---

This change is additive and non-breaking, as code written for 2.4.0 will compile and work fine using the default argument. The previous tests for decodeJSONBody are the living proof.