### PR TITLE
race condition & other fluent fixes

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -50,10 +50,6 @@ public final class Application: Container {
         self.eventLoop = try DefaultEventLoop(label: "codes.vapor.application")
         self.router = try self.make(Router.self, for: Application.self)
 
-        Thread.async {
-            self.eventLoop.runLoop()
-        }
-
         // boot all service providers
         for provider in services.providers {
             try provider.boot(self)
@@ -78,7 +74,7 @@ public final class Application: Container {
 
         let console = try make(Console.self)
         try console.run(command, input: &.commandLine)
-
+        
         // Enforce `Never` return.
         // It's possible that this method may actually return, since
         // not all Vapor commands have run loops.

--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -39,7 +39,8 @@ public final class EngineServer: Server, Service {
         
         for i in 1...config.workerCount {
             let eventLoop = try DefaultEventLoop(label: "codes.vapor.engine.server.worker.\(i)")
-            let responder = EngineResponder(container: self.container, responder: responder)
+            let subContainer = self.container.subContainer(on: eventLoop)
+            let responder = EngineResponder(container: subContainer, responder: responder)
             let acceptStream = tcpServer.stream(on: eventLoop).map(to: TCPSocketStream.self) {
                 $0.socket.stream(on: eventLoop) { _, error in
                     logger.reportError(error, as: "Server Error")

--- a/Sources/Vapor/Engine/Request.swift
+++ b/Sources/Vapor/Engine/Request.swift
@@ -33,7 +33,7 @@ public final class Request: ParameterContainer {
     /// Called when the request deinitializes
     deinit {
         if hasActiveConnections {
-            try! privateContainer.releaseCachedConnections()
+            try! releaseCachedConnections()
         }
     }
 }
@@ -84,6 +84,6 @@ extension Request: DatabaseConnectable {
             fatalError("Model.defaultDatabase required to use request as worker.")
         }
         hasActiveConnections = true
-        return privateContainer.requestCachedConnection(to: database)
+        return requestCachedConnection(to: database)
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -74,7 +74,7 @@ class ApplicationTests: XCTestCase {
         _ = try fakeClient.send(.get, headers: ["foo": "bar"], to: "/baz", content: "hello").await(on: app)
         if let lastReq = fakeClient.lastReq {
             XCTAssertEqual(lastReq.http.headers[.contentLength], "5")
-xes            XCTAssertEqual(lastReq.http.headers["foo"], "bar")
+            XCTAssertEqual(lastReq.http.headers["foo"], "bar")
             XCTAssertEqual(lastReq.http.uri.path, "/baz")
             try XCTAssertEqual(lastReq.http.body.makeData(max: 100).await(on: app), Data("hello".utf8))
         } else {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -74,7 +74,7 @@ class ApplicationTests: XCTestCase {
         _ = try fakeClient.send(.get, headers: ["foo": "bar"], to: "/baz", content: "hello").await(on: app)
         if let lastReq = fakeClient.lastReq {
             XCTAssertEqual(lastReq.http.headers[.contentLength], "5")
-            XCTAssertEqual(lastReq.http.headers["foo"], "bar")
+xes            XCTAssertEqual(lastReq.http.headers["foo"], "bar")
             XCTAssertEqual(lastReq.http.uri.path, "/baz")
             try XCTAssertEqual(lastReq.http.body.makeData(max: 100).await(on: app), Data("hello".utf8))
         } else {


### PR DESCRIPTION
- [x] fixes some issues in fluent
- [x] fixes possible race conditions caused by `Thread.async { }` in application init

Use `.await(on: ...)` for any tasks that use the application as an event loop.