### PR TITLE
Fixed Exclusive Access to Memory bug

### DIFF
--- a/Sources/Validation/Validatable.swift
+++ b/Sources/Validation/Validatable.swift
@@ -51,11 +51,11 @@ struct ValidatableError: ValidationError {
 
     /// See ValidationError.reason
     var reason: String {
-        return errors.map { err in
-            var error = err
-            error.codingPath = codingPath + err.codingPath
-            return error.reason
-        }.joined(separator: ", ")
+        return errors.map { error in
+            var mutableError = error
+            mutableError.codingPath = codingPath + error.codingPath
+            return mutableError.reason
+            }.joined(separator: ", ")
     }
 
     /// creates a new validatable error

--- a/Sources/Validation/Validatable.swift
+++ b/Sources/Validation/Validatable.swift
@@ -51,9 +51,9 @@ struct ValidatableError: ValidationError {
 
     /// See ValidationError.reason
     var reason: String {
-        return errors.map { error in
-            var error = error
-            error.codingPath = codingPath + error.codingPath
+        return errors.map { err in
+            var error = err
+            error.codingPath = codingPath + err.codingPath
             return error.reason
         }.joined(separator: ", ")
     }

--- a/Sources/Validation/Validatable.swift
+++ b/Sources/Validation/Validatable.swift
@@ -55,7 +55,7 @@ struct ValidatableError: ValidationError {
             var mutableError = error
             mutableError.codingPath = codingPath + error.codingPath
             return mutableError.reason
-            }.joined(separator: ", ")
+        }.joined(separator: ", ")
     }
 
     /// creates a new validatable error

--- a/Sources/Validation/Validators/AndValidator.swift
+++ b/Sources/Validation/Validators/AndValidator.swift
@@ -55,15 +55,15 @@ internal struct AndValidatorError: ValidationError {
 
     /// See ValidationError.reason
     var reason: String {
-        if var left = left, var right = right {
-            left.codingPath = codingPath + left.codingPath
-            right.codingPath = codingPath + right.codingPath
+        if var left = self.left, var right = self.right {
+            left.codingPath = codingPath + self.left!.codingPath
+            right.codingPath = codingPath + self.right!.codingPath
             return "\(left.reason) and \(right.reason)"
         } else if var left = left {
-            left.codingPath = codingPath + left.codingPath
+            left.codingPath = codingPath + self.left!.codingPath
             return left.reason
         } else if var right = right {
-            right.codingPath = codingPath + right.codingPath
+            right.codingPath = codingPath + self.right!.codingPath
             return right.reason
         } else {
             return ""

--- a/Sources/Validation/Validators/AndValidator.swift
+++ b/Sources/Validation/Validators/AndValidator.swift
@@ -55,16 +55,19 @@ internal struct AndValidatorError: ValidationError {
 
     /// See ValidationError.reason
     var reason: String {
-        if var left = self.left, var right = self.right {
-            left.codingPath = codingPath + self.left!.codingPath
-            right.codingPath = codingPath + self.right!.codingPath
-            return "\(left.reason) and \(right.reason)"
-        } else if var left = left {
-            left.codingPath = codingPath + self.left!.codingPath
-            return left.reason
-        } else if var right = right {
-            right.codingPath = codingPath + self.right!.codingPath
-            return right.reason
+        if let left = left, let right = right {
+            var mutableLeft = left, mutableRight = right
+            mutableLeft.codingPath = codingPath + left.codingPath
+            mutableRight.codingPath = codingPath + right.codingPath
+            return "\(mutableLeft.reason) and \(mutableRight.reason)"
+        } else if let left = left {
+            var mutableLeft = left
+            mutableLeft.codingPath = codingPath + left.codingPath
+            return mutableLeft.reason
+        } else if let right = right {
+            var mutableRight = right
+            mutableRight.codingPath = codingPath + right.codingPath
+            return mutableRight.reason
         } else {
             return ""
         }

--- a/Sources/Validation/Validators/OrValidator.swift
+++ b/Sources/Validation/Validators/OrValidator.swift
@@ -49,9 +49,9 @@ internal struct OrValidatorError: ValidationError {
     /// See ValidationError.reason
     var reason: String {
         var left = self.left
-        left.codingPath = codingPath + left.codingPath
+        left.codingPath = codingPath + self.left.codingPath
         var right = self.right
-        right.codingPath = codingPath + right.codingPath
+        right.codingPath = codingPath + self.right.codingPath
         return "\(left.reason) and \(right.reason)"
     }
 


### PR DESCRIPTION
The last swift snapshot (2018-02-08) start to enforce the Exclusive Access to Memory (SE-0176) this  cause to fail to build vapor Validation sources.
This PR is fixing that.