### PR TITLE
Add heroku config option to EngineServerConfig

### DIFF
--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -299,12 +299,15 @@ public struct EngineServerConfig {
 }
 
 extension EngineServerConfig {
-    public static func heroku(port: UInt16=8080) -> EngineServerConfig {
+    /// Creates server config for use with Heroku.
+    /// Heroku requires that the port be set to $PORT
+    /// and the hostname be 0.0.0.0
+    public static func heroku() -> EngineServerConfig {
         if let portString = ProcessInfo.processInfo.environment["PORT"],
             let customPort = UInt16(portString) {
             return EngineServerConfig(hostname: "0.0.0.0", port: customPort)
         }
-        return EngineServerConfig(hostname: "localhost", port: port)
+        return EngineServerConfig()
     }
 }
 

--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -297,3 +297,14 @@ public struct EngineServerConfig {
         // self.ssl = nil
     }
 }
+
+extension EngineServerConfig {
+    public static func heroku(port: UInt16=8080) -> EngineServerConfig {
+        if let portString = ProcessInfo.processInfo.environment["PORT"],
+            let customPort = UInt16(portString) {
+            return EngineServerConfig(hostname: "0.0.0.0", port: customPort)
+        }
+        return EngineServerConfig(hostname: "localhost", port: port)
+    }
+}
+


### PR DESCRIPTION
This way you can set your app up to accept the `$PORT` environment variable that Heroku requires. Config is done the same way as all the other configs.
Inside `config.swift`:
`services.use(EngineServerConfig.heroku())`