### PR TITLE
content coders

### DIFF
--- a/Sources/Vapor/Content/ContentConfig.swift
+++ b/Sources/Vapor/Content/ContentConfig.swift
@@ -2,42 +2,98 @@ import Foundation
 import FormURLEncoded
 
 /// Configures which encoders/decoders to use for a given media type.
-public struct ContentConfig: Service {
+public struct ContentConfig: Service, ServiceType {
+    /// See `ServiceType.serviceSupports`
+    public static let serviceSupports: [Any.Type] = []
+
+    /// See `ServiceType.makeService`
+    public static func makeService(for worker: Container) throws -> ContentConfig {
+        return ContentConfig.default()
+    }
+
+    /// Represents a yet-to-be-configured object.
+    typealias Lazy<T> = (Container) throws -> T
+
+    /// Configured encoders.
+    private var lazyEncoders: [MediaType: Lazy<BodyEncoder>]
+
+    /// Configured decoders.
+    private var lazyDecoders: [MediaType: Lazy<BodyDecoder>]
+
+    /// Create a new content config.
+    public init() {
+        self.lazyEncoders = [:]
+        self.lazyDecoders = [:]
+    }
+
+    /// Adds an encoder for the specified media type.
+    public mutating func use(encoder: BodyEncoder, for mediaType: MediaType) {
+        self.lazyEncoders[mediaType] = { container in
+            return encoder
+        }
+    }
+
+    /// Adds a decoder for the specified media type.
+    public mutating func use(decoder: BodyDecoder, for mediaType: MediaType) {
+        self.lazyDecoders[mediaType] = { container in
+            return decoder
+        }
+    }
+
+    /// Adds an encoder for the specified media type.
+    public mutating func use<B>(encoder: B.Type, for mediaType: MediaType) where B: BodyEncoder {
+        self.lazyEncoders[mediaType] = { container in
+            return try container.make(B.self, for: ContentConfig.self)
+        }
+    }
+
+    /// Adds a decoder for the specified media type.
+    public mutating func use<B>(decoder: B.Type, for mediaType: MediaType) where B: BodyDecoder {
+        self.lazyDecoders[mediaType] = { container in
+            return try container.make(B.self, for: ContentConfig.self)
+        }
+    }
+
+    /// Creates all lazy coders.
+    internal func boot(using container: Container) throws -> ContentCoders {
+        return try ContentCoders(
+            encoders: lazyEncoders.mapValues { try $0(container) },
+            decoders: lazyDecoders.mapValues { try $0(container) }
+        )
+    }
+}
+
+/// MARK: Coders
+
+public struct ContentCoders: Service, ServiceType {
+    /// See `ServiceType.serviceSupports`
+    public static let serviceSupports: [Any.Type] = []
+
+    /// See `ServiceType.makeService`
+    public static func makeService(for worker: Container) throws -> ContentCoders {
+        let config = try worker.make(ContentConfig.self, for: ContentCoders.self)
+        return try config.boot(using: worker)
+    }
+
     /// Configured encoders.
     var encoders: [MediaType: BodyEncoder]
 
     /// Configured decoders.
     var decoders: [MediaType: BodyDecoder]
 
-    /// Create a new content config.
-    public init() {
-        self.encoders = [:]
-        self.decoders = [:]
-    }
-
-    /// Adds an encoder for the specified media type.
-    public mutating func use(encoder: BodyEncoder, for mediaType: MediaType) {
-        self.encoders[mediaType] = encoder
-    }
-
-    /// Adds a decoder for the specified media type.
-    public mutating func use(decoder: BodyDecoder, for mediaType: MediaType) {
-        self.decoders[mediaType] = decoder
-    }
-
     /// Returns an encoder for the specified media type or throws an error.
-    func requireEncoder(for mediaType: MediaType) throws -> BodyEncoder {
+    public func requireEncoder(for mediaType: MediaType) throws -> BodyEncoder {
         guard let encoder = encoders[mediaType] else {
-            throw VaporError(identifier: "encoder-missing", reason: "There is no known encoder for \(mediaType)")
+            throw VaporError(identifier: "contentEncoder", reason: "There is no known encoder for \(mediaType)")
         }
 
         return encoder
     }
 
     /// Returns a decoder for the specified media type or throws an error.
-    func requireDecoder(for mediaType: MediaType) throws -> BodyDecoder {
+    public func requireDecoder(for mediaType: MediaType) throws -> BodyDecoder {
         guard let decoder = decoders[mediaType] else {
-            throw VaporError(identifier: "encoder-missing", reason: "There is no known decoder for \(mediaType)")
+            throw VaporError(identifier: "contentDecoder", reason: "There is no known decoder for \(mediaType)")
         }
 
         return decoder
@@ -57,7 +113,6 @@ extension ContentConfig {
         // data
         config.use(encoder: DataEncoder(), for: .plainText)
         config.use(encoder: DataEncoder(), for: .html)
-
 
         // form-urlencoded
         config.use(encoder: FormURLEncoder(), for: .urlEncodedForm)

--- a/Sources/Vapor/Content/ContentConfig.swift
+++ b/Sources/Vapor/Content/ContentConfig.swift
@@ -84,7 +84,7 @@ public struct ContentCoders: Service, ServiceType {
     /// Returns an encoder for the specified media type or throws an error.
     public func requireEncoder(for mediaType: MediaType) throws -> BodyEncoder {
         guard let encoder = encoders[mediaType] else {
-            throw VaporError(identifier: "contentEncoder", reason: "There is no known encoder for \(mediaType)")
+            throw VaporError(identifier: "contentEncoder", reason: "There is no configured encoder for \(mediaType)")
         }
 
         return encoder
@@ -93,7 +93,7 @@ public struct ContentCoders: Service, ServiceType {
     /// Returns a decoder for the specified media type or throws an error.
     public func requireDecoder(for mediaType: MediaType) throws -> BodyDecoder {
         guard let decoder = decoders[mediaType] else {
-            throw VaporError(identifier: "contentDecoder", reason: "There is no known decoder for \(mediaType)")
+            throw VaporError(identifier: "contentDecoder", reason: "There is no configured decoder for \(mediaType)")
         }
 
         return decoder

--- a/Sources/Vapor/Content/Message+Content.swift
+++ b/Sources/Vapor/Content/Message+Content.swift
@@ -33,15 +33,15 @@ extension ContentContainer {
 
     /// Creates a data encoder from the content config or throws.
     private func requireEncoder(for mediaType: MediaType) throws -> BodyEncoder {
-        let coders = try container.superContainer.make(ContentConfig.self, for: ContentContainer.self)
+        let coders = try container.superContainer.make(ContentCoders.self, for: ContentContainer.self)
         return try coders.requireEncoder(for: mediaType)
     }
 
     /// Creates a data decoder from the content config or throws.
     private func requireDecoder() throws -> BodyDecoder {
-        let coders = try container.superContainer.make(ContentConfig.self, for: ContentContainer.self)
+        let coders = try container.superContainer.make(ContentCoders.self, for: ContentContainer.self)
         guard let mediaType = mediaType else {
-            throw VaporError(identifier: "no-media-type", reason: "Cannot decode content without mediatype")
+            throw VaporError(identifier: "mediaType", reason: "Cannot decode content without mediatype")
         }
         return try coders.requireDecoder(for: mediaType)
     }

--- a/Sources/Vapor/Engine/QueryContainer.swift
+++ b/Sources/Vapor/Engine/QueryContainer.swift
@@ -14,7 +14,7 @@ extension QueryContainer {
 
     /// Gets the query decoder or throws an error
     fileprivate func requireDecoder() throws -> BodyDecoder {
-        let coders = try container.superContainer.make(ContentConfig.self, for: QueryContainer.self)
+        let coders = try container.superContainer.make(ContentCoders.self, for: QueryContainer.self)
         return try coders.requireDecoder(for: .urlEncodedForm)
     }
 }

--- a/Sources/Vapor/Engine/Request+StreamFile.swift
+++ b/Sources/Vapor/Engine/Request+StreamFile.swift
@@ -54,9 +54,7 @@ extension Request {
         res.http.body = HTTPBody(
             chunked: passthrough
         )
-        
         reader.read(at: path, into: passthrough, chunkSize: 2048)
-        
         return res
     }
 }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -121,9 +121,8 @@ extension Services {
         }
 
         // register content coders
-        services.register { container -> ContentConfig in
-            return ContentConfig.default()
-        }
+        services.register(ContentConfig.self)
+        services.register(ContentCoders.self)
         
         // register transfer encodings
         services.register { container -> TransferEncodingConfig in


### PR DESCRIPTION
- [x] allows registering BodyEncoder/Decoder _types_ to `ContentConfig`
- [x] creates a separated "configured" struct `ContentCoders`
- [x] uses `ServiceType` to cleanup the `Services+default.swift` file a bit