### PR TITLE
properly set html mediatype for views

### DIFF
--- a/Sources/Vapor/Content/ContentConfig.swift
+++ b/Sources/Vapor/Content/ContentConfig.swift
@@ -163,7 +163,7 @@ extension ContentConfig {
 
         // data
         config.use(encoder: PlaintextEncoder(), for: .plainText)
-        config.use(encoder: PlaintextEncoder(), for: .html)
+        config.use(encoder: PlaintextEncoder(mediaType: .html), for: .html)
 
         // form-urlencoded
         config.use(encoder: FormURLEncoder(), for: .urlEncodedForm)

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -4,9 +4,13 @@ import Foundation
 public final class PlaintextEncoder: DataEncoder, HTTPMessageEncoder {
     fileprivate let encoder: _DataEncoder
 
+    /// The specific plaintext media type to use.
+    private let mediaType: MediaType
+
     /// Creates a new data encoder
-    public init() {
+    public init(mediaType: MediaType = .plainText) {
         encoder = .init()
+        self.mediaType = mediaType
     }
 
     /// See `DataEncoder`
@@ -22,7 +26,7 @@ public final class PlaintextEncoder: DataEncoder, HTTPMessageEncoder {
     public func encode<E, M>(_ encodable: E, to message: inout M, on worker: Worker) throws
         where E: Encodable, M: HTTPMessage
     {
-        message.mediaType = .plainText
+        message.mediaType = self.mediaType
         message.body = try HTTPBody(data: encode(encodable))
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -243,6 +243,20 @@ class ApplicationTests: XCTestCase {
         }
     }
 
+    func testViewResponse() throws {
+        let app = try Application.makeTest { router in
+            router.get("view") { req -> View in
+                return View(data: "<h1>hello</h1>".convertToData())
+            }
+        }
+
+        try app.test(.GET, "view") { res in
+            XCTAssertEqual(res.http.status.code, 200)
+            XCTAssertEqual(res.http.mediaType, .html)
+            XCTAssertEqual(res.http.body.string, "<h1>hello</h1>")
+        }
+    }
+
     static let allTests = [
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
@@ -254,6 +268,7 @@ class ApplicationTests: XCTestCase {
         ("testContentContainer", testContentContainer),
         ("testMultipartDecode", testMultipartDecode),
         ("testMultipartEncode", testMultipartEncode),
+        ("testViewResponse", testViewResponse),
     ]
 }
 


### PR DESCRIPTION
- [x] fixes an issue where returning a `View` in a route closure would yield `text/plain` content type.