### PR TITLE
Fixing typo `converToURL` -> `convertToURL`

### DIFF
--- a/Sources/Vapor/HTTP/Client.swift
+++ b/Sources/Vapor/HTTP/Client.swift
@@ -18,7 +18,7 @@ extension Client {
         return Future.flatMap(on: container) {
             let req = Request(using: self.container)
             req.http.method = method
-            req.http.url = url.converToURL()!
+            req.http.url = url.convertToURL()!
             req.http.headers = headers
             return try self.respond(to: req)
         }
@@ -34,7 +34,7 @@ extension Client {
         return Future.flatMap(on: container) {
             let req = Request(using: self.container)
             req.http.method = method
-            req.http.url = url.converToURL()!
+            req.http.url = url.convertToURL()!
             req.http.headers = headers
             try req.content.encode(content)
             return try self.respond(to: req)
@@ -91,17 +91,17 @@ extension Client {
 }
 
 public protocol URLRepresentable {
-    func converToURL() -> URL?
+    func convertToURL() -> URL?
 }
 
 extension String: URLRepresentable {
-    public func converToURL() -> URL? {
+    public func convertToURL() -> URL? {
         return URL(string: self)
     }
 }
 
 extension URL: URLRepresentable {
-    public func converToURL() -> URL? {
+    public func convertToURL() -> URL? {
         return self
     }
 }


### PR DESCRIPTION
Fixing a typo in `Client.swift` where the `URLRepresentable` protocol defines a method to convert a type to `URL`.

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- ⚠️ There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.

### Comments
- This is renaming a public API, so it could be seen as a breaking change to a public API. Should I add a deprecation/rename warning in `Deprecated.swift`?
- If `converToURL` was the intended name, feel free to close this PR without merging 👋