### PR TITLE
Change short flag for version command to "v"

### DIFF
--- a/Sources/Vapor/Commands/MainCommand.swift
+++ b/Sources/Vapor/Commands/MainCommand.swift
@@ -11,7 +11,7 @@ internal struct MainCommand: CommandGroup {
     init(commands: [String: CommandRunnable], defaultRunnable: CommandRunnable?) {
         self.commands = commands
         self.options = [
-            .flag(name: "version", short: "c", help: ["Displays the framework's version"])
+            .flag(name: "version", short: "v", help: ["Displays the framework's version"])
         ]
         self.help = ["Runs your Vapor application's commands"]
         self.defaultRunnable = defaultRunnable


### PR DESCRIPTION
The version command prints the version of the framework. There are 2 ways to run it, by passing in the long flag (`--version`) and the short flag. The latter is currently `-c` but that was most likely a typo and should be `-v`.