### PR TITLE
Hostname middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you find a **security vulnerability**, please contact [security@vapor.codes](
 
 ### 💙 Code of Conduct
 
-Our goal is to create a safe and empowering environment for anyone who decides to use or contribute to Vapor. Please help us make the community a better place by abiding to this [Code of Conduct](/Docs/CODE_OF_CONDUCT.md) during your interactions surrounding this project.
+Our goal is to create a safe and empowering environment for anyone who decides to use or contribute to Vapor. Please help us make the community a better place by abiding to this [Code of Conduct](https://github.com/vapor/vapor/blob/master/Docs/code_of_conduct.md) during your interactions surrounding this project.
 
 ### 🏫 Tutorials
 

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -51,6 +51,7 @@ do {
 
     var middlewareConfig = MiddlewareConfig()
     middlewareConfig.use(ErrorMiddleware.self)
+    middlewareConfig.use(HostMiddleware(writer: .static("example.com")))
 //    middlewareConfig.use(DateMiddleware.self)
 //    middlewareConfig.use(FileMiddleware(publicDirectory: "/Users/tanner/Desktop/"))
 //    middlewareConfig.use(SessionsMiddleware.self)

--- a/Sources/Vapor/Middleware/HostMiddleware.swift
+++ b/Sources/Vapor/Middleware/HostMiddleware.swift
@@ -1,3 +1,5 @@
+import Service
+
 /// A specification that can write a hostname to a Response
 public struct HostnameWriter {
     /// A closure that can write a Response's Host header based on the `Request`
@@ -22,7 +24,7 @@ public struct HostnameWriter {
 }
 
 /// A middleware that changes the `Host` header field to either a preset hostname or a dynamic one
-public final class HostMiddleware: Middleware {
+public final class HostMiddleware: Middleware, Service {
     /// See `HostnameWriter`
     let hostnameWriter: HostnameWriter
     

--- a/Sources/Vapor/Middleware/HostMiddleware.swift
+++ b/Sources/Vapor/Middleware/HostMiddleware.swift
@@ -1,0 +1,42 @@
+/// A specification that can write a hostname to a Response
+public struct HostnameWriter {
+    /// A closure that can write a Response's Host header based on the `Request`
+    internal typealias Modify = (Request, Response) -> ()
+    
+    /// See `Modify`
+    internal var modify: Modify
+    
+    /// Sets the `Response`'s hostname to the `Requests` URI.hostname
+    public static func adaptive() -> HostnameWriter {
+        return self.init { request, response in
+            response.http.headers[.host] = request.http.uri.hostname
+        }
+    }
+    
+    /// Always sets the hostname to the provided name
+    public static func `static`(_ name: String) -> HostnameWriter {
+        return self.init { _, response in
+            response.http.headers[.host] = name
+        }
+    }
+}
+
+/// A middleware that changes the `Host` header field to either a preset hostname or a dynamic one
+public final class HostMiddleware: Middleware {
+    /// See `HostnameWriter`
+    let hostnameWriter: HostnameWriter
+    
+    /// Creates a new Hostname writing middleware based on a `HostnameWriter` specification
+    public init(writer: HostnameWriter) {
+        self.hostnameWriter = writer
+    }
+    
+    /// Updates the returned response to write the hostname
+    public func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
+        // Since `Response` is a class we don't need to transform  it
+        // We can change the variables by reference instead
+        return try next.respond(to: request).do { response in
+            self.hostnameWriter.modify(request, response)
+        }
+    }
+}

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -40,5 +40,6 @@ class MiddlewareTests : XCTestCase {
 
     static let allTests = [
         ("testNotConfigurable", testNotConfigurable),
+        ("testHostnameMiddlware", testHostnameMiddlware),
     ]
 }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -24,6 +24,19 @@ class MiddlewareTests : XCTestCase {
         _ = try app.make(Responder.self).respond(to: req).blockingAwait()
         XCTAssert(myMiddleware.flag == true)
     }
+    
+    func testHostnameMiddlware() throws {
+        var services = Services.default()
+        var middlewareConfig = MiddlewareConfig()
+        middlewareConfig.use(HostMiddleware(writer: .static("example.com")))
+        services.register(middlewareConfig)
+        
+        let app = try Application(services: services)
+        
+        let req = Request(http: .init(), using: app)
+        let response = try app.make(Responder.self).respond(to: req).blockingAwait()
+        XCTAssertEqual(response.http.headers[.host], "example.com")
+    }
 
     static let allTests = [
         ("testNotConfigurable", testNotConfigurable),


### PR DESCRIPTION
Adds a middleware that sets the hostname adaptively or statically.

This middleware is not added to the default middleware configuration, if agreed upon I think this should be added.