### PR TITLE
Make the fields of `Proxy` readable outside of Vapor itself.

### DIFF
--- a/Sources/Vapor/Engine/Client/ClientProtocol.swift
+++ b/Sources/Vapor/Engine/Client/ClientProtocol.swift
@@ -16,9 +16,9 @@ public protocol ClientProtocol: Responder {
 // MARK: Proxy
 
 public struct Proxy {
-    var hostname: String
-    var port: Port
-    var securityLayer: SecurityLayer
+    public var hostname: String
+    public var port: Port
+    public var securityLayer: SecurityLayer
 }
 
 


### PR DESCRIPTION
Vapor 2's `Proxy` structure is useful for storing proxy server information (amazing, isn't it?), but its fields have no access modifier, defaulting to `internal`, making it useless to anything other than the built-in `Client`s despite the struct itself being `public`. This PR makes the fields public as well so the structure can be reused - in particular, this enables apps to read the proxy settings from `Config/client.json` without rewriting the code already present in `ClientFactory`.

Categorized as a bug because the current state does not appear to be the intended functionality.