### PR TITLE
Make HTTPStatus conform to ResponseEncodable

### DIFF
--- a/Sources/Vapor/Engine/ResponseCodable.swift
+++ b/Sources/Vapor/Engine/ResponseCodable.swift
@@ -1,3 +1,4 @@
+import HTTP
 /// Can be converted from a response.
 ///
 /// [Learn More →](https://docs.vapor.codes/3.0/http/response/#responseinitializable)
@@ -30,6 +31,15 @@ extension HTTPResponse: ResponseEncodable {
     public func encode(for req: Request) throws -> Future<Response> {
         let new = req.makeResponse()
         new.http = self
+        return Future(new)
+    }
+}
+
+extension HTTPStatus: ResponseEncodable {
+    /// See ResponseRepresentable.makeResponse
+    public func encode(for req: Request) throws -> Future<Response> {
+        let new = req.makeResponse()
+        new.http = HTTPResponse(status: self)
         return Future(new)
     }
 }


### PR DESCRIPTION
Done so statuses can be returned on their own.

Example:
```
        versionOneGroup.delete("park") { (req)  in
            return req.withConnection(to: .sqlite) { (db) in
                return db.query(Parking.self).first().flatMap(to: HTTPStatus.self) {
                    guard let park = $0 else {
                        throw Abort(.notFound, reason: "Could not find parking.")
                    }
                    
                    return park.delete(on: db).transform(to: HTTPStatus.ok)
                }
            }
        }
```