### PR TITLE
Add port option

### DIFF
--- a/Sources/Vapor/Commands/CommandConfig.swift
+++ b/Sources/Vapor/Commands/CommandConfig.swift
@@ -80,6 +80,11 @@ let envOption = Option(name: "env", help: [
     "Ex: prod, dev, test, my-custom-env"
 ], default: nil)
 
+let portOption = Option(name: "port", help: [
+    "Changes the port"
+], default: nil)
+
+
 /// Wraps all vapor commands and adds support
 /// for the `--env` flag which is resolved outside
 /// of this module
@@ -94,7 +99,7 @@ internal struct VaporCommandWrapper: Command {
 
     /// See Runnable.options
     var options: [Option] {
-        return subCommand.options + [envOption]
+        return subCommand.options + [envOption, portOption]
     }
 
     /// See Runnable.help

--- a/Sources/Vapor/Commands/CommandConfig.swift
+++ b/Sources/Vapor/Commands/CommandConfig.swift
@@ -63,7 +63,7 @@ public struct CommandConfig {
         }
         return BasicCommandGroup(
             commands: commands,
-            options: [envOption],
+            options: [envOption, portOption],
             help: ["Runs your Vapor application's commands"]
         ) { console, input in
             if let lazy = self.defaultRunnable {
@@ -99,7 +99,7 @@ internal struct VaporCommandWrapper: Command {
 
     /// See Runnable.options
     var options: [Option] {
-        return subCommand.options + [envOption, portOption]
+        return subCommand.options + [envOption]
     }
 
     /// See Runnable.help


### PR DESCRIPTION
Heroku needs to pass Vapor a custom port on Run (Ex. `Run --env=production --port=36693`). This used to be done through config.json files, but those are no longer used in this beta. This PR permits Vapor to accept `--port` as an option.

Heroku currently throws `Fatal error: Error raised at top level: ⚠️ Command Error: Unexpected option `port`.`