### PR TITLE
client uri + tls

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,6 +1,7 @@
 import COperatingSystem
 import Vapor
 import Dispatch
+import Foundation
 
 
 
@@ -92,27 +93,25 @@ do {
         return "123" as StaticString
     }
 
-    router.get("example") { req -> Future<Response> in
+    router.get("client", "zombo") { req -> Future<Response> in
         let client = try req.make(Client.self, for: Request.self)
         return client.send(.get, to: "http://www.zombo.com/")
     }
 
-    router.get("example1") { req -> Future<Response> in
+    router.get("client", "romans") { req -> Future<Response> in
         let client = try req.make(Client.self, for: Request.self)
 
         return client.send(.get, to: "http://www.romansgohome.com")
     }
 
-    router.get("example2") { req -> Future<Response> in
+    router.get("client", "example") { req -> Future<Response> in
         let client = try req.make(Client.self, for: Request.self)
 
         return client.send(.get, to: "http://example.com")
     }
 
-    router.get("example3") { req -> Future<Response> in
-        let client = try req.make(Client.self, for: Request.self)
-
-        return client.send(.get, to: "https://www.google.com")
+    router.get("client", "google") { req -> Future<HTTPStatus> in
+        return try req.make(Client.self).get("https://www.google.com").transform(to: .ok)
     }
 
 //    router.get("hello2") { req -> Future<[User]> in

--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -13,83 +13,91 @@ extension Client {
     public func send(
         _ method: HTTPMethod,
         headers: HTTPHeaders = [:],
-        to url: URI
+        to uri: URIRepresentable
     ) -> Future<Response> {
         return Future.flatMap {
             let req = Request(using: self.container)
             req.http.method = method
-            req.http.uri = url
+            req.http.uri = try uri.makeURI()
             req.headers = headers
+            print(req)
             return try self.respond(to: req)
         }
     }
 
     /// Sends an HTTP request from the client using the method, url, and content.
-    public func send<C: Content>(
+    public func send<C>(
         _ method: HTTPMethod,
         headers: HTTPHeaders = [:],
-        to url: URI,
+        to uri: URIRepresentable,
         content: C
-    ) -> Future<Response> {
+    ) -> Future<Response> where C: Content {
         return Future.flatMap {
             let req = Request(using: self.container)
             try req.content.encode(content)
             req.http.method = method
-            req.http.uri = url
+            req.http.uri = try uri.makeURI()
             req.http.headers = headers
             return try self.respond(to: req)
         }
     }
 }
 
+/// MARK: Basic
+
 extension Client {
     /// Sends a GET request without body
-    public func get(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+    public func get(_ url: URIRepresentable, headers: HTTPHeaders = [:]) -> Future<Response> {
         return send(.get, headers: headers, to: url)
     }
     
-    /// Sends a GET request with body
-    public func get<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
-        return send(.get, headers: headers, to: url, content: content)
-    }
-    
     /// Sends a PUT request without body
-    public func put(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+    public func put(_ url: URIRepresentable, headers: HTTPHeaders = [:]) -> Future<Response> {
         return send(.put, headers: headers, to: url)
     }
     
-    /// Sends a GET request with body
-    public func put<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
-        return send(.put, headers: headers, to: url, content: content)
-    }
-    
     /// Sends a PUT request without body
-    public func post(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+    public func post(_ url: URIRepresentable, headers: HTTPHeaders = [:]) -> Future<Response> {
         return send(.post, headers: headers, to: url)
     }
     
-    /// Sends a POST request with body
-    public func post<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
-        return send(.post, headers: headers, to: url, content: content)
-    }
-    
     /// Sends a POST request without body
-    public func delete(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+    public func delete(_ url: URIRepresentable, headers: HTTPHeaders = [:]) -> Future<Response> {
         return send(.delete, headers: headers, to: url)
     }
-    
-    /// Sends a POST request with body
-    public func delete<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
-        return send(.delete, headers: headers, to: url, content: content)
-    }
-    
+
     /// Sends a PATCH request without body
-    public func patch(_ url: URI, headers: HTTPHeaders = [:]) -> Future<Response> {
+    public func patch(_ url: URIRepresentable, headers: HTTPHeaders = [:]) -> Future<Response> {
         return send(.patch, headers: headers, to: url)
     }
-    
+}
+
+/// MARK: Content
+
+extension Client {
+    /// Sends a GET request with body
+    public func get<C>(_ url: URIRepresentable, headers: HTTPHeaders = [:], content: C) -> Future<Response> where C: Content {
+        return send(.get, headers: headers, to: url, content: content)
+    }
+
+    /// Sends a GET request with body
+    public func put<C>(_ url: URIRepresentable, headers: HTTPHeaders = [:], content: C) -> Future<Response> where C: Content {
+        return send(.put, headers: headers, to: url, content: content)
+    }
+
+    /// Sends a POST request with body
+    public func post<C>(_ url: URIRepresentable, headers: HTTPHeaders = [:], content: C) -> Future<Response> where C: Content {
+        return send(.post, headers: headers, to: url, content: content)
+    }
+
+
+    /// Sends a POST request with body
+    public func delete<C>(_ url: URIRepresentable, headers: HTTPHeaders = [:], content: C) -> Future<Response> where C: Content {
+        return send(.delete, headers: headers, to: url, content: content)
+    }
+
     /// Sends a PATCH request with body
-    public func patch<C: Content>(_ url: URI, headers: HTTPHeaders = [:], content: C) -> Future<Response> {
+    public func patch<C>(_ url: URIRepresentable, headers: HTTPHeaders = [:], content: C) -> Future<Response> where C: Content {
         return send(.patch, headers: headers, to: url, content: content)
     }
 }

--- a/Sources/Vapor/Engine/EngineClient.swift
+++ b/Sources/Vapor/Engine/EngineClient.swift
@@ -1,6 +1,5 @@
 import Async
 import HTTP
-/*import HTTP2*/
 import TCP
 import TLS
 #if os(Linux)
@@ -25,64 +24,54 @@ public final class EngineClient: Client, Service {
 
     /// See Responder.respond
     public func respond(to req: Request) -> Future<Response> {
-        let ssl = req.http.uri.scheme == "https" ? true : false
-        /*if ssl {
-            /// if using ssl, try to connect with http/2 first
-            /// it will fallback to http/1 automatically
-            return HTTP2Client.connect(
-                to: req.http.uri.hostname ?? "",
-                port: req.http.uri.port,
-                settings: HTTP2Settings(),
-                on: req.Worker
-            ).then { client in
-                return client.send(request: req.http).then { httpRes -> Response in
-                    let res = req.makeResponse()
-                    res.http = httpRes
-                    return res
-                }
+        return Future.flatMap {
+            if req.http.uri.scheme == "https" ? true : false {
+                return try self.tlsRespond(to: req)
+            } else {
+                return try self.plaintextRespond(to: req)
             }
-        } else {*/
-            /// if using cleartext, just use http/1.
+        }
+    }
 
-        if ssl {
-            #if os(macOS)
-                return Future.flatMap {
-                    let tcpSocket = try TCPSocket(isNonBlocking: true)
-                    let tcpClient = try TCPClient(socket: tcpSocket)
-                    let tlsClient = try AppleTLSClient(tcp: tcpClient, using: TLSClientSettings())
-                    try tlsClient.connect(hostname: req.http.uri.hostname!, port: req.http.uri.port ?? 443)
-                    let client = HTTPClient(
-                        stream: tlsClient.socket.stream(on: self.container),
-                        on: self.container,
-                        maxResponseSize: self.config.maxResponseSize
-                    )
-                    req.http.headers[.host] = req.http.uri.hostname
-                    return client.send(req.http).map(to: Response.self) { httpRes in
-                        let res = req.makeResponse()
-                        res.http = httpRes
-                        return res
-                    }
-                }
-            #else
-                fatalError("HTTPS not yet supported")
-            #endif
-        } else {
-            return Future.flatMap {
-                let tcpSocket = try TCPSocket(isNonBlocking: true)
-                let tcpClient = try TCPClient(socket: tcpSocket)
-                try tcpClient.connect(hostname: req.http.uri.hostname!, port: req.http.uri.port ?? 80)
-                let client = HTTPClient(
-                    stream: tcpSocket.stream(on: self.container),
-                    on: self.container,
-                    maxResponseSize: self.config.maxResponseSize
-                )
-                req.http.headers[.host] = req.http.uri.hostname
-                return client.send(req.http).map(to: Response.self) { httpRes in
-                    let res = req.makeResponse()
-                    res.http = httpRes
-                    return res
-                }
-            }
+    /// Responds to a Request using TLS client.
+    private func tlsRespond(to req: Request) throws -> Future<Response> {
+        let tcpSocket = try TCPSocket(isNonBlocking: true)
+        let tcpClient = try TCPClient(socket: tcpSocket)
+        #if os(macOS)
+            let tlsClient = try AppleTLSClient(tcp: tcpClient, using: TLSClientSettings())
+        #else
+            let tlsClient = try OenSSLClient(tcp: tcpClient, using: TLSClientSettings())
+        #endif
+        try tlsClient.connect(hostname: req.http.uri.requireHostname(), port: req.http.uri.port ?? 443)
+        let client = HTTPClient(
+            stream: tlsClient.socket.stream(on: self.container),
+            on: self.container,
+            maxResponseSize: self.config.maxResponseSize
+        )
+        req.http.headers[.host] = req.http.uri.hostname
+        return client.send(req.http).map(to: Response.self) { httpRes in
+            let res = req.makeResponse()
+            res.http = httpRes
+            return res
+        }
+    }
+
+    /// Responds to a Request using TCP client.
+    private func plaintextRespond(to req: Request) throws -> Future<Response> {
+        let tcpSocket = try TCPSocket(isNonBlocking: true)
+        let tcpClient = try TCPClient(socket: tcpSocket)
+        try tcpClient.connect(hostname: req.http.uri.requireHostname(), port: req.http.uri.port ?? 80)
+        let client = HTTPClient(
+            stream: tcpSocket.stream(on: self.container),
+            on: self.container,
+            maxResponseSize: self.config.maxResponseSize
+        )
+        req.http.headers[.host] = req.http.uri.hostname
+        return client.send(req.http).map(to: Response.self) { httpRes in
+            print("httpRes: \(httpRes)")
+            let res = req.makeResponse()
+            res.http = httpRes
+            return res
         }
     }
 }
@@ -96,5 +85,15 @@ public struct EngineClientConfig: Service {
     /// Create a new EngineClientConfig.
     public init(maxResponseSize: Int) {
         self.maxResponseSize = maxResponseSize
+    }
+}
+
+extension URI {
+    /// Returns the URI hostname, throwing if none exists.
+    fileprivate func requireHostname() throws -> String {
+        guard let hostname = self.hostname else {
+            throw VaporError(identifier: "requireHostname", reason: "URI with hostname required.")
+        }
+        return hostname
     }
 }

--- a/Sources/Vapor/Engine/EngineClient.swift
+++ b/Sources/Vapor/Engine/EngineClient.swift
@@ -40,7 +40,7 @@ public final class EngineClient: Client, Service {
         #if os(macOS)
             let tlsClient = try AppleTLSClient(tcp: tcpClient, using: TLSClientSettings())
         #else
-            let tlsClient = try OenSSLClient(tcp: tcpClient, using: TLSClientSettings())
+            let tlsClient = try OpenSSLClient(tcp: tcpClient, using: TLSClientSettings())
         #endif
         try tlsClient.connect(hostname: req.http.uri.requireHostname(), port: req.http.uri.port ?? 443)
         let client = HTTPClient(

--- a/Sources/Vapor/Engine/URIRepresentable.swift
+++ b/Sources/Vapor/Engine/URIRepresentable.swift
@@ -1,0 +1,19 @@
+/// Able to convert to a `URI`.
+public protocol URIRepresentable {
+    /// Converts this type to a `URI`.
+    func makeURI() throws -> URI
+}
+
+extension URI: URIRepresentable {
+    /// See `URIRepresentable.makeURI()`
+    public func makeURI() throws -> URI {
+        return self
+    }
+}
+
+extension String: URIRepresentable {
+    /// See `URIRepresentable.makeURI()`
+    public func makeURI() throws -> URI {
+        return URI(self)
+    }
+}


### PR DESCRIPTION
- Adds `String` support to `Client` convenience methods.
- Cleans up internal TLS code for `EngineClient`