### PR TITLE
Fix usage of the updated Base64 API

### DIFF
--- a/Sources/Vapor/Sessions/KeyedCacheSessions.swift
+++ b/Sources/Vapor/Sessions/KeyedCacheSessions.swift
@@ -27,7 +27,7 @@ public final class KeyedCacheSessions: Sessions {
         if let existing = session.id {
             sessionID = existing
         } else {
-            sessionID = OSRandom().data(count: 16).base64Encoded()!
+            sessionID = OSRandom().data(count: 16).base64Encoded()
         }
         session.id = sessionID
         return try keyedCache.set(session.data, forKey: sessionID).transform(to: session)

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -38,7 +38,7 @@ public final class MemorySessions: Sessions {
         if let existing = session.id {
             sessionID = existing
         } else {
-            sessionID = OSRandom().data(count: 16).base64Encoded()! // should never fail
+            sessionID = OSRandom().data(count: 16).base64Encoded()
         }
         session.id = sessionID
         sessions[sessionID] = session


### PR DESCRIPTION
(This was broken since making `Data.base64Encoded()` throwing yesterday, and it's still broken after making it non-throwing again today. This fixes it once `fix-base64` is merged in `vapor-core`.)