### PR TITLE
Build Vapor 1 with Xcode 9.2

### DIFF
--- a/Sources/Vapor/Validation/Convenience/Alphanumeric.swift
+++ b/Sources/Vapor/Validation/Convenience/Alphanumeric.swift
@@ -3,6 +3,8 @@
     given string contains only alphanumeric characters
 */
 public struct OnlyAlphanumeric: ValidationSuite {
+    public typealias InputType = String
+    
     private static let alphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789"
     private static let validCharacters = alphanumeric.characters
 

--- a/Sources/Vapor/Validation/Convenience/Email.swift
+++ b/Sources/Vapor/Validation/Convenience/Email.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public class Email: ValidationSuite {
+    public typealias InputType = String
+    
     public static func validate(input value: String) throws {
         guard
             let localName = value.components(separatedBy: "@").first,

--- a/Sources/Vapor/Validation/Convenience/Unique.swift
+++ b/Sources/Vapor/Validation/Convenience/Unique.swift
@@ -7,6 +7,8 @@ public struct Unique<
     T: Validatable,
     T.Iterator.Element: Equatable
 {
+    public typealias InputType = T
+    
 
     /**
         validate

--- a/Sources/Vapor/Validation/Validators.swift
+++ b/Sources/Vapor/Validation/Validators.swift
@@ -67,12 +67,6 @@ public protocol Validator {
 
 public protocol ValidationSuite: Validator {
     /**
-        The type of value that this validator is capable
-        of evaluating
-    */
-    associatedtype InputType: Validatable
-
-    /**
         Used to validate a given input. Should throw
         error if validation fails using:
 


### PR DESCRIPTION
Vapor 1 build crashes the Swift compiler in Xcode 9.2 (Swift 4.0.3). Swift crash is fixed in 4.1 but this PR fixes a redundant conformance warning too, so might as well.