### PR TITLE
simplify router closure return

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -233,8 +233,8 @@ do {
         return Future(res)
     }
 
-    router.get("123") { req -> Future<String> in
-        return Future("123")
+    router.get("123") { req in
+        return "123"
     }
 //
 //    router.get("hello") { req in

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -17,15 +17,17 @@ extension Content {
     }
 
     /// See RequestEncodable.encode
-    public func encode(to req: inout Request) throws -> Future<Void> {
+    public func encode(using container: Container) throws -> Future<Request> {
+        let req = Request(using: container)
         try req.content.encode(self)
-        return .done
+        return Future(req)
     }
 
     /// See ResponseEncodable.encode
-    public func encode(to res: inout Response, for req: Request) throws -> Future<Void> {
+    public func encode(for req: Request) throws -> Future<Response> {
+        let res = req.makeResponse()
         try res.content.encode(self)
-        return .done
+        return Future(res)
     }
 
     /// See RequestDecodable.decode

--- a/Sources/Vapor/Engine/RequestCodable.swift
+++ b/Sources/Vapor/Engine/RequestCodable.swift
@@ -5,7 +5,7 @@ public protocol RequestDecodable {
 
 /// Can be converted to a request
 public protocol RequestEncodable {
-    func encode(to req: inout Request) throws -> Future<Void>
+    func encode(using container: Container) throws -> Future<Request>
 }
 
 /// Can be converted from and to a request
@@ -14,9 +14,8 @@ public typealias RequestCodable = RequestDecodable & RequestEncodable
 // MARK: Request Conformance
 
 extension Request: RequestEncodable {
-    public func encode(to req: inout Request) throws -> Future<Void> {
-        req = self
-        return .done
+    public func encode(using container: Container) throws -> Future<Request> {
+        return Future(self)
     }
 }
 

--- a/Sources/Vapor/Engine/Responder.swift
+++ b/Sources/Vapor/Engine/Responder.swift
@@ -11,7 +11,7 @@ public struct RouteResponder<T>: Responder
     where T: ResponseEncodable
 {
     /// Responder closure
-    public typealias Closure = (Request) throws -> Future<T>
+    public typealias Closure = (Request) throws -> T
 
     /// The stored responder closure.
     public let closure: Closure
@@ -23,12 +23,8 @@ public struct RouteResponder<T>: Responder
 
     /// See: HTTP.Responder.respond
     public func respond(to req: Request) throws -> Future<Response> {
-        return try closure(req).flatMap(to: Response.self) { rep in
-            var res = req.makeResponse()
-            return try rep.encode(to: &res, for: req).map(to: Response.self) {
-                return res
-            }
-        }
+        let encodable = try closure(req)
+        return try encodable.encode(for: req)
     }
 }
 

--- a/Sources/Vapor/Engine/ResponseCodable.swift
+++ b/Sources/Vapor/Engine/ResponseCodable.swift
@@ -10,7 +10,7 @@ public protocol ResponseDecodable {
 /// [Learn More →](https://docs.vapor.codes/3.0/http/response/#responserepresentable)
 public protocol ResponseEncodable {
     /// Makes a response using the context provided by the HTTPRequest
-    func encode(to res: inout Response, for req: Request) throws -> Future<Void>
+    func encode(for req: Request) throws -> Future<Response>
 }
 
 /// Can be converted from and to a response
@@ -20,18 +20,16 @@ public typealias ResponseCodable = ResponseDecodable & ResponseEncodable
 
 extension Response: ResponseEncodable {
     /// See ResponseRepresentable.makeResponse
-    public func encode(to res: inout Response, for req: Request) throws -> Future<Void> {
-        res = self
-        return .done
+    public func encode(for req: Request) throws -> Future<Response> {
+        return Future(self)
     }
 }
 
 extension HTTPResponse: ResponseEncodable {
     /// See ResponseRepresentable.makeResponse
-    public func encode(to res: inout Response, for req: Request) throws -> Future<Void> {
+    public func encode(for req: Request) throws -> Future<Response> {
         let new = req.makeResponse()
         new.http = self
-        res = new
-        return .done
+        return Future(new)
     }
 }

--- a/Sources/Vapor/Routing/Router+Method.swift
+++ b/Sources/Vapor/Routing/Router+Method.swift
@@ -19,6 +19,23 @@ extension Router {
     }
 }
 
+extension Future: ResponseEncodable {
+    /// See ResponseEncodable.encode
+    public func encode(for req: Request) throws -> Future<Response> {
+        return flatMap(to: Response.self) { exp in
+            guard let encodable = exp as? ResponseEncodable else {
+                throw VaporError(
+                    identifier: "futureResponseEncodable",
+                    reason: "`Future<\(Expectation.self)>` is not `ResponseEncodable` because `\(Expectation.self)` is not `ResponseEncodable`."
+                )
+            }
+
+            return try encodable.encode(for: req)
+        }
+    }
+
+
+}
 
 extension Router {
     /// Creates a `Route` at the provided path using the `GET` method.

--- a/Sources/Vapor/Utilities/AnyResponse.swift
+++ b/Sources/Vapor/Utilities/AnyResponse.swift
@@ -12,7 +12,7 @@ public struct AnyResponse: ResponseEncodable {
     }
 
     /// Encodes the response
-    public func encode(to res: inout Response, for req: Request) throws -> Future<Void> {
-        return try encodable.encode(to: &res, for: req)
+    public func encode(for req: Request) throws -> Future<Response> {
+        return try encodable.encode(for: req)
     }
 }


### PR DESCRIPTION
Since we no longer rely on generic `FutureType`, we can greatly simplify router closure returns by conforming `Future<T>` to `ResponseEncodable`. 

This means you can now return any `ResponseEncodable` type in a router closure, including futures.

```swift
    router.get("123") { req in
        return "123"
    }

    router.get("123") { req in
        return Future("123")
    }
```

Both of the above examples are valid. Swift should also be able to infer return type easier, meaning less `->`.

Caveat: Futures that _don't_ contain response encodable types will also be returnable. This will throw a runtime error instead. This can be fixed w/ conditional conformance.
