### PR TITLE
Append headers to Client requests

### DIFF
--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -36,7 +36,11 @@ extension Client {
             try req.content.encode(content)
             req.http.method = method
             req.http.uri = try uri.makeURI()
-            req.http.headers = headers
+
+            for header in headers where header.name != .contentLength {
+                req.http.headers[header.name] = header.value
+            }
+
             return try self.respond(to: req)
         }
     }


### PR DESCRIPTION
This resolves #1481 by appending supplied headers to the request's headers (and not overwriting the content's `Content-Length` header).

Had to include the filter as `HTTPHeaders` automatically includes a `Content-Length` of 0 on init.