### PR TITLE
Add missing headers to request

### DIFF
--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -36,6 +36,7 @@ extension Client {
             try req.content.encode(content)
             req.http.method = method
             req.http.uri = url
+            req.http.headers = headers
             return try self.respond(to: req)
         }
     }


### PR DESCRIPTION
This expands upon #1437 to also fix the second `send` method