### PR TITLE
Fixed tests to reflect changes in vapor/core#144

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -214,10 +214,10 @@ class ApplicationTests: XCTestCase {
             debugPrint(res)
             XCTAssertEqual(res.http.status.code, 200)
             let boundary = res.http.contentType?.parameters["boundary"] ?? "none"
-            XCTAssertEqual(res.http.body.string.contains("Content-Disposition: form-data; name=name"), true)
+            XCTAssertEqual(res.http.body.string.contains("Content-Disposition: form-data; name=\"name\""), true)
             XCTAssertEqual(res.http.body.string.contains("--\(boundary)"), true)
-            XCTAssertEqual(res.http.body.string.contains("filename=droplet.png"), true)
-            XCTAssertEqual(res.http.body.string.contains("name=image"), true)
+            XCTAssertEqual(res.http.body.string.contains("filename=\"droplet.png\""), true)
+            XCTAssertEqual(res.http.body.string.contains("name=\"image\""), true)
         }
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

This PR changes test related to multipart form encoding, so that fix to bug reported in vapor/multipart#22 and fixed in vapor/core#144 can pass the tests.

Essentially, the change requested in vapor/multipart#22 is simple and wraps all values in multipart parts in quotation marks, increasing the request size slightly but making the request more compatible with clients (browsers, etc.) and other servers.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
