### PR TITLE
routing 3.0.0 gm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // 🔑 Hashing (BCrypt, SHA, HMAC, etc), encryption, and randomness.
         .package(url: "https://github.com/vapor/crypto.git", from: "3.0.0-rc.2"),
 
-        // 🗄 Core services for creating database integrations.tttttttttttt
+        // 🗄 Core services for creating database integrations.
         .package(url: "https://github.com/vapor/database-kit.git", from: "1.0.0-rc.2"),
 
         // 🚀 Non-blocking, event-driven HTTP for Swift built on Swift NIO.
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/multipart.git", from: "3.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing.git", from: "3.0.0-rc.2"),
+        .package(url: "https://github.com/vapor/routing.git", from: "3.0.0"),
 
         // 📦 Dependency injection / inversion of control framework.
         .package(url: "https://github.com/vapor/service.git", from: "1.0.0-rc.2"),

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -11,11 +11,11 @@ public func routes(_ router: Router) throws {
     }
 
     router.get("hello", String.parameter) { req in
-        return try req.parameter(String.self)
+        return try req.parameters.next(String.self)
     }
 
     router.get("users", User.parameter, "foo") { req in
-        return try req.parameter(User.self)
+        return try req.parameters.next(User.self)
     }
 
     router.get("search") { req in
@@ -31,13 +31,7 @@ public func routes(_ router: Router) throws {
 
 struct User: Parameter, Content {
     let string: String
-
-    static func make(for parameter: String, using container: Container) throws -> EventLoopFuture<User> {
-        return Future.map(on: container) {
-            return User(string: parameter)
-        }
+    static func resolveParameter(_ parameter: String, on container: Container) throws -> Future<User> {
+        return container.eventLoop.newSucceededFuture(result: User(string: parameter))
     }
-
-    typealias ResolvedParameter = Future<User>
-
 }

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -24,7 +24,7 @@ do {
     }
 
     router.get("hash", String.parameter) { req -> String in
-        let string = try req.parameter(String.self)
+        let string = try req.parameters.next(String.self)
         let hash = try BCrypt.hash(string)
         return String(data: hash, encoding: .ascii)!
     }
@@ -103,7 +103,7 @@ do {
     }
 
     router.get("string", String.parameter) { req -> String in
-        return try req.parameter(String.self)
+        return try req.parameters.next(String.self)
     }
 
     router.get("error") { req -> Future<String> in

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -75,7 +75,7 @@ public struct RoutesCommand: Command, Service {
             guard let first = route.path.first, case .constant(let method) = first else {
                 continue
             }
-            console.success(method.string, newLine: false)
+            console.success(method, newLine: false)
 
             for _ in 0..<longestMethod - method.count {
                 console.print(" ", newLine: false)
@@ -89,12 +89,12 @@ public struct RoutesCommand: Command, Service {
                 switch comp {
                 case .constant(let const):
                     console.info("/", newLine: false)
-                    console.print(const.string, newLine: false)
+                    console.print(const, newLine: false)
                     pathLength += const.count + 1
                 case .parameter(let param):
                     console.info("/", newLine: false)
                     console.print(":", newLine: false)
-                    console.info(param.string, newLine: false)
+                    console.info(param, newLine: false)
                     pathLength += param.count + 2
                 case .anything:
                     console.info("/*", newLine: false)

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -1,1 +1,17 @@
-/// Nothing here yet...
+extension Request {
+    /// Use `Request.parameters`.
+    @available(*, deprecated, renamed: "parameters.next")
+    public func parameter<P>() throws -> P
+        where P: Parameter, P.ResolvedParameter == P
+    {
+        return try parameters.next(P.self)
+    }
+
+    /// Use `Request.parameters`.
+    @available(*, deprecated, renamed: "parameters.next")
+    public func parameter<P>(_ parameter: P.Type) throws -> P.ResolvedParameter
+        where P: Parameter
+    {
+        return try parameters.next(P.self)
+    }
+}

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -5,7 +5,7 @@ import Foundation
 /// An HTTP wrapper around the TrieNodeRouter
 public final class EngineRouter: Router {
     /// The internal router
-    private let router: Routing.Router<Responder>
+    private let router: TrieRouter<Responder>
 
     private let notFound: Responder
 

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -5,7 +5,9 @@ import Foundation
 /// An HTTP wrapper around the TrieNodeRouter
 public final class EngineRouter: Router {
     /// The internal router
-    private let router: TrieRouter<Responder>
+    private let router: Routing.Router<Responder>
+
+    private let notFound: Responder
 
     /// See Router.routes
     public var routes: [Route<Responder>] {
@@ -15,19 +17,20 @@ public final class EngineRouter: Router {
     /// Create a new engine router
     public init(caseInsensitive: Bool) {
         self.router = .init()
-        self.router.caseInsensitive = caseInsensitive
+        if caseInsensitive {
+            self.router.options.insert(.caseInsensitive)
+        }
+        let notFoundRes = HTTPResponse(status: .notFound, body: "Not found")
+        self.notFound = BasicResponder { req in
+            let res = req.makeResponse()
+            res.http = notFoundRes
+            return req.eventLoop.newSucceededFuture(result: res)
+        }
     }
 
     /// Create a new engine router with default settings.
     public static func `default`() -> EngineRouter {
-        let router = EngineRouter(caseInsensitive: false)
-        router.router.fallback = BasicResponder { req in
-            let res = req.makeResponse()
-            res.http.status = .notFound
-            res.http.body = HTTPBody(string: "Not found")
-            return Future.map(on: req) { res }
-        }
-        return router
+        return EngineRouter(caseInsensitive: false)
     }
 
     /// See Router.register
@@ -37,24 +40,24 @@ public final class EngineRouter: Router {
 
     /// See Router.route
     public func route(request: Request) -> Responder? {
-        let path: [PathComponent] = request.http.urlString
+        // FIXME: use NIO's underlying uri byte buffer when possible
+        // instead of converting to string. `router.route` accepts conforming to `RoutablePath`
+        let path: [String] = request.http.urlString
             .split(separator: "?")[0]
-            .split(separator: "/").map { .init(substring: $0) }
-
-        return router.route(
-            path:  [request.http.method.pathComponent] + path,
-            parameters: request
-        )
+            .split(separator: "/").map { .init($0) }
+        return router.route(path:  [request.http.method.string] + path, parameters: &request._parameters) ?? notFound
     }
 }
 
 extension HTTPMethod {
-    var pathComponent: PathComponent {
+    var string: String {
         switch self {
-        case .GET: return .init(bytes: _getData.withByteBuffer { $0 })
-        default: return .init(string: "\(self)")
+        case .GET: return "GET"
+        default: return "\(self)"
         }
     }
-}
 
-private let _getData = Data("GET".utf8)
+    var pathComponent: PathComponent {
+        return .constant(string)
+    }
+}

--- a/Sources/Vapor/Routing/LazyMiddlewareRouteGroup.swift
+++ b/Sources/Vapor/Routing/LazyMiddlewareRouteGroup.swift
@@ -1,3 +1,5 @@
+import Routing
+
 extension Router {
     /// Creates a group with the provided middleware type.
     ///

--- a/Sources/Vapor/Routing/ParametersContainer.swift
+++ b/Sources/Vapor/Routing/ParametersContainer.swift
@@ -1,3 +1,5 @@
+import Routing
+
 /// Helper for accessing route parameters from an HTTP request.
 ///
 ///     let id = try req.parameters.next(Int.self)

--- a/Sources/Vapor/Routing/ParametersContainer.swift
+++ b/Sources/Vapor/Routing/ParametersContainer.swift
@@ -6,6 +6,11 @@ public struct ParametersContainer {
     /// Private `Request`.
     private let request: Request
 
+    /// The `ParameterValue`s that this request collected as it was being routed.
+    public var values: [ParameterValue] {
+        return request._parameters.values
+    }
+
     /// Creates a new `ParametersContainer`. Use `Request.parameters`.
     init(_ request: Request) {
         self.request = request

--- a/Sources/Vapor/Routing/ParametersContainer.swift
+++ b/Sources/Vapor/Routing/ParametersContainer.swift
@@ -1,0 +1,47 @@
+/// Helper for accessing route parameters from an HTTP request.
+///
+///     let id = try req.parameters.next(Int.self)
+///
+public struct ParametersContainer {
+    /// Private `Request`.
+    private let request: Request
+
+    /// Creates a new `ParametersContainer`. Use `Request.parameters`.
+    init(_ request: Request) {
+        self.request = request
+    }
+
+    /// Grabs the next parameter from the parameter bag.
+    ///
+    ///     let id = try req.parameters.next(Int.self)
+    ///
+    /// - note: the parameters _must_ be fetched in the order they appear in the path.
+    ///
+    /// For example GET /posts/:post_id/comments/:comment_id must be fetched in this order:
+    ///
+    ///     let post = try req.parameters.next(Post.self)
+    ///     let comment = try req.parameters.next(Comment.self)
+    ///
+    public func next<P>() throws -> P
+        where P: Parameter, P.ResolvedParameter == P
+    {
+        return try next(P.self)
+    }
+
+    /// Grabs the next parameter from the parameter bag.
+    ///
+    ///     let id = try req.parameters.next(Int.self)
+    ///
+    /// - note: the parameters _must_ be fetched in the order they appear in the path.
+    ///
+    /// For example GET /posts/:post_id/comments/:comment_id must be fetched in this order:
+    ///
+    ///     let post = try req.parameters.next(Post.self)
+    ///     let comment = try req.parameters.next(Comment.self)
+    ///
+    public func next<P>(_ parameter: P.Type) throws -> P.ResolvedParameter
+        where P: Parameter
+    {
+        return try request._parameters.next(P.self, on: request)
+    }
+}

--- a/Sources/Vapor/Routing/Router+Method.swift
+++ b/Sources/Vapor/Routing/Router+Method.swift
@@ -4,33 +4,23 @@ import Routing
 extension Router {
     /// Registers a route handler at the supplied path.
     @discardableResult
-    public func on<T>(
-        _ method: HTTPMethod,
-        at path: [DynamicPathComponent],
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
+    public func on<T>(_ method: HTTPMethod, at path: [PathComponent], use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
         let responder = RouteResponder(closure: closure)
-        let route = Route<Responder>(
-            path: [.constant(method.pathComponent)] + path,
-            output: responder
-        )
-        self.register(route: route)
+        let route = Route<Responder>(path: [method.pathComponent] + path, output: responder)
+        register(route: route)
         return route
     }
     
     /// Registers a route handler at the supplied path.
     @discardableResult
-    public func on<C, T>(
-        _ method: HTTPMethod,
-        at path: [DynamicPathComponent],
-        use closure: @escaping RequestDecodableResponder<C, T>.Closure
-    ) -> Route<Responder> where C: RequestDecodable, T: ResponseEncodable {
+    public func on<C, T>(_ method: HTTPMethod, at path: [PathComponent], use closure: @escaping (Request, C) throws -> T) -> Route<Responder>
+        where C: RequestDecodable, T: ResponseEncodable
+    {
         let responder = RequestDecodableResponder(closure: closure)
-        let route = Route<Responder>(
-            path: [.constant(method.pathComponent)] + path,
-            output: responder
-        )
-        self.register(route: route)
+        let route = Route<Responder>(path: [method.pathComponent] + path, output: responder)
+        register(route: route)
         return route
     }
 }
@@ -49,55 +39,50 @@ extension Router {
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/routing/)
     @discardableResult
-    public func get<T>(
-        _ path: DynamicPathComponentRepresentable...,
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
-        return self.on(.GET, at: path.makeDynamicPathComponents(), use: closure)
+    public func get<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
+        return on(.GET, at: path.convertToPathComponents(), use: closure)
     }
 
     /// Creates a `Route` at the provided path using the `PUT` method.
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/routing/)
     @discardableResult
-    public func put<T>(
-        _ path: DynamicPathComponentRepresentable...,
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
-        return self.on(.PUT, at: path.makeDynamicPathComponents(), use: closure)
+    public func put<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
+        return on(.PUT, at: path.convertToPathComponents(), use: closure)
     }
 
     /// Creates a `Route` at the provided path using the `POST` method.
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/routing/)
     @discardableResult
-    public func post<T>(
-        _ path: DynamicPathComponentRepresentable...,
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
-        return self.on(.POST, at: path.makeDynamicPathComponents(), use: closure)
+    public func post<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
+        return on(.POST, at: path.convertToPathComponents(), use: closure)
     }
 
     /// Creates a `Route` at the provided path using the `DELETE` method.
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/routing/)
     @discardableResult
-    public func delete<T>(
-        _ path: DynamicPathComponentRepresentable...,
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
-        return self.on(.DELETE, at: path.makeDynamicPathComponents(), use: closure)
+    public func delete<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
+        return on(.DELETE, at: path.convertToPathComponents(), use: closure)
     }
 
     /// Creates a `Route` at the provided path using the `PATCH` method.
     ///
     /// [Learn More →](https://docs.vapor.codes/3.0/getting-started/routing/)
     @discardableResult
-    public func patch<T>(
-        _ path: DynamicPathComponentRepresentable...,
-        use closure: @escaping RouteResponder<T>.Closure
-    ) -> Route<Responder> where T: ResponseEncodable {
-        return self.on(.PATCH, at: path.makeDynamicPathComponents(), use: closure)
+    public func patch<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+        where T: ResponseEncodable
+    {
+        return on(.PATCH, at: path.convertToPathComponents(), use: closure)
     }
 }
 
@@ -108,10 +93,10 @@ extension Router {
     @discardableResult
     public func put<C, T>(
         _ content: C.Type,
-        at path: DynamicPathComponentRepresentable...,
+        at path: PathComponentsRepresentable...,
         use closure: @escaping RequestDecodableResponder<C, T>.Closure
     ) -> Route<Responder> where C: RequestDecodable, T: ResponseEncodable {
-        return self.on(.PUT, at: path.makeDynamicPathComponents(), use: closure)
+        return self.on(.PUT, at: path.convertToPathComponents(), use: closure)
     }
     
     /// Creates a `Route` at the provided path using the `POST` method.
@@ -120,10 +105,10 @@ extension Router {
     @discardableResult
     public func post<C, T>(
         _ content: C.Type,
-        at path: DynamicPathComponentRepresentable...,
+        at path: PathComponentsRepresentable...,
         use closure: @escaping RequestDecodableResponder<C, T>.Closure
     ) -> Route<Responder> where C: RequestDecodable, T: ResponseEncodable {
-        return self.on(.POST, at: path.makeDynamicPathComponents(), use: closure)
+        return self.on(.POST, at: path.convertToPathComponents(), use: closure)
     }
     
     /// Creates a `Route` at the provided path using the `PATCH` method.
@@ -132,9 +117,9 @@ extension Router {
     @discardableResult
     public func patch<C, T>(
         _ content: C.Type,
-        at path: DynamicPathComponentRepresentable...,
+        at path: PathComponentsRepresentable...,
         use closure: @escaping RequestDecodableResponder<C, T>.Closure
     ) -> Route<Responder> where C: RequestDecodable, T: ResponseEncodable {
-        return self.on(.PATCH, at: path.makeDynamicPathComponents(), use: closure)
+        return self.on(.PATCH, at: path.convertToPathComponents(), use: closure)
     }
 }

--- a/Sources/Vapor/Routing/RoutingGroups.swift
+++ b/Sources/Vapor/Routing/RoutingGroups.swift
@@ -24,8 +24,8 @@ extension Router {
     ///
     /// - Parameter path: Group path components separated by commas
     /// - Returns: created RouteGroup
-    public func grouped(_ path: DynamicPathComponentRepresentable...) -> Router {
-        return RouteGroup(cascadingTo: self, components: path.makeDynamicPathComponents())
+    public func grouped(_ path: PathComponentsRepresentable...) -> Router {
+        return RouteGroup(cascadingTo: self, components: path.convertToPathComponents())
     }
 
 
@@ -49,8 +49,8 @@ extension Router {
     ///
     /// - Parameter path: Group path components separated by commas
     /// - Returns: created RouteGroup
-    public func group(_ path: DynamicPathComponentRepresentable..., configure: (Router) -> ()) {
-        configure(RouteGroup(cascadingTo: self, components: path.makeDynamicPathComponents()))
+    public func group(_ path: PathComponentsRepresentable..., configure: (Router) -> ()) {
+        configure(RouteGroup(cascadingTo: self, components: path.convertToPathComponents()))
     }
 
 
@@ -170,12 +170,12 @@ extension Router {
 /// All middleware will be applied to the Responder
 ///
 /// [Learn More →](https://docs.vapor.codes/3.0/vapor/route-group/)
-fileprivate final class RouteGroup: Router {
+private final class RouteGroup: Router {
     /// All routes registered to this group
     private(set) var routes: [Route<Responder>] = []
 
     let `super`: Router
-    let components: [DynamicPathComponent]
+    let components: [PathComponent]
     let middleware: [Middleware]
     
     /// Creates a new group
@@ -183,7 +183,7 @@ fileprivate final class RouteGroup: Router {
     /// All path components will be inserted before the Route's path
     ///
     /// All middleware will be applied to the Responder
-    init(cascadingTo router: Router, components: [DynamicPathComponent] = [], middleware: [Middleware] = []) {
+    init(cascadingTo router: Router, components: [PathComponent] = [], middleware: [Middleware] = []) {
         self.super = router
         self.components = components
         self.middleware = middleware

--- a/Sources/Vapor/Utilities/Exports.swift
+++ b/Sources/Vapor/Utilities/Exports.swift
@@ -10,13 +10,9 @@
 @_exported import Multipart
 @_exported import NIO
 @_exported import NIOHTTP1
+@_exported import Routing
 @_exported import Service
 @_exported import TemplateKit
 @_exported import URLEncodedForm
 @_exported import Validation
 @_exported import WebSocket
-
-/// Only import `Parameter` from routing because both modules
-/// declare a `Router` type.
-import Routing
-public typealias Parameter = Routing.Parameter

--- a/Sources/Vapor/Utilities/Exports.swift
+++ b/Sources/Vapor/Utilities/Exports.swift
@@ -10,9 +10,13 @@
 @_exported import Multipart
 @_exported import NIO
 @_exported import NIOHTTP1
-@_exported import Routing
 @_exported import Service
 @_exported import TemplateKit
 @_exported import URLEncodedForm
 @_exported import Validation
 @_exported import WebSocket
+
+/// Only import `Parameter` from routing because both modules
+/// declare a `Router` type.
+import Routing
+public typealias Parameter = Routing.Parameter

--- a/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
@@ -1,3 +1,5 @@
+import Routing
+
 /// Vapor's default `WebSocketServer` implementation. Includes conformance to `WebSocketServer`
 /// that is backed by a `TrieRouter` for registering multiple different websocket handlers.
 ///

--- a/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
@@ -14,7 +14,7 @@
 public final class EngineWebSocketServer: WebSocketServer, Service {
     /// The internal trie-node router backing this server.
     /// This will be used to register and retreive all websocket responding routes.
-    private let router: TrieRouter<WebSocketResponder>
+    private let router: Routing.Router<WebSocketResponder>
 
     /// All websocket responder routes that have been added to this `EngineWebSocketServer`.
     public var routes: [Route<WebSocketResponder>]
@@ -50,10 +50,9 @@ public final class EngineWebSocketServer: WebSocketServer, Service {
     /// - returns: HTTPHeaders to include in the 101 switching protocols HTTP response.
     ///            If `nil`, the HTTP upgrade request will be denied.
     public func webSocketShouldUpgrade(for request: Request) -> HTTPHeaders? {
-        guard let route = router.route(
-            path: request.http.urlString.split(separator: "/").map { .init(substring: $0) },
-            parameters: request
-        ) else {
+        // FIXME: move to using uri bytes when possible
+        let path: [String] = request.http.urlString.split(separator: "/").map { String($0) }
+        guard let route = router.route(path: path, parameters: &request._parameters) else {
             return nil
         }
         return route.shouldUpgrade(request)
@@ -66,12 +65,10 @@ public final class EngineWebSocketServer: WebSocketServer, Service {
     ///     - webSocket: The newly connected websocket client. Use this to send and receive messages from the client.
     ///     - request: The HTTP request that initiated the websocket protocol upgrade.
     public func webSocketOnUpgrade(_ webSocket: WebSocket, for request: Request) {
+        let path: [String] = request.http.urlString.split(separator: "/").map { String($0) }
         do {
-            guard let route = router.route(
-                path: request.http.urlString.split(separator: "/").map { .init(substring: $0) },
-                parameters: request
-                ) else {
-                    throw VaporError(identifier: "websocketOnUpgrade", reason: "Could not find route for upgraded WebSocket", source: .capture())
+            guard let route = router.route(path: path, parameters: &request._parameters) else {
+                throw VaporError(identifier: "websocketOnUpgrade", reason: "Could not find route for upgraded WebSocket", source: .capture())
             }
             try route.onUpgrade(webSocket, request)
         } catch {
@@ -95,7 +92,7 @@ extension EngineWebSocketServer {
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.
     @discardableResult
-    public func get(at path: [DynamicPathComponent], use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
+    public func get(at path: [PathComponent], use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
         let responder = WebSocketResponder(
             shouldUpgrade: { _ in [:] },
             onUpgrade: closure
@@ -116,8 +113,8 @@ extension EngineWebSocketServer {
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.
     @discardableResult
-    public func get(_ path: DynamicPathComponent..., use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
-        return self.get(at: path, use: closure)
+    public func get(_ path: PathComponent..., use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
+        return get(at: path, use: closure)
     }
 
     /// Registers a new websocket handling route at the supplied dynamic path.
@@ -131,7 +128,7 @@ extension EngineWebSocketServer {
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.
     @discardableResult
-    public func get(_ path: DynamicPathComponentRepresentable..., use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
-        return self.get(at: path.makeDynamicPathComponents(), use: closure)
+    public func get(_ path: PathComponentsRepresentable..., use closure: @escaping (WebSocket, Request) throws -> ()) -> Route<WebSocketResponder> {
+        return get(at: path.convertToPathComponents(), use: closure)
     }
 }

--- a/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/EngineWebSocketServer.swift
@@ -1,5 +1,3 @@
-import Routing
-
 /// Vapor's default `WebSocketServer` implementation. Includes conformance to `WebSocketServer`
 /// that is backed by a `TrieRouter` for registering multiple different websocket handlers.
 ///
@@ -16,7 +14,7 @@ import Routing
 public final class EngineWebSocketServer: WebSocketServer, Service {
     /// The internal trie-node router backing this server.
     /// This will be used to register and retreive all websocket responding routes.
-    private let router: Routing.Router<WebSocketResponder>
+    private let router: TrieRouter<WebSocketResponder>
 
     /// All websocket responder routes that have been added to this `EngineWebSocketServer`.
     public var routes: [Route<WebSocketResponder>]

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -66,7 +66,7 @@ class ApplicationTests: XCTestCase {
     func testParameter() throws {
         let app = try Application.runningTest(port: 8081) { router in
             router.get("hello", String.parameter) { req in
-                return try req.parameter(String.self)
+                return try req.parameters.next(String.self)
             }
         }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -197,25 +197,6 @@ class ApplicationTests: XCTestCase {
     }
 
     func testMultipartEncode() throws {
-        func expected(_ boundary: String) -> String {
-            return  """
-            --\(boundary)\r
-            Content-Disposition: form-data; name=name\r
-            \r
-            Vapor\r
-            --\(boundary)\r
-            Content-Disposition: form-data; name=age\r
-            \r
-            3\r
-            --\(boundary)\r
-            Content-Disposition: form-data; filename=droplet.png; name=image\r
-            \r
-            <contents of image>\r
-            --\(boundary)--\r
-
-            """
-        }
-
         struct User: Content {
             static var defaultMediaType: MediaType = .formData
             var name: String
@@ -233,7 +214,10 @@ class ApplicationTests: XCTestCase {
             debugPrint(res)
             XCTAssertEqual(res.http.status.code, 200)
             let boundary = res.http.contentType?.parameters["boundary"] ?? "none"
-            XCTAssertEqual(res.http.body.string, expected(boundary))
+            XCTAssertEqual(res.http.body.string.contains("Content-Disposition: form-data; name=name"), true)
+            XCTAssertEqual(res.http.body.string.contains("--\(boundary)"), true)
+            XCTAssertEqual(res.http.body.string.contains("filename=droplet.png"), true)
+            XCTAssertEqual(res.http.body.string.contains("name=image"), true)
         }
     }
 

--- a/Tests/VaporTests/RoutingTestsMocks.swift
+++ b/Tests/VaporTests/RoutingTestsMocks.swift
@@ -38,14 +38,8 @@ class FakeMiddleware: Middleware {
 /// Equatable
 // FIXME: move to Engine
 
-extension PathComponent : Equatable {
+extension PathComponent: Equatable {
     public static func ==(lhs: PathComponent, rhs: PathComponent) -> Bool {
-        return rhs.bytes == lhs.bytes
-    }
-}
-
-extension DynamicPathComponent: Equatable {
-    public static func ==(lhs: DynamicPathComponent, rhs: DynamicPathComponent) -> Bool {
         switch (lhs, rhs) {
         case (.constant(let lParams), .constant(let rParams)):
             return lParams == rParams


### PR DESCRIPTION
- [x] updates to routing 3.0.0 gm
- [x] ⚠️ `req.parameter(...)` has been renamed to `req.parameters.next(...)`:

### `req.parameters.next(...)`

A couple of reasons for this change:

- To namespace parameter interaction methods under `req.parameters.x` which makes it easier to add new methods in the future (such as `req.parameters.values`) without polluting the namespace. 
- This is a pattern that exists elsewhere in Vapor (`req.query.x`, `res.content.x`, etc) which should help make the API more intuitive. 
- `req.parameters(...)` did not indicate very clearly that you were getting the "next" parameter, and that the order in which you call this method is important.
- `req.parameters.next(...)` was the API in Vapor 2 and there is really no reason to change it.

Due to the prevalence of the unfortunate old API, it will remain available after 3.0.0, deprecated with a fixit warning. This will automatically correct the code when you click it:

![screen shot 2018-04-19 at 8 23 13 pm](https://user-images.githubusercontent.com/1342803/39024527-8262831e-440f-11e8-8e58-0ed8c345e069.png)

![screen shot 2018-04-19 at 8 22 20 pm](https://user-images.githubusercontent.com/1342803/39024505-61282a50-440f-11e8-9ddb-5c8b33bf918a.png)

![screen shot 2018-04-19 at 8 22 49 pm](https://user-images.githubusercontent.com/1342803/39024521-735932fa-440f-11e8-953a-b10778981121.png)
