### PR TITLE
Adds get request with a query to Client

### DIFF
--- a/Sources/Vapor/HTTP/Client.swift
+++ b/Sources/Vapor/HTTP/Client.swift
@@ -74,6 +74,19 @@ extension Client {
 /// MARK: Content
 
 extension Client {
+    /// Sends a GET request with query parameters
+    func get<C: Content>(_ url: URLRepresentable, headers: HTTPHeaders = .init(), query: C) -> Future<Response> {
+        let queryMirror = Mirror(reflecting: query)
+        let url = "\(url)?"
+        var queryStrings = [String]()
+        
+        for child in queryMirror.children {
+            queryStrings.append("\(child.label!)=\(child.value)")
+        }
+        
+        return self.get("\(url)\(queryStrings.joined(separator: "&"))", headers: headers)
+    }
+    
     /// Sends a PUT request with body
     public func put<C>(_ url: URLRepresentable, headers: HTTPHeaders = .init(), content: C) -> Future<Response> where C: Content {
         return send(.PUT, headers: headers, to: url, content: content)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->
This PR adds `.get<C: Content>(_:headers:query:)` to `Client` so that users can pass in a `Content` to construct query parameters rather than manually constructing the query themselves.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
