### PR TITLE
sessions clear invalid cookie

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -507,6 +507,21 @@ class ApplicationTests: XCTestCase {
         })
     }
 
+    func testInvalidCookie() throws {
+        try Application.makeTest { router in
+            router.grouped(SessionsMiddleware.self).get("get") { req -> String in
+                return try req.session()["name"] ?? "n/a"
+            }
+        }.test(.GET, "get", beforeSend: { req in
+            req.http.cookies["vapor-session"] = "asdf"
+        }, afterSend: { res in
+            print(res)
+            XCTAssertEqual(res.http.status, .ok)
+            XCTAssertNotNil(res.http.headers[.setCookie])
+            XCTAssertEqual(res.http.body.string, "n/a")
+        })
+    }
+
     static let allTests = [
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
@@ -529,6 +544,7 @@ class ApplicationTests: XCTestCase {
         ("testVaporProvider", testVaporProvider),
         ("testResponseEncodableStatus", testResponseEncodableStatus),
         ("testHeadRequest", testHeadRequest),
+        ("testInvalidCookie", testInvalidCookie),
     ]
 }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -515,7 +515,6 @@ class ApplicationTests: XCTestCase {
         }.test(.GET, "get", beforeSend: { req in
             req.http.cookies["vapor-session"] = "asdf"
         }, afterSend: { res in
-            print(res)
             XCTAssertEqual(res.http.status, .ok)
             XCTAssertNotNil(res.http.headers[.setCookie])
             XCTAssertEqual(res.http.body.string, "n/a")


### PR DESCRIPTION
- [x] changes logic for handling invalid cookies. previous behavior would error if a non-matching cookie was found. now, a new session is created replacing the invalid cookie.