### PR TITLE
make blockingio thread pool a singleton

### DIFF
--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -81,6 +81,7 @@ extension Services {
 
         // blocking IO pool is thread safe
         let sharedThreadPool = BlockingIOThreadPool(numberOfThreads: 2)
+        sharedThreadPool.start()
         services.register(sharedThreadPool)
 
         // file

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -79,9 +79,12 @@ extension Services {
             return PlaintextRenderer.init(viewsDir: dir.workDir + "Resources/Views/", on: container)
         }
 
+        // blocking IO pool is thread safe
+        let sharedThreadPool = BlockingIOThreadPool(numberOfThreads: 2)
+        services.register(sharedThreadPool)
+
         // file
         services.register(NonBlockingFileIO.self)
-        services.register(BlockingIOThreadPool.self)
 
         // websocket
         services.register(NIOWebSocketClient.self)

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -38,6 +38,7 @@ class ClientTests: XCTestCase {
         let app = try Application()
 
         let client = try app.make(Client.self)
+        print(type(of: client))
 
         let response = try client.get("http://httpbin.org/absolute-redirect/5").wait()
         XCTAssertEqual(response.http.status.code, 200)


### PR DESCRIPTION
Fixes an issue where a new `BlockingIOThreadPool` would be created for each EventLoop. This class is thread-safe and meant to be shared across all EventLoops to minimize thread overhead.