### PR TITLE
nio-based websockets

### DIFF
--- a/Docs/contributing.md
+++ b/Docs/contributing.md
@@ -12,7 +12,9 @@ Utilities/contributor_test.sh
 
 ## Testing
 
-Once in Xcode, select the `FluentPostgreSQL-Package` scheme and use `CMD+U` to run the tests.
+Once in Xcode, select the `Vapor-Package` scheme and use `CMD+U` to run the tests.
+
+You can use the `Boilerplate...` and `Development` executables for testing out your code.
 
 When adding new tests (please do 😁), don't forget to add the method name to the `allTests` array. 
 If you add a new `XCTestCase` subclass, make sure to add it to the `Tests/LinuxMain.swift` file.

--- a/Docs/contributing.md
+++ b/Docs/contributing.md
@@ -1,0 +1,63 @@
+# Contributing to Vapor
+
+👋 Welcome to the Vapor team! 
+
+## Linux
+
+You can use the included bash script to test your PR on macOS and Linux before submitting (you must have Docker installed).
+
+```sh
+Utilities/contributor_test.sh 
+```
+
+## Testing
+
+Once in Xcode, select the `FluentPostgreSQL-Package` scheme and use `CMD+U` to run the tests.
+
+When adding new tests (please do 😁), don't forget to add the method name to the `allTests` array. 
+If you add a new `XCTestCase` subclass, make sure to add it to the `Tests/LinuxMain.swift` file.
+
+If you are fixing a single GitHub issue in particular, you can add a test named `testGH<issue number>` to ensure
+that your fix is working. This will also help prevent regression.
+
+## SemVer
+
+Vapor follows [SemVer](https://semver.org). This means that any changes to the source code that can cause
+existing code to stop compiling _must_ wait until the next major version to be included. 
+
+Code that is only additive and will not break any existing code can be included in the next minor release.
+
+## Extras
+
+Here are some bash functions to help you test Swift on Linux easily from macOS (you must have Docker installed).
+
+```bash
+# Starts docker-machine and exports env variables.
+_docker_start() {
+    docker-machine start default
+    eval "$(docker-machine env default)"
+}
+alias docker-start='_docker_start'
+
+# Executes /usr/bin/swift in a Swift 4.1 docker container
+_swift_linux() {
+    _docker_start
+    docker run -it -v $PWD:/root/code -w /root/code norionomura/swift:swift-4.1-branch /usr/bin/swift $1
+}
+alias swift-linux='_swift_linux'
+```
+
+You can add these methods to your `~/.bash_profile`. Just run `source ~/.bash_profile` after or restart your terminal.
+
+Once added, you can run the following to test Swift projects on both macOS and Linux.
+
+```sh
+swift test
+swift-linux test
+```
+
+----------
+
+Join us on Slack if you have any questions: [http://vapor.team](http://vapor.team).
+
+&mdash; Thanks! 🙌

--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,7 @@ let package = Package(
             "Service",
             "TemplateKit",
             "Validation",
+            "WebSocket"
         ]),
         .testTarget(name: "VaporTests", dependencies: ["Vapor"]),
     ]

--- a/Sources/Boilerplate/configure.swift
+++ b/Sources/Boilerplate/configure.swift
@@ -10,6 +10,13 @@ public func configure(
     try routes(router)
     services.register(router, as: Router.self)
 
+    let websockets = EngineWebSocketServer.default { ws, req in
+        ws.onText { text in
+            ws.send(text.reversed())
+        }
+    }
+    services.register(websockets, as: WebSocketServer.self)
+
     // configure your application here
     let middlewareConfig = MiddlewareConfig()
     // middlewareConfig.use(DateMiddleware.self)

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -14,6 +14,10 @@ public func routes(_ router: Router) throws {
         return try req.parameter(String.self)
     }
 
+    router.get("users", User.parameter, "foo") { req in
+        return try req.parameter(User.self)
+    }
+
     router.get("search") { req in
         return req.query["q"] ?? "none"
     }
@@ -23,4 +27,17 @@ public func routes(_ router: Router) throws {
             return String(data: res.http.body.data ?? Data(), encoding: .ascii) ?? ""
         }
     }
+}
+
+struct User: Parameter, Content {
+    let string: String
+
+    static func make(for parameter: String, using container: Container) throws -> EventLoopFuture<User> {
+        return Future.map(on: container) {
+            return User(string: parameter)
+        }
+    }
+
+    typealias ResolvedParameter = Future<User>
+
 }

--- a/Sources/Vapor/Engine/EngineServer.swift
+++ b/Sources/Vapor/Engine/EngineServer.swift
@@ -36,6 +36,22 @@ public final class EngineServer: Server, Service {
 
         let group = MultiThreadedEventLoopGroup(numThreads: config.workerCount)
 
+        /// http upgrade
+        var upgraders: [HTTPProtocolUpgrader] = []
+
+        /// web socket upgrade
+        if let wss = try? container.make(WebSocketServer.self, for: EngineServer.self) {
+            let ws = WebSocket.httpProtocolUpgrader(shouldUpgrade: { req in
+                let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
+                return wss.webSocketShouldUpgrade(for: Request(http: req, using: container))
+            }, onUpgrade: { ws, req in
+                let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
+                return wss.webSocketOnUpgrade(ws, for: Request(http: req, using: container))
+            })
+            upgraders.append(ws)
+        }
+
+
         let server = try HTTPServer.start(
             hostname: config.hostname,
             port: config.port,
@@ -44,6 +60,7 @@ public final class EngineServer: Server, Service {
             backlog: config.backlog,
             reuseAddress: config.reuseAddress,
             tcpNoDelay: config.tcpNoDelay,
+            upgraders: upgraders,
             on: group
         ) { error in
             logger.reportError(error)
@@ -61,26 +78,39 @@ struct EngineResponder: HTTPResponder {
     }
 
     func respond(to request: HTTPRequest, on worker: Worker) -> Future<HTTPResponse> {
-        let container: SubContainer
-        if let existing = Thread.current.threadDictionary["subcontainer"] as? SubContainer {
-            container = existing
-        } else {
-            let new = rootContainer.subContainer(on: worker)
-            container = new
-            Thread.current.threadDictionary["subcontainer"] = new
+        let container = Thread.current.cachedSubContainer(for: rootContainer, on: worker)
+        return Future.flatMap(on: worker) {
+            let responder = try Thread.current.cachedResponder(for: container)
+            let req = Request(http: request, using: container)
+            return try responder.respond(to: req).map(to: HTTPResponse.self) { $0.http }
         }
+    }
+}
 
+extension Thread {
+    func cachedSubContainer(for container: Container, on worker: Worker) -> SubContainer {
+        let subContainer: SubContainer
+        if let existing = threadDictionary["subcontainer"] as? SubContainer {
+            subContainer = existing
+        } else {
+            let new = container.subContainer(on: worker)
+            subContainer = new
+            threadDictionary["subcontainer"] = new
+        }
+        return subContainer
+    }
+
+
+    func cachedResponder(for container: Container) throws -> Responder {
         let responder: Responder
-        if let existing = Thread.current.threadDictionary["responder"] as? ApplicationResponder {
+        if let existing = threadDictionary["responder"] as? ApplicationResponder {
             responder = existing
         } else {
-            let new = try! container.make(Responder.self, for: EngineServer.self)
+            let new = try container.make(Responder.self, for: EngineServer.self)
             responder = new
-            Thread.current.threadDictionary["responder"] = new
+            threadDictionary["responder"] = new
         }
-
-        let req = Request(http: request, using: container)
-        return try! responder.respond(to: req).map(to: HTTPResponse.self) { $0.http }
+        return responder
     }
 }
 

--- a/Sources/Vapor/Engine/WebSocket.swift
+++ b/Sources/Vapor/Engine/WebSocket.swift
@@ -1,0 +1,31 @@
+public protocol WebSocketServer {
+    func webSocketShouldUpgrade(for request: Request) -> Bool
+    func webSocketOnUpgrade(_ webSocket: WebSocket, for request: Request)
+}
+
+public final class EngineWebSocketServer: WebSocketServer, Service {
+    private let shouldUpgrade: (Request) -> Bool
+    private let onUpgrade: (WebSocket, Request) throws -> ()
+
+    public init(shouldUpgrade: @escaping (Request) -> Bool, onUpgrade: @escaping (WebSocket, Request) throws -> ()) {
+        self.shouldUpgrade = shouldUpgrade
+        self.onUpgrade = onUpgrade
+    }
+
+    public static func `default`(shouldUpgrade: @escaping (Request) -> Bool = { _ in return true }, onUpgrade: @escaping (WebSocket, Request) throws -> ()) -> EngineWebSocketServer {
+        return .init(shouldUpgrade: shouldUpgrade, onUpgrade: onUpgrade)
+    }
+
+    public func webSocketShouldUpgrade(for request: Request) -> Bool {
+        return shouldUpgrade(request)
+    }
+
+    public func webSocketOnUpgrade(_ webSocket: WebSocket, for request: Request) {
+        do {
+            return try onUpgrade(webSocket, request)
+        } catch {
+            ERROR("WebSocket: \(error)")
+            webSocket.close()
+        }
+    }
+}

--- a/Sources/Vapor/Middleware/DateMiddleware.swift
+++ b/Sources/Vapor/Middleware/DateMiddleware.swift
@@ -37,16 +37,10 @@ public final class DateMiddleware: Middleware, Service {
 
     /// See `Middleware.respond(to:)`
     public func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
-        let promise = request.eventLoop.newPromise(Response.self)
-        
-        try next.respond(to: request).do { res in
+        return try next.respond(to: request).map(to: Response.self) { res in
             res.http.headers.replaceOrAdd(name: "Date", value: self.getDate())
-            promise.succeed(result: res)
-        }.catch { error in
-            promise.fail(error: error)
+            return res
         }
-        
-        return promise.futureResult
     }
 
     /// Gets the current RFC 1123 date string.

--- a/Sources/Vapor/Sessions/KeyedCacheSessions.swift
+++ b/Sources/Vapor/Sessions/KeyedCacheSessions.swift
@@ -27,7 +27,7 @@ public final class KeyedCacheSessions: Sessions {
         if let existing = session.id {
             sessionID = existing
         } else {
-            sessionID = OSRandom().data(count: 16).base64Encoded()!
+            sessionID = try URandom().data(count: 16).base64Encoded()!
         }
         session.id = sessionID
         return try keyedCache.set(session.data, forKey: sessionID).transform(to: session)

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -38,7 +38,7 @@ public final class MemorySessions: Sessions {
         if let existing = session.id {
             sessionID = existing
         } else {
-            sessionID = OSRandom().data(count: 16).base64Encoded()! // should never fail
+            sessionID = try URandom().data(count: 16).base64Encoded()! // should never fail
         }
         session.id = sessionID
         sessions[sessionID] = session

--- a/Sources/Vapor/Utilities/Exports.swift
+++ b/Sources/Vapor/Utilities/Exports.swift
@@ -14,3 +14,4 @@
 @_exported import class Foundation.URLSession
 @_exported import struct Foundation.Data
 @_exported import struct Foundation.Date
+@_exported import WebSocket

--- a/Utilities/contributor_test.sh
+++ b/Utilities/contributor_test.sh
@@ -1,0 +1,27 @@
+echo "💧  Running unit tests on macOS"
+swift test
+MACOS_EXIT=$?
+
+echo "💧  Starting docker-machine"
+docker-machine start default
+
+echo "💧  Exporting docker-machine env"
+eval "$(docker-machine env default)"
+
+echo "💧  Running unit tests on Linux"
+docker run -it -v $PWD:/root/code -w /root/code norionomura/swift:swift-4.1-branch /usr/bin/swift test
+LINUX_EXIT=$?
+
+if [[ $MACOS_EXIT == 0 ]];
+then
+	echo "✅  macOS Passed"
+else
+	echo "🚫  macOS Failed"
+fi
+
+if [[ $LINUX_EXIT == 0 ]];
+then
+	echo "✅  Linux Passed"
+else
+	echo "🚫  Linux Failed"
+fi


### PR DESCRIPTION
- [x] adds NIO-based WebSocket support to Vapor
- [ ] add fix-it and deprecations to old websocket API

Due to the way NIO handles HTTP protocol upgrades, the API for WebSockets will need to change quite a bit. 

The updated API allows you to register a `WebSocketServer` like you would any other service (in your `configure.swift` file).

```swift
let websockets = EngineWebSocketServer.default { ws, req in
    ws.onText { text in
        ws.send(text.reversed())
    }
}
services.register(websockets, as: WebSocketServer.self)
```

By default, all websocket upgrade requests will be accepted, and the connected websocket will be supplied to the closure.

It's also possible to specify another closure that can accept or deny a websocket connection given the HTTP request that requested it.

With this new design, websocket requests and responses will no longer flow through the application middleware structure. This is an important difference to the previous structure and to the structure from Vapor 2. Re-creating that would require opting out of the NIO defaults for websocket and creating a custom HTTP upgrader implementation. I don't think that's worth it to keep the old API, especially when this will be the case for future HTTP protocol upgrade handlers as well. However, this is open to discussion.