### PR TITLE
Headers are now used in requests from client

### DIFF
--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -19,6 +19,7 @@ extension Client {
             let req = Request(using: self.container)
             req.http.method = method
             req.http.uri = url
+            req.headers = headers
             return try self.respond(to: req)
         }
     }


### PR DESCRIPTION
Headers previously weren't being attached to requests