### PR TITLE
Add Data responses and TypedDataResponse

### DIFF
--- a/Sources/Vapor/Response/TypedDataResponse.swift
+++ b/Sources/Vapor/Response/TypedDataResponse.swift
@@ -1,7 +1,8 @@
 /// A container representing `Data` with a specific content type (used for returning as a `Response`).
-public struct TypedDataResponse: ResponseEncodable {
+private struct TypedDataResponse: ResponseEncodable {
     /// The data held by this container.
     let data: Data
+
     /// The type of the data held by this container.
     let contentType: MediaType
     
@@ -20,11 +21,13 @@ extension Data: ResponseEncodable {
         return try response(type: .any).encode(for: req)
     }
     
-    /**
-     Get a `ResponseEncodable` container holding this data with your provided contentType.
-     - parameter contentType: The type of data to return the container with.
-     */
-    public func response(type: MediaType) -> TypedDataResponse {
+    /// Get a `ResponseEncodable` container holding this data with your provided contentType.
+    ///
+    ///     data.response(type: .html)
+    ///
+    /// - parameters:
+    ///     - type: The type of data to return the container with.
+    public func response(type: MediaType) -> ResponseEncodable {
         return TypedDataResponse(data: self, contentType: type)
     }
 }

--- a/Sources/Vapor/Response/TypedDataResponse.swift
+++ b/Sources/Vapor/Response/TypedDataResponse.swift
@@ -1,0 +1,30 @@
+/// A container representing `Data` with a specific content type (used for returning as a `Response`).
+public struct TypedDataResponse: ResponseEncodable {
+    /// The data held by this container.
+    let data: Data
+    /// The type of the data held by this container.
+    let contentType: MediaType
+    
+    /// See `ResponseEncodable`.
+    public func encode(for req: Request) throws -> EventLoopFuture<Response> {
+        let res = req.makeResponse()
+        res.http.body = data.convertToHTTPBody()
+        res.http.contentType = contentType
+        return try res.encode(for: req)
+    }
+}
+
+extension Data: ResponseEncodable {
+    /// See `ResponseEncodable`.
+    public func encode(for req: Request) throws -> EventLoopFuture<Response> {
+        return try response(type: .any).encode(for: req)
+    }
+    
+    /**
+     Get a `ResponseEncodable` container holding this data with your provided contentType.
+     - parameter contentType: The type of data to return the container with.
+     */
+    public func response(type: MediaType) -> TypedDataResponse {
+        return TypedDataResponse(data: self, contentType: type)
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -520,6 +520,29 @@ class ApplicationTests: XCTestCase {
             XCTAssertEqual(res.http.body.string, "n/a")
         })
     }
+    
+    func testDataResponses() throws {
+        // without specific content type
+        try Application.makeTest { router in
+            router.get("hello") { req -> Data in
+                return "Hello!".data(using: .utf8)!
+            }
+        }.test(.GET, "hello") { res in
+            XCTAssertEqual(res.http.status, .ok)
+            XCTAssertEqual(res.http.body.string, "Hello!")
+        }
+
+        // with specific content type
+        try Application.makeTest { router in
+            router.get("hey") { req -> TypedDataResponse in
+                return "Hey!".data(using: .utf8)!.response(type: .html)
+            }
+        }.test(.GET, "hey") { res in
+            XCTAssertEqual(res.http.status, .ok)
+            XCTAssertEqual(res.http.contentType, MediaType.html)
+            XCTAssertEqual(res.http.body.string, "Hey!")
+        }
+    }
 
     static let allTests = [
         ("testContent", testContent),
@@ -544,6 +567,7 @@ class ApplicationTests: XCTestCase {
         ("testResponseEncodableStatus", testResponseEncodableStatus),
         ("testHeadRequest", testHeadRequest),
         ("testInvalidCookie", testInvalidCookie),
+        ("testDataResponses", testDataResponses)
     ]
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->
In some cases, you may want to just return raw `Data` as a Response. Before this commit, you might have had to make your own `ResponseEncodable` type that just provides the data, which seems a bit much for such a simple function.

Say we have this super important data that we need to respond with:

    let data = "Hello!".data(using: .utf8)!

At it's simplest, this new functionality allows you to respond with a `Data` object by simply returning it:

    router.get("hello") { req in
        return data
    }

However, sometimes, you might want to return this data with a custom content type. In this case, you can simply get a `TypedDataResponse` from a new Data extension, and return it, instead of the `Data`:

    router.get("hello") { req in
        return data.response(type: .html)
    }

As an aside, `TypedDataResponse` is also used under the hood if you just return `Data` on it's own, with a content type of `MediaType.any`.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.