### PR TITLE
file middleware fix

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -53,7 +53,8 @@ do {
 
     var middlewareConfig = MiddlewareConfig()
     middlewareConfig.use(ErrorMiddleware.self)
-//    middlewareConfig.use(DateMiddleware.self)
+    middlewareConfig.use(DateMiddleware.self)
+    middlewareConfig.use(FileMiddleware(publicDirectory: "/Users/tanner/Desktop/"))
 //    middlewareConfig.use(SessionsMiddleware.self)
     services.register(middlewareConfig)
 

--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -30,7 +30,7 @@ public final class EngineServer: Server, Service {
 
     /// Start the server. Server protocol requirement.
     public func start() throws {
-        let tcpServer = try TCPServer(socket: TCPSocket(isNonBlocking: true))
+        let tcpServer = try TCPServer(socket: TCPSocket(isNonBlocking: true, shouldReuseAddress: true))
         // leaking, probably because of client capturing itself in closure
         // tcpServer.willAccept = PeerValidator(maxConnectionsPerIP: config.maxConnectionsPerIP).willAccept
         

--- a/Sources/Vapor/Engine/Request+StreamFile.swift
+++ b/Sources/Vapor/Engine/Request+StreamFile.swift
@@ -18,7 +18,6 @@ extension Request {
     ///
     /// For an example of how this is used, look at 'FileMiddleware'
     public func streamFile(at path: String) throws -> Response {
-        let reader = try make(FileReader.self, for: Request.self)
         let res = makeResponse()
 
         guard
@@ -49,12 +48,16 @@ extension Request {
             res.http.mediaType = type
         }
 
-        let passthrough = ConnectingStream<ByteBuffer>()
-        
-        res.http.body = HTTPBody(
-            chunked: passthrough
-        )
-        reader.read(at: path, into: passthrough, chunkSize: 2048)
+        res.http.body = HTTPBody(FileManager.default.contents(atPath: path) ?? Data())
         return res
+        // FIXME: actually stream the file
+        // let reader = try make(FileReader.self, for: Request.self)
+//        let passthrough = ConnectingStream<ByteBuffer>()
+//
+//        res.http.body = HTTPBody(
+//            chunked: passthrough
+//        )
+//        reader.read(at: path, into: passthrough, chunkSize: 2048)
+//        return res
     }
 }


### PR DESCRIPTION
Fixes #1491

- [x] (non-streaming) fix for `Request+StreamFile`
- [x] re-enables SO_REUSEADDR to prevent socket is already bound error after quick server restart