### PR TITLE
Fix typo

### DIFF
--- a/Sources/Vapor/Logging/Logger+LogError.swift
+++ b/Sources/Vapor/Logging/Logger+LogError.swift
@@ -27,11 +27,11 @@ extension Logger {
             switch e {
             case let localized as LocalizedError: reason = localized.localizedDescription
             case let convertible as CustomStringConvertible: reason = convertible.description
-            default: reason = "\(error)"
+            default: reason = "\(e)"
             }
             error(reason)
             if verbose {
-                debug("Conform `\(type(of: error))` to `Debuggable` for better debug info.")
+                debug("Conform `\(type(of: e))` to `Debuggable` for better debug info.")
             }
         }
 


### PR DESCRIPTION
Looks like there should be `e` instead of `error`

### Checklist
- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
