### PR TITLE
client content-length headers fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,10 +54,12 @@ let package = Package(
         // Vapor
         .target(name: "Development", dependencies: ["Vapor"]),
         .target(name: "Vapor", dependencies: [
+            "Async",
             "CodableKit",
             "Command",
             "Console",
             "COperatingSystem",
+            "Crypto",
             "DatabaseKit",
             "Debugging",
             "FormURLEncoded",
@@ -71,7 +73,8 @@ let package = Package(
             "TLS",
             tlsImpl,
             "ServerSecurity",
-             "WebSocket",
+            "WebSocket",
+            "Validation"
         ]),
         .testTarget(name: "VaporTests", dependencies: ["Vapor"]),
     ]

--- a/Sources/Vapor/Engine/Client.swift
+++ b/Sources/Vapor/Engine/Client.swift
@@ -33,10 +33,10 @@ extension Client {
     ) -> Future<Response> where C: Content {
         return Future.flatMap {
             let req = Request(using: self.container)
-            try req.content.encode(content)
             req.http.method = method
             req.http.uri = try uri.makeURI()
             req.http.headers = headers
+            try req.content.encode(content)
             return try self.respond(to: req)
         }
     }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -68,9 +68,39 @@ class ApplicationTests: XCTestCase {
         XCTAssertEqual(req.query["hello"], "world")
     }
 
+    func testClientHeaders() throws {
+        let app = try Application()
+        let fakeClient = LastRequestClient(container: app)
+        _ = try fakeClient.send(.get, headers: ["foo": "bar"], to: "/baz", content: "hello").await(on: app)
+        if let lastReq = fakeClient.lastReq {
+            XCTAssertEqual(lastReq.http.headers[.contentLength], "5")
+            XCTAssertEqual(lastReq.http.headers["foo"], "bar")
+            XCTAssertEqual(lastReq.http.uri.path, "/baz")
+            try XCTAssertEqual(lastReq.http.body.makeData(max: 100).await(on: app), Data("hello".utf8))
+        } else {
+            XCTFail("No last request")
+        }
+    }
+
     static let allTests = [
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
         ("testQuery", testQuery),
+        ("testClientHeaders", testClientHeaders)
     ]
 }
+
+/// MARK: Utilities
+
+final class LastRequestClient: Client {
+    var container: Container
+    var lastReq: Request?
+    init(container: Container) {
+        self.container = container
+    }
+    func respond(to req: Request) throws -> Future<Response> {
+        lastReq = req
+        return Future(req.makeResponse())
+    }
+}
+


### PR DESCRIPTION
- [x] fixes a bug where `client.send(...)` would overwrite the content-length header.