### PR TITLE
Added new optional metadata parameter to conform with new additions to RouteBuilder protocol 

### DIFF
--- a/Sources/Vapor/Routing/Droplet+Routing.swift
+++ b/Sources/Vapor/Routing/Droplet+Routing.swift
@@ -3,8 +3,8 @@ import HTTP
 @_exported import Routing
 
 extension Droplet: RouteBuilder {
-    public func register(host: String?, method: Method, path: [String], responder: Responder) {
-        router.register(host: host, method: method, path: path, responder: responder)
+    public func register(host: String?, method: Method, path: [String], metadata: [String: String]? = nil, responder: Responder) {
+        router.register(host: host, method: method, path: path, metadata: metadata, responder: responder)
     }
 }
 

--- a/Sources/Vapor/Routing/Droplet+Routing.swift
+++ b/Sources/Vapor/Routing/Droplet+Routing.swift
@@ -3,7 +3,11 @@ import HTTP
 @_exported import Routing
 
 extension Droplet: RouteBuilder {
-    public func register(host: String?, method: Method, path: [String], metadata: [String: String]? = nil, responder: Responder) {
+    public func register(host: String?, method: Method, path: [String], responder: Responder) {
+        router.register(host: host, method: method, path: path, responder: responder)
+    }
+    
+    public func register(host: String?, method: Method, path: [String], metadata: [String: Any], responder: Responder) {
         router.register(host: host, method: method, path: path, metadata: metadata, responder: responder)
     }
 }


### PR DESCRIPTION
Added new optional metadata parameter to Droplet: RouteBuilder extension to conform with new additions to RouteBuilder protocol.

Requires https://github.com/vapor/routing/pull/34 