### PR TITLE
middleware order

### DIFF
--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -19,7 +19,7 @@ extension Array where Element == Middleware {
     /// - note: The array of middleware must be `[Middleware]` not `[M] where M: Middleware`.
     public func makeResponder(chainedto responder: Responder) -> Responder {
         var responder = responder
-        for middleware in self {
+        for middleware in reversed() {
             responder = middleware.makeResponder(chainingTo: responder)
         }
         return responder


### PR DESCRIPTION
Currently middleware ordering with `grouped` and `group` methods on `Router` is seemingly reversed. This PR rectifies the issue so that the following snippet would run the middlewares in order: a, b, c. 

```swift
router.grouped(
    OrderMiddleware("a"), OrderMiddleware("b"), OrderMiddleware("c")
).get("order") { req -> String in
    return "done"
}
```