### PR TITLE
fix DateMiddleWare cached timestamp return logic

### DIFF
--- a/Sources/Vapor/Middleware/DateMiddleware.swift
+++ b/Sources/Vapor/Middleware/DateMiddleware.swift
@@ -53,7 +53,7 @@ public final class DateMiddleware: Middleware, Service {
     fileprivate func getDate() -> String {
         var date = COperatingSystem.time(nil)
 
-        if let (timestamp, createdAt) = cachedTimestamp, date <= createdAt + accuracy {
+        if let (timestamp, createdAt) = cachedTimestamp, (createdAt...(createdAt + accuracy)).contains(date) {
             return timestamp
         }
         

--- a/Sources/Vapor/Middleware/DateMiddleware.swift
+++ b/Sources/Vapor/Middleware/DateMiddleware.swift
@@ -53,7 +53,7 @@ public final class DateMiddleware: Middleware, Service {
     fileprivate func getDate() -> String {
         var date = COperatingSystem.time(nil)
 
-        if let (timestamp, createdAt) = cachedTimestamp, createdAt <= date + accuracy {
+        if let (timestamp, createdAt) = cachedTimestamp, date <= createdAt + accuracy {
             return timestamp
         }
         


### PR DESCRIPTION
`createdAt <= date + accuracy` will always evaluate to `true`, thus the cached timestamp value will always be returned, never recalculated.

Suggested `date <= createdAt + accuracy` will only return if accuracy threshold has not been exceeded, and otherwise fall through to create a new timestamp value.

Further discussion raised other potential issues:

> A more human-readable way to write the logic might be `(date..<(date + accuracy)).contains(createdAt)`
>
> (But is very slightly less efficient)
>
> Here's another more readable form: `date - createdAt < accuracy` - however this suffers from the signed arithmetic problem where the system clock can be adjusted arbitrarily without warning.
>
> (in fact the current way of tracking it is also susceptible to that - `time()` is not a monotonic clock)
>
> The closed range form is the only one which will correctly toss the existing timestamp if the system clock is adjusted backwards by > 1 second (DST for example, or even general drift)