### PR TITLE
use environment for command line arguments

### DIFF
--- a/Sources/Boilerplate/configure.swift
+++ b/Sources/Boilerplate/configure.swift
@@ -7,8 +7,10 @@ public func configure(
     _ services: inout Services
 ) throws {
     let router = EngineRouter.default()
-    try routes(router)
+    try routes(router) 
     services.register(router, as: Router.self)
+
+    try services.register(EngineServerConfig.detect(from: &env))
 
     let websockets = EngineWebSocketServer.default()
     websockets.get(.anything) { ws, req in

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -42,18 +42,80 @@ public final class Application: Container {
     /// Use this to create stored properties in extensions.
     public var extend: Extend
 
-    /// Creates a new `Application`.
+    // MARK: Boot
+
+    /// Asynchronously creates and boots a new `Application`.
     ///
     /// - parameters:
     ///     - config: Configuration preferences for this service container.
     ///     - environment: Application's environment type (i.e., testing, production).
     ///                    Different environments can trigger different application behavior (for example, supressing verbose logs in production mode).
     ///     - services: Application's available services. A copy of these services will be passed to all sub event-loops created by this Application.
-    public init(
+    public static func asyncBoot(config: Config = .default(), environment: Environment = .development, services: Services = .default()) -> Future<Application> {
+        let app = Application(config, environment, services)
+        return app.boot().map(to: Application.self) { app }
+    }
+
+    /// Synchronously creates and boots a new `Application`.
+    ///
+    /// - parameters:
+    ///     - config: Configuration preferences for this service container.
+    ///     - environment: Application's environment type (i.e., testing, production).
+    ///                    Different environments can trigger different application behavior (for example, supressing verbose logs in production mode).
+    ///     - services: Application's available services. A copy of these services will be passed to all sub event-loops created by this Application.
+    public convenience init(
         config: Config = .default(),
         environment: Environment = .development,
         services: Services = .default()
     ) throws {
+        self.init(config, environment, services)
+        try boot().wait()
+    }
+
+    // MARK: Run
+
+    /// Asynchronously runs the `Application`'s commands. This method will call the `willRun(_:)` methods of all
+    /// registered `VaporProvider's` before running.
+    ///
+    /// Normally this command will boot an `HTTPServer`. However, depending on configuration and command-line arguments/flags, this method may run a different command.
+    /// See `CommandConfig` for more information about customizing the commands that this method runs.
+    ///
+    ///     try app.asyncRun().wait()
+    ///
+    /// Note: When running a server, `asyncRun()` will return when the server has finished _booting_. Use the `runningServer` property on `Application` to wait
+    /// for the server to close. The synchronous `run()` method will call this automatically.
+    ///
+    ///     try app.runningServer?.onClose().wait()
+    ///
+    /// All `VaporProvider`'s `didRun(_:)` methods will be called before finishing.
+    public func asyncRun() -> Future<Void> {
+        return Future.flatMap(on: self) {
+            // will-run all vapor service providers
+            return try self.services.providers.onlyVapor.map { try $0.willRun(self) }.flatten(on: self)
+        }.flatMap(to: Void.self) {
+            let command = try self.make(CommandConfig.self)
+                .makeCommandGroup(for: self)
+            let console = try self.make(Console.self)
+
+            /// Create a mutable copy of the environment input for this run.
+            var runInput = self.environment.commandInput
+            return try console.run(command, input: &runInput, on: self)
+        }.flatMap(to: Void.self) {
+            // did-run all vapor service providers
+            return try self.services.providers.onlyVapor.map { try $0.didRun(self) }.flatten(on: self)
+        }
+    }
+
+    /// Synchronously calls `asyncRun()` and waits for the running server to close (if one exists).
+    public func run() throws {
+        try asyncRun().wait()
+        try runningServer?.onClose.wait()
+    }
+
+    // MARK: Internal
+
+    /// Internal initializer. Creates an `Application` without booting providers.
+    internal init(_ config: Config, _ environment: Environment, _ services: Services) {
         self.config = config
         self.environment = environment
         self.services = services
@@ -61,61 +123,29 @@ public final class Application: Container {
         self.extend = Extend()
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
 
-        // let providers detect and mutate the environment
-        for provider in services.providers {
-            try provider.detect(&self.environment)
-        }
+    }
 
-        // will-boot all service providers
-        for provider in services.providers {
-            try provider.willBoot(self).wait()
-        }
-
-        if _isDebugAssertConfiguration() && environment.isRelease {
-            let log = try self.make(Logger.self)
-            log.warning("Debug build mode detected while configured for release environment: \(environment.name).")
-            log.info("Compile your application with `-c release` to enable code optimizations.")
-        }
-
-        // did-boot all service providers
-        for provider in services.providers {
-            try provider.didBoot(self).wait()
+    /// Internal method. Boots the application and its providers.
+    internal func boot() -> Future<Void> {
+        return Future.map(on: self) {
+            // let providers detect and mutate the environment
+            try self.services.providers.forEach { try $0.detect(&self.environment) }
+        }.flatMap(to: Void.self) {
+            // will-boot all service providers
+            return try self.services.providers.map { try $0.willBoot(self) }.flatten(on: self)
+        }.map(to: Void.self) {
+            if _isDebugAssertConfiguration() && self.environment.isRelease {
+                let log = try self.make(Logger.self)
+                log.warning("Debug build mode detected while configured for release environment: \(self.environment.name).")
+                log.info("Compile your application with `-c release` to enable code optimizations.")
+            }
+        }.flatMap(to: Void.self) {
+            // did-boot all service providers
+            return try self.services.providers.map { try $0.didBoot(self) }.flatten(on: self)
         }
     }
 
-    /// Runs the `Application`'s commands. This method will call the `willRun(_:)` methods of all registered `VaporProvider's` before running.
-    ///
-    /// Normally this command will boot an `HTTPServer` that will run indefinitely. However, depending on configuration and command-line arguments/flags, this method may run a different command.
-    /// To prevent confusion, this method will call `exit` before finishing and returns `Never`.
-    ///
-    /// See `CommandConfig` for more information about customizing the commands that this method runs.
-    ///
-    /// All `VaporProvider`'s `didRun(_:)` methods will be called before the `Application` calls `exit`.
-    public func run() throws -> Never {
-        // will-run all vapor service providers
-        for provider in services.providers.onlyVapor {
-            try provider.willRun(self).wait()
-        }
-
-        let command = try make(CommandConfig.self)
-            .makeCommandGroup(for: self)
-
-        let console = try make(Console.self)
-        try console.run(command, input: &environment.commandInput)
-
-        // did-run all vapor service providers
-        for provider in services.providers.onlyVapor {
-            try provider.didRun(self).wait()
-        }
-        
-        // Enforce `Never` return.
-        // It's possible that this method may actually return, since
-        // not all Vapor commands have run loops.
-        // However, because this method likely _can_ result in
-        // a run loop, having a `Never` may help reduce bugs.
-        exit(0)
-    }
-
+    /// Called when the app deinitializes.
     deinit {
         eventLoopGroup.shutdownGracefully {
             if let error = $0 {

--- a/Sources/Vapor/Commands/CommandConfig.swift
+++ b/Sources/Vapor/Commands/CommandConfig.swift
@@ -61,31 +61,3 @@ public struct CommandConfig: Service {
         )
     }
 }
-
-extension Environment {
-    /// Detects the environment from command line arguments
-    /// or returns development if none was passed.
-    public static func detect() throws -> Environment {
-        var env: Environment = .development
-        if let value = try CommandInput.commandLine.parse(option: .value(name: "env")) {
-            env = Environment(commandLine: value)
-        }
-        return env
-    }
-}
-
-extension Environment {
-    /// Initialize the environment from a command line argument.
-    internal init(commandLine string: String) {
-        switch string {
-        case "prod", "production":
-            self = .production
-        case "dev", "development":
-            self = .development
-        case "test", "testing":
-            self = .testing
-        default:
-            self = .custom(name: string)
-        }
-    }
-}

--- a/Sources/Vapor/Commands/MainCommand.swift
+++ b/Sources/Vapor/Commands/MainCommand.swift
@@ -17,16 +17,17 @@ internal struct MainCommand: CommandGroup {
         self.defaultRunnable = defaultRunnable
     }
 
-    func run(using context: CommandContext) throws {
+    func run(using context: CommandContext) throws -> Future<Void> {
         if context.options["version"] == "true" {
             context.console.info("Vapor Framework v", newLine: false)
             context.console.print("3.0")
         } else {
             if let lazy = self.defaultRunnable {
-                try lazy.run(using: context)
+                return try lazy.run(using: context)
             } else {
                 throw VaporError(identifier: "noDefaultCommand", reason: "No default command has been registered.", source: .capture())
             }
         }
+        return .done(on: context.container)
     }
 }

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -22,7 +22,7 @@ public struct RoutesCommand: Command, Service {
     }
 
     /// See Runnable.run
-    public func run(using context: CommandContext) throws {
+    public func run(using context: CommandContext) throws -> Future<Void> {
         let console = context.console
         
         var longestMethod = 0
@@ -109,6 +109,8 @@ public struct RoutesCommand: Command, Service {
             console.print(" |")
             hr()
         }
+
+        return .done(on: context.container)
     }
 }
 

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -21,7 +21,7 @@ public struct ServeCommand: Command, Service {
     }
 
     /// See Runnable.run
-    public func run(using context: CommandContext) throws {
-        try server.start()
+    public func run(using context: CommandContext) throws -> Future<Void> {
+        return server.start()
     }
 }

--- a/Sources/Vapor/HTTP/EngineServer.swift
+++ b/Sources/Vapor/HTTP/EngineServer.swift
@@ -200,11 +200,12 @@ extension EngineServerConfig {
         workerCount: Int = ProcessInfo.processInfo.activeProcessorCount,
         maxBodySize: Int = 1_000_0000,
         reuseAddress: Bool = true,
-        tcpNoDelay: Bool = true
+        tcpNoDelay: Bool = true,
+        from env: inout Environment
     ) throws -> EngineServerConfig {
         return try EngineServerConfig(
-            hostname: CommandInput.commandLine.parse(option: .value(name: "hostname")) ?? hostname,
-            port: CommandInput.commandLine.parse(option: .value(name: "port")).flatMap(Int.init) ?? port,
+            hostname: env.commandInput.parse(option: .value(name: "hostname")) ?? hostname,
+            port: env.commandInput.parse(option: .value(name: "port")).flatMap(Int.init) ?? port,
             backlog: backlog,
             workerCount: workerCount,
             maxBodySize: maxBodySize,

--- a/Sources/Vapor/HTTP/EngineServer.swift
+++ b/Sources/Vapor/HTTP/EngineServer.swift
@@ -26,48 +26,53 @@ public final class EngineServer: Server, Service {
     }
 
     /// Start the server. Server protocol requirement.
-    public func start() throws {
-        let console = try container.make(Console.self)
-        let logger = try container.make(Logger.self)
+    public func start() -> Future<Void> {
+        let container = self.container
+        let config = self.config
 
-        console.print("Server starting on ", newLine: false)
-        console.output("http://" + config.hostname, style: .init(color: .cyan), newLine: false)
-        console.output(":" + config.port.description, style: .init(color: .cyan))
+        return Future.flatMap(on: container) {
+            let console = try container.make(Console.self)
+            let logger = try container.make(Logger.self)
 
-        let group = MultiThreadedEventLoopGroup(numThreads: config.workerCount)
+            console.print("Server starting on ", newLine: false)
+            console.output("http://" + config.hostname, style: .init(color: .cyan), newLine: false)
+            console.output(":" + config.port.description, style: .init(color: .cyan))
 
-        /// http upgrade
-        var upgraders: [HTTPProtocolUpgrader] = []
+            let group = MultiThreadedEventLoopGroup(numThreads: config.workerCount)
 
-        /// web socket upgrade
-        if let wss = try? container.make(WebSocketServer.self) {
-            let ws = WebSocket.httpProtocolUpgrader(shouldUpgrade: { req in
-                let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
-                return wss.webSocketShouldUpgrade(for: Request(http: req, using: container))
-            }, onUpgrade: { ws, req in
-                let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
-                return wss.webSocketOnUpgrade(ws, for: Request(http: req, using: container))
-            })
-            upgraders.append(ws)
+            /// http upgrade
+            var upgraders: [HTTPProtocolUpgrader] = []
+
+            /// web socket upgrade
+            if let wss = try? container.make(WebSocketServer.self) {
+                let ws = WebSocket.httpProtocolUpgrader(shouldUpgrade: { req in
+                    let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
+                    return wss.webSocketShouldUpgrade(for: Request(http: req, using: container))
+                }, onUpgrade: { ws, req in
+                    let container = Thread.current.cachedSubContainer(for: self.container, on: group.next())
+                    return wss.webSocketOnUpgrade(ws, for: Request(http: req, using: container))
+                })
+                upgraders.append(ws)
+            }
+
+            return HTTPServer.start(
+                hostname: config.hostname,
+                port: config.port,
+                responder: EngineResponder(rootContainer: container),
+                maxBodySize: config.maxBodySize,
+                backlog: config.backlog,
+                reuseAddress: config.reuseAddress,
+                tcpNoDelay: config.tcpNoDelay,
+                upgraders: upgraders,
+                on: group
+            ) { error in
+                logger.reportError(error)
+            }.map(to: Void.self) { server in
+                if let app = container as? Application {
+                    app.runningServer = RunningServer(onClose: server.onClose, close: server.close)
+                }
+            }
         }
-
-
-        let server = try HTTPServer.start(
-            hostname: config.hostname,
-            port: config.port,
-            responder: EngineResponder(rootContainer: container),
-            maxBodySize: config.maxBodySize,
-            backlog: config.backlog,
-            reuseAddress: config.reuseAddress,
-            tcpNoDelay: config.tcpNoDelay,
-            upgraders: upgraders,
-            on: group
-        ) { error in
-            logger.reportError(error)
-        }.wait()
-
-        // wait for the server to shutdown
-        try server.onClose.wait()
     }
 }
 
@@ -149,6 +154,28 @@ extension Logger {
 
 /// Engine server config struct.
 public struct EngineServerConfig: Service {
+    /// Detects `EngineServerConfig` from the environment.
+    public static func detect(
+        from env: inout Environment,
+        hostname: String = "localhost",
+        port: Int = 8080,
+        backlog: Int = 256,
+        workerCount: Int = ProcessInfo.processInfo.activeProcessorCount,
+        maxBodySize: Int = 1_000_0000,
+        reuseAddress: Bool = true,
+        tcpNoDelay: Bool = true
+    ) throws -> EngineServerConfig {
+        return try EngineServerConfig(
+            hostname: env.commandInput.parse(option: .value(name: "hostname")) ?? hostname,
+            port: env.commandInput.parse(option: .value(name: "port")).flatMap(Int.init) ?? port,
+            backlog: backlog,
+            workerCount: workerCount,
+            maxBodySize: maxBodySize,
+            reuseAddress: reuseAddress,
+            tcpNoDelay: tcpNoDelay
+        )
+    }
+
     /// Host name the server will bind to.
     public var hostname: String
 
@@ -188,29 +215,5 @@ public struct EngineServerConfig: Service {
         self.maxBodySize = maxBodySize
         self.reuseAddress = reuseAddress
         self.tcpNoDelay = tcpNoDelay
-    }
-}
-
-extension EngineServerConfig {
-    /// Detects `EngineServerConfig` from the environment.
-    public static func detect(
-        hostname: String = "localhost",
-        port: Int = 8080,
-        backlog: Int = 256,
-        workerCount: Int = ProcessInfo.processInfo.activeProcessorCount,
-        maxBodySize: Int = 1_000_0000,
-        reuseAddress: Bool = true,
-        tcpNoDelay: Bool = true,
-        from env: inout Environment
-    ) throws -> EngineServerConfig {
-        return try EngineServerConfig(
-            hostname: env.commandInput.parse(option: .value(name: "hostname")) ?? hostname,
-            port: env.commandInput.parse(option: .value(name: "port")).flatMap(Int.init) ?? port,
-            backlog: backlog,
-            workerCount: workerCount,
-            maxBodySize: maxBodySize,
-            reuseAddress: reuseAddress,
-            tcpNoDelay: tcpNoDelay
-        )
     }
 }

--- a/Sources/Vapor/HTTP/Server.swift
+++ b/Sources/Vapor/HTTP/Server.swift
@@ -1,8 +1,57 @@
-//import HTTP
-
-/// Servers are capable of binding to an address
-/// and subsequently responding to requests sent
-/// to that address.
+/// Servers are capable of binding to an address and subsequently responding to requests sent to that address.
 public protocol Server {
-    func start() throws
+    /// Starts the `Server`.
+    ///
+    /// Upon starting, the `Server` must set the application's `runningServer` property.
+    ///
+    /// - returns: A future notification that will complete when the `Server` has started successfully.
+    func start() -> Future<Void>
+}
+
+extension Application {
+    /// Stores a reference to the `Application`'s currently running server.
+    public var runningServer: RunningServer? {
+        get {
+            guard let cache = try? self.make(RunningServerCache.self) else {
+                return nil
+            }
+            return cache.storage
+        }
+        set {
+            guard let cache = try? self.make(RunningServerCache.self) else {
+                return
+            }
+            cache.storage = newValue
+        }
+    }
+}
+
+/// A context for the currently running `Server` protocol. When a `Server` succesfully boots,
+/// it sets one of these on the `runningServer` property of the `Application`.
+///
+/// This struct can be used to close the server.
+///
+///     try app.runningServer?.close().wait()
+///
+/// It can also be used to wait until something else closes the server.
+///
+///     try app.runningServer?.onClose().wait()
+///
+public struct RunningServer {
+    /// A future that will be completed when the server closes.
+    public let onClose: Future<Void>
+
+    /// Stops the currently running server, if one is running.
+    public let close: () -> Future<Void>
+}
+
+/// MARK: Private
+
+/// Reference-type wrapper around a `RunningServer`.
+final class RunningServerCache: Service {
+    /// The stored `RunningServer`.
+    var storage: RunningServer?
+
+    /// Creates a new `RunningServerCache`.
+    init() { storage = nil }
 }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -17,11 +17,12 @@ extension Services {
                 container: container
             )
         }
-        
+
+        // register defualt `EngineServerConfig`
         services.register { container -> EngineServerConfig in
-            /// temporary so that this change is backward compatible
+            /// require app for mutable environment
             guard let app = container as? Application else {
-                fatalError()
+                throw VaporError(identifier: "serverConfig", reason: "Default `EngineServerConfig` can only be created for `Application`.", source: .capture())
             }
             return try .detect(from: &app.environment)
         }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -19,11 +19,11 @@ extension Services {
         }
         
         services.register { container -> EngineServerConfig in
-            if container.environment.isRelease {
-                return try EngineServerConfig.detect(port: 80, from: &container.environment)
-            } else {
-                return try EngineServerConfig.detect(from: &container.environment)
+            /// temporary so that this change is backward compatible
+            guard let app = container as? Application else {
+                fatalError()
             }
+            return try .detect(from: &app.environment)
         }
 
         // bcrypt
@@ -46,6 +46,8 @@ extension Services {
         services.register(SessionsMiddleware.self)
         services.register(KeyedCacheSessions.self)
         services.register(SessionsConfig.self)
+
+        services.register(RunningServerCache())
 
         // keyed cache, memory. thread-safe
         let memoryKeyedCache = MemoryKeyedCache()

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -20,9 +20,9 @@ extension Services {
         
         services.register { container -> EngineServerConfig in
             if container.environment.isRelease {
-                return try EngineServerConfig.detect(port: 80)
+                return try EngineServerConfig.detect(port: 80, from: &container.environment)
             } else {
-                return try EngineServerConfig.detect()
+                return try EngineServerConfig.detect(from: &container.environment)
             }
         }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -150,8 +150,10 @@ extension Application {
         try configure(router)
         var services = Services.default()
         services.register(router, as: Router.self)
-        let app = try Application(config: .default(), environment: .testing, services: services)
-        app.testRun(port: port)
+        var env = Environment.testing
+        env.commandInput = CommandInput(arguments: ["vapor", "--port", port.description])
+        let app = try Application(config: .default(), environment: env, services: services)
+        app.testRun()
         usleep(250_000) // 1/4 of a second
         return ApplicationTester(app: app, port: port)
     }
@@ -164,9 +166,8 @@ extension Application {
         return try Application(config: .default(), environment: .testing, services: services)
     }
 
-    func testRun(port: Int) {
+    func testRun() {
         Thread.async {
-            CommandInput.commandLine = CommandInput(arguments: ["vapor", "--port", port.description])
             try! self.run()
         }
     }


### PR DESCRIPTION
- [x] move to using the `Environment.commandLine` property for accessing CLI arguments. An improvement over using a statically available property that could create issues for projects with multiple applications.
- [x] Adds `runningServer` property.
- [x] Adds `asyncBoot` and `asyncRun` methods to `Application`
- [x] relies on https://github.com/vapor/console/pull/60
- [x] relies on https://github.com/vapor/service/pull/20