### PR TITLE
Better convert status code into HTTPResponseStatus

### DIFF
--- a/Sources/Vapor/HTTP/FoundationClient.swift
+++ b/Sources/Vapor/HTTP/FoundationClient.swift
@@ -78,7 +78,7 @@ extension HTTPRequest {
 extension HTTPResponse {
     /// Creates an `HTTP.HTTPResponse` to `Foundation.URLResponse`
     fileprivate static func fromFoundationResponse(_ httpResponse: HTTPURLResponse, data: Data?, on worker: Worker) -> HTTPResponse {
-        var res = HTTPResponse(status: .custom(code: UInt(httpResponse.statusCode), reasonPhrase: ""))
+        var res = HTTPResponse(status: .init(statusCode: httpResponse.statusCode))
         for (key, value) in httpResponse.allHeaderFields {
             res.headers.replaceOrAdd(name: "\(key)", value: "\(value)")
         }


### PR DESCRIPTION
This depends on version 1.3.0 of SwiftNIO, see: https://github.com/apple/swift-nio/pull/158

The benefit of this change is that when you have a known status code (e.g. 200) this will be converted to `HTTPResponseStatus.ok` instead of `HTTPResponseStatus.custom(200, "")`. This allows comparing the status code of the resulting `HTTPResponse` directly to a `HTTPResponseStatus` case.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
