### PR TITLE
foundation client

### DIFF
--- a/Sources/Vapor/Engine/FoundationClient.swift
+++ b/Sources/Vapor/Engine/FoundationClient.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// `Client` wrapper around `Foundation.URLSession`.
+public final class FoundationClient: Client {
+    /// See `Client.container`
+    public var container: Container
+
+    /// The `URLSession` powering this client.
+    private let urlSession: URLSession
+
+    /// Creates a new `FoundationClient`
+    public init(_ urlSession: URLSession, on container: Container) {
+        self.urlSession = urlSession
+        self.container = container
+    }
+
+    /// Creates a `FoundationClient` with default settings.
+    public static func `default`(on container: Container) -> FoundationClient {
+        return .init(.init(configuration: .default), on: container)
+    }
+
+    /// See `Client.respond(to:)`
+    public func respond(to req: Request) throws -> Future<Response> {
+        return req.http.makeFoundationRequest().flatMap(to: Response.self) { urlReq in
+            let promise = Promise(Response.self)
+            self.urlSession.dataTask(with: urlReq) { data, urlResponse, error in
+                if let error = error {
+                    promise.fail(error, onNextTick: self.container)
+                    return
+                }
+
+                guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                    fatalError("URLResponse was not a HTTPURLResponse.")
+                }
+
+                let response = HTTPResponse.fromFoundationResponse(httpResponse, data: data)
+                promise.complete(Response(http: response, using: self.container), onNextTick: self.container)
+            }.resume()
+            return promise.future
+        }
+    }
+}
+
+/// MARK: Service
+
+extension FoundationClient: ServiceType {
+    /// See `ServiceType.serviceSupports`
+    public static var serviceSupports: [Any.Type] { return [Client.self] }
+
+    /// See `ServiceType.makeService(for:)`
+    public static func makeService(for worker: Container) throws -> FoundationClient {
+        if let sub = worker as? SubContainer {
+            /// if a request is creating a client, we should
+            /// use the event loop as the container
+            return .default(on: sub.superContainer)
+        } else {
+            return .default(on: worker)
+        }
+    }
+}
+
+/// MARK: Utility
+
+extension HTTPRequest {
+    /// Converts an `HTTP.HTTPRequest` to `Foundation.URLRequest`
+    fileprivate func makeFoundationRequest() -> Future<URLRequest> {
+        let http = self
+        return http.body.makeData(max: 100_000).map(to: URLRequest.self) { body in
+            let url = http.uri.makeFoundationURL()
+            var request = URLRequest(url: url)
+            request.httpMethod = http.method.string.uppercased()
+            request.httpBody = body
+            http.headers.forEach { key, val in
+                request.addValue(val, forHTTPHeaderField: key.description)
+            }
+            return request
+        }
+    }
+}
+
+extension HTTPResponse {
+    /// Creates an `HTTP.HTTPResponse` to `Foundation.URLResponse`
+    fileprivate static func fromFoundationResponse(_ httpResponse: HTTPURLResponse, data: Data?) -> HTTPResponse {
+        var res = HTTPResponse(status: .init(code: httpResponse.statusCode))
+        for (key, value) in httpResponse.allHeaderFields {
+            res.headers[.init("\(key)")] = "\(value)"
+        }
+        if let data = data {
+            res.body = HTTPBody(data)
+        }
+        return res
+    }
+}
+
+extension URI {
+    /// Converts an `HTTP.URI` to a `Foundation.URL`
+    fileprivate func makeFoundationURL() -> URL {
+        var comps = URLComponents()
+        comps.scheme = scheme
+        comps.user = userInfo?.username
+        comps.password = userInfo?.info
+        comps.host = hostname
+        comps.port = port.flatMap(Int.init)
+        comps.path = path
+        comps.query = query
+        comps.fragment = fragment
+        guard let url = comps.url else {
+            fatalError()
+        }
+        return url
+    }
+}

--- a/Sources/Vapor/Services/Config+Default.swift
+++ b/Sources/Vapor/Services/Config+Default.swift
@@ -5,6 +5,7 @@ extension Config {
     public static func `default`() -> Config {
         var config = Config()
         config.prefer(ConsoleLogger.self, for: Logger.self)
+        config.prefer(EngineClient.self, for: Client.self)
         return config
     }
 }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -89,6 +89,7 @@ extension Services {
                 return try EngineClient(container: container, config: container.make(for: EngineClient.self))
             }
         }
+        services.register(FoundationClient.self)
 
         services.register { container -> EngineClientConfig in
             return EngineClientConfig()

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -151,6 +151,17 @@ class ApplicationTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .ascii)?.contains("iPhone"), true)
     }
 
+    func testFoundationClientItunesAPI() throws {
+        var config = Config.default()
+        config.prefer(FoundationClient.self, for: Client.self)
+        let app = try Application(config: config)
+        let client = try app.make(Client.self)
+        XCTAssert(client is FoundationClient)
+        let res = try client.send(.get, to: "https://itunes.apple.com/search?term=mapstr&country=fr&entity=software&limit=1").await(on: app)
+        let data = try res.http.body.makeData(max: 100_000).await(on: app)
+        XCTAssertEqual(String(data: data, encoding: .ascii)?.contains("iPhone"), true)
+    }
+
     static let allTests = [
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
@@ -164,6 +175,7 @@ class ApplicationTests: XCTestCase {
         ("testClientTooManyAbsoluteRedirects", testClientTooManyAbsoluteRedirects),
         ("testClientHeaders", testClientHeaders),
         ("testClientItunesAPI", testClientItunesAPI),
+        ("testFoundationClientItunesAPI", testFoundationClientItunesAPI),
     ]
 }
 


### PR DESCRIPTION
- [x] adds a `FoundationClient` class that implements `Client` protocol using `URLSession`. This provides a useful but less performant alternative to `EngineClient`.

**Create a single `FoundationClient`**

```swift
let client = try req.make(FoundationClient.self)
...
```

**Or prefer `FoundationClient` globally**

```swift
var config = Config.default()
config.prefer(FoundationClient.self, for: Client.self)
let app = try Application(config: config)
let client = try app.make(Client.self)
print(client is FoundationClient) // true
```

**Use just like `EngineClient`**

```swift
...
let res = try client.send(.get, to: "http://vapor.codes")
debugPrint(res)
```