### PR TITLE
Make vapor compile with swift 4.1

### DIFF
--- a/Sources/Configs/Config+Directory.swift
+++ b/Sources/Configs/Config+Directory.swift
@@ -47,11 +47,15 @@ extension FileManager {
     fileprivate func isDirectory(path: String) -> Bool {
         var isDirectory: ObjCBool = false
         _ = fileExists(atPath: path, isDirectory: &isDirectory)
-        #if os(Linux)
-            return isDirectory
-        #else
+	#if swift(>=4.1)
             return isDirectory.boolValue
-        #endif
+	#else
+	    #if os(Linux)
+                return isDirectory
+	    #else
+                return isDirectory.boolValue
+	    #endif
+	#endif
     }
 
     fileprivate func files(path: String) throws -> [String] {


### PR DESCRIPTION
Swift 4.1 on Linux removed protocol Boolean aligning behavior with 
the macOS/IOS. This PR fixes compilation on Swift 4.1 - dev which previously errored with: 

```
error: cannot convert return expression of type 'ObjCBool' to return type 'Bool'
            return isDirectory
```
