### PR TITLE
chttp refactor

### DIFF
--- a/Sources/Boilerplate/configure.swift
+++ b/Sources/Boilerplate/configure.swift
@@ -1,4 +1,5 @@
 import Vapor
+import Foundation
 
 public func configure(
     _ config: inout Config,
@@ -6,4 +7,7 @@ public func configure(
     _ services: inout Services
 ) throws {
     // configure your application here
+    var middlewareConfig = MiddlewareConfig()
+    //middlewareConfig.use(DateMiddleware.self)
+    services.register(middlewareConfig)
 }

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -14,5 +14,17 @@ final class Routes: RouteCollection {
             let res = try req.make(Client.self).get("http://httpbin.org/ip").await(on: req)
             return Future(res)
         }
+
+        router.get("ping") { req in
+            return "123" as StaticString
+        }
+
+        router.get("ip") { req -> Future<String> in
+            return try req.make(Client.self).get("http://httpbin.org/ip").map(to: String.self) { res in
+                print(res)
+                debugPrint(res)
+                return "done"
+            }
+        }
     }
 }

--- a/Sources/Vapor/Content/Message+Content.swift
+++ b/Sources/Vapor/Content/Message+Content.swift
@@ -41,7 +41,7 @@ extension ContentContainer {
     private func requireDecoder() throws -> BodyDecoder {
         let coders = try container.superContainer.make(ContentCoders.self, for: ContentContainer.self)
         guard let mediaType = mediaType else {
-            throw VaporError(identifier: "mediaType", reason: "Cannot decode content without mediatype")
+            throw VaporError(identifier: "mediaType", reason: "Cannot decode content without Media Type")
         }
         return try coders.requireDecoder(for: mediaType)
     }

--- a/Sources/Vapor/Content/MultipartContent.swift
+++ b/Sources/Vapor/Content/MultipartContent.swift
@@ -27,8 +27,8 @@ extension MultipartForm: Content {
         }
         
         let data = MultipartSerializer(form: self).serialize()
-        req.body = HTTPBody(data)
-        req.headers[.contentType] = "multipart/form-data; boundary=" + boundary
+        req.http.body = HTTPBody(data)
+        req.http.headers[.contentType] = "multipart/form-data; boundary=" + boundary
         
         return .done
     }
@@ -40,30 +40,30 @@ extension MultipartForm: Content {
         }
         
         let data = MultipartSerializer(form: self).serialize()
-        res.body = HTTPBody(data)
-        res.headers[.contentType] = "multipart/form-data; boundary=" + boundary
+        res.http.body = HTTPBody(data)
+        res.http.headers[.contentType] = "multipart/form-data; boundary=" + boundary
         
         return .done
     }
     
     /// See RequestDecodable.decode
     public static func decode(from req: Request) throws -> Future<MultipartForm> {
-        guard let boundary = req.headers[.contentType, "boundary"] else {
+        guard let boundary = req.http.headers[.contentType, "boundary"] else {
             throw VaporError(identifier: "boundary-utf8", reason: "The Multipart boundary was found in the headers")
         }
         
-        return req.body.makeData(max: 1_000_000).map(to: MultipartForm.self) { data in
+        return req.http.body.makeData(max: 1_000_000).map(to: MultipartForm.self) { data in
             return try MultipartParser(data: data, boundary: Array(boundary.utf8)).parse()
         }
     }
     
     /// See ResponseDecodable.decode
     public static func decode(from res: Response, for req: Request) throws -> Future<MultipartForm> {
-        guard let boundary = req.headers[.contentType, "boundary"] else {
+        guard let boundary = req.http.headers[.contentType, "boundary"] else {
             throw VaporError(identifier: "boundary-utf8", reason: "The Multipart boundary was found in the headers")
         }
         
-        return req.body.makeData(max: 1_000_000).map(to: MultipartForm.self) { data in
+        return req.http.body.makeData(max: 1_000_000).map(to: MultipartForm.self) { data in
             return try MultipartParser(data: data, boundary: Array(boundary.utf8)).parse()
         }
     }

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -1,0 +1,57 @@
+extension Request {
+    @available(*, deprecated, renamed: "http.method")
+    public var method: HTTPMethod {
+        get { return http.method }
+        set { http.method = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.uri")
+    public var uri: URI {
+        get { return http.uri }
+        set { http.uri = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.version")
+    public var version: HTTPVersion {
+        get { return http.version }
+        set { http.version = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.headers")
+    public var headers: HTTPHeaders {
+        get { return http.headers }
+        set { http.headers = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.body")
+    public var body: HTTPBody {
+        get { return http.body }
+        set { http.body = newValue }
+    }
+}
+
+extension Response {
+    @available(*, deprecated, renamed: "http.status")
+    public var method: HTTPStatus {
+        get { return http.status }
+        set { http.status = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.version")
+    public var version: HTTPVersion {
+        get { return http.version }
+        set { http.version = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.headers")
+    public var headers: HTTPHeaders {
+        get { return http.headers }
+        set { http.headers = newValue }
+    }
+
+    @available(*, deprecated, renamed: "http.body")
+    public var body: HTTPBody {
+        get { return http.body }
+        set { http.body = newValue }
+    }
+}

--- a/Sources/Vapor/Engine/BasicStream.swift
+++ b/Sources/Vapor/Engine/BasicStream.swift
@@ -16,4 +16,3 @@ public struct BasicResponder: Responder {
         return try closure(req)
     }
 }
-

--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -19,8 +19,7 @@ extension Client {
             let req = Request(using: self.container)
             req.http.method = method
             req.http.uri = try uri.makeURI()
-            req.headers = headers
-            print(req)
+            req.http.headers = headers
             return try self.respond(to: req)
         }
     }

--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -30,8 +30,9 @@ public final class EngineServer: Server, Service {
 
     /// Start the server. Server protocol requirement.
     public func start(with responder: Responder) throws {
-        var tcpServer = try TCPServer(socket: TCPSocket(isNonBlocking: true))
-        tcpServer.willAccept = PeerValidator(maxConnectionsPerIP: config.maxConnectionsPerIP).willAccept
+        let tcpServer = try TCPServer(socket: TCPSocket(isNonBlocking: true))
+        // leaking, probably because of client capturing itself in closure
+        // tcpServer.willAccept = PeerValidator(maxConnectionsPerIP: config.maxConnectionsPerIP).willAccept
         
         let console = try container.make(Console.self, for: EngineServer.self)
         let logger = try container.make(Logger.self, for: EngineServer.self)

--- a/Sources/Vapor/Engine/Request+StreamFile.swift
+++ b/Sources/Vapor/Engine/Request+StreamFile.swift
@@ -29,7 +29,7 @@ extension Request {
             throw Abort(.internalServerError)
         }
 
-        var headers: [HTTPHeaders.Name: String] = [:]
+        var headers: [HTTPHeaderName: String] = [:]
 
         // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
         let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize.intValue)"

--- a/Sources/Vapor/Engine/Request.swift
+++ b/Sources/Vapor/Engine/Request.swift
@@ -3,6 +3,7 @@ import Dispatch
 import HTTP
 import Routing
 import Service
+import Foundation
 
 public final class Request: ParameterContainer {
     /// Underlying HTTP request.
@@ -17,45 +18,6 @@ public final class Request: ParameterContainer {
     /// Holds parameters for routing
     public var parameters: Parameters
     
-    /// HTTP requests have a method, like GET or POST
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/method/)
-    public var method: HTTPMethod {
-        get { return http.method }
-        set { http.method = newValue }
-    }
-    
-    /// This is usually just a path like `/foo` but
-    /// may be a full URI in the case of a proxy
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/uri/)
-    public var uri: URI {
-        get { return http.uri }
-        set { http.uri = newValue }
-    }
-    
-    /// See `Message.version`
-    public var version: HTTPVersion {
-        get { return http.version }
-        set { http.version = newValue }
-    }
-    
-    /// See `Message.headers`
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/headers/)
-    public var headers: HTTPHeaders {
-        get { return http.headers }
-        set { http.headers = newValue }
-    }
-    
-    /// See `Message.body`
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/body/)
-    public var body: HTTPBody {
-        get { return http.body }
-        set { http.body = newValue }
-    }
-
     /// True if this request has active connections
     internal var hasActiveConnections: Bool
 
@@ -73,6 +35,20 @@ public final class Request: ParameterContainer {
         if hasActiveConnections {
             try! privateContainer.releaseCachedConnections()
         }
+    }
+}
+
+extension Request: CustomStringConvertible {
+    /// See `CustomStringConvertible.description
+    public var description: String {
+        return http.description
+    }
+}
+
+extension Request: CustomDebugStringConvertible {
+    /// See `CustomDebugStringConvertible.debugDescription`
+    public var debugDescription: String {
+        return http.debugDescription
     }
 }
 

--- a/Sources/Vapor/Engine/Response.swift
+++ b/Sources/Vapor/Engine/Response.swift
@@ -16,52 +16,6 @@ public final class Response: EphemeralContainer {
 
     /// This response's private container.
     public let privateContainer: SubContainer
-    
-    /// See Message.version
-    public var version: HTTPVersion {
-        get {
-            return http.version
-        }
-        set {
-            http.version = newValue
-        }
-    }
-    
-    /// HTTP response status code.
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/status/)
-    public var status: HTTPStatus {
-        get {
-            return http.status
-        }
-        set {
-            http.status = newValue
-        }
-    }
-    
-    /// See Message.headers
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/headers/)
-    public var headers: HTTPHeaders {
-        get {
-            return http.headers
-        }
-        set {
-            http.headers = newValue
-        }
-    }
-    
-    /// See Message.body
-    ///
-    /// [Learn More →](https://docs.vapor.codes/3.0/http/body/)
-    public var body: HTTPBody {
-        get {
-            return http.body
-        }
-        set {
-            http.body = newValue
-        }
-    }
 
     /// Create a new Response
     public init(http: HTTPResponse = HTTPResponse(), using container: Container) {
@@ -71,10 +25,23 @@ public final class Response: EphemeralContainer {
         Response.onInit?(self)
     }
 
-
     /// Called when request is deinitializing
     deinit {
         Response.onDeinit?(self)
+    }
+}
+
+extension Response: CustomStringConvertible {
+    /// See `CustomStringConvertible.description
+    public var description: String {
+        return http.description
+    }
+}
+
+extension Response: CustomDebugStringConvertible {
+    /// See `CustomDebugStringConvertible.debugDescription`
+    public var debugDescription: String {
+        return http.debugDescription
     }
 }
 

--- a/Sources/Vapor/Engine/ResponseCodable.swift
+++ b/Sources/Vapor/Engine/ResponseCodable.swift
@@ -48,7 +48,8 @@ extension StaticString: ResponseEncodable {
     /// See ResponseRepresentable.makeResponse
     public func encode(for req: Request) throws -> Future<Response> {
         let new = req.makeResponse()
-        new.body = HTTPBody(staticString: self)
+        new.http.headers[.contentType] = "text/plain; charset=utf-8"
+        new.http.body = HTTPBody(staticString: self)
         return Future(new)
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -8,37 +8,6 @@ import TCP
 import XCTest
 
 class ApplicationTests: XCTestCase {
-    func testAnyResponse() throws {
-//        let response = "hello"
-//        let app = try Application()
-//        var result = Response(using: app)
-//        let req = Request(using: app)
-//        
-//        AnyResponse(response).map { encodable in
-//            try encodable.encode(to: &result, for: req).blockingAwait()
-//            XCTAssertEqual(result.http.body.data, Data("hello".utf8))
-//        }.catch { error in
-//            XCTFail("\(error)")
-//        }
-//        
-//        let response2: Future<String?> = Future(nil)
-//        let response3: Future<String?> = Future("test")
-//        
-//        AnyResponse(future: response2, or: "fail").map { encodable in
-//            try encodable.encode(to: &result, for: req).blockingAwait()
-//            XCTAssertEqual(result.http.body.data, Data("fail".utf8))
-//        }.catch { error in
-//            XCTFail("\(error)")
-//        }
-//        
-//        AnyResponse(future: response3, or: "fail").map { encodable in
-//            try encodable.encode(to: &result, for: req).blockingAwait()
-//            XCTAssertEqual(result.http.body.data, Data("test".utf8))
-//        }.catch { error in
-//            XCTFail("\(error)")
-//        }
-    }
-
     func testContent() throws {
         let app = try Application()
         let req = Request(using: app)
@@ -48,7 +17,7 @@ class ApplicationTests: XCTestCase {
             "hello": "world"
         }
         """.makeBody()
-        try XCTAssertEqual(req.content["hello"].await(on: app), "world")
+        try XCTAssertEqual(req.content.get(at: "hello").await(on: app), "world")
     }
 
     func testComplexContent() throws {
@@ -101,7 +70,6 @@ class ApplicationTests: XCTestCase {
     }
 
     static let allTests = [
-        ("testAnyResponse", testAnyResponse),
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
         ("testQuery", testQuery),

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -11,12 +11,12 @@ class ApplicationTests: XCTestCase {
     func testContent() throws {
         let app = try Application()
         let req = Request(using: app)
-        req.http.mediaType = .json
         req.http.body = try """
         {
             "hello": "world"
         }
         """.makeBody()
+        req.http.mediaType = .json
         try XCTAssertEqual(req.content.get(at: "hello").await(on: app), "world")
     }
 
@@ -52,10 +52,10 @@ class ApplicationTests: XCTestCase {
         """
         let app = try Application()
         let req = Request(using: app)
-        req.http.mediaType = .json
         req.http.body = try complexJSON.makeBody()
+        req.http.mediaType = .json
 
-        try XCTAssertEqual(req.content["batters", "batter", 1, "type"].await(on: app), "Chocolate")
+        try XCTAssertEqual(req.content.get(at: "batters", "batter", 1, "type").await(on: app), "Chocolate")
     }
 
     func testQuery() throws {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -61,7 +61,6 @@ class ApplicationTests: XCTestCase {
     func testQuery() throws {
         /// FIXME: https://github.com/vapor/vapor/issues/1419
         return;
-        
         let app = try Application()
         let req = Request(using: app)
         req.http.mediaType = .json


### PR DESCRIPTION
- [x] updates to vapor/engine:chttp-refactor branch
- [x] various performance optimizations
- [x] deprecates `req.http.*` conveniences in favor of explicit call
- [x] adds better `print(...)` and `debugPrint(...)` to `Request` and `Response`