### PR TITLE
Rename makeResponse to response

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -102,7 +102,7 @@ do {
         print(loginRequest.email) // user@vapor.codes
         print(loginRequest.password) // don't look!
 
-        return req.makeResponse()
+        return req.response()
     }
 
     router.get("string", String.parameter) { req -> String in
@@ -114,7 +114,7 @@ do {
     }
 
     router.get("fast") { req -> Response in
-        let res = req.makeResponse()
+        let res = req.response()
         res.http.body = HTTPBody(string: "123")
         return res
     }

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -31,7 +31,7 @@ public protocol Content: Codable, ResponseCodable, RequestCodable {
     ///     }
     ///
     ///     router.get("greeting2") { req in
-    ///         let res = req.makeResponse()
+    ///         let res = req.response()
     ///         try res.content.encode(Hello(), as: .json)
     ///         return res // {"message":"Hello!"}
     ///     }
@@ -62,7 +62,7 @@ extension Content {
     ///
     /// See `ResponseEncodable`.
     public func encode(for req: Request) throws -> Future<Response> {
-        let res = req.makeResponse()
+        let res = req.response()
         try res.content.encode(self)
         return Future.map(on: req) { res }
     }

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -36,3 +36,17 @@ extension MemorySessions {
         self.init()
     }
 }
+
+extension Request {
+    /// See `req.response(http:)`.
+    @available(*, deprecated, renamed: "response(http:)")
+    public func makeResponse(http: HTTPResponse = .init()) -> Response {
+        return response(http: http)
+    }
+    
+    /// See `req.response(_ body:as:)`.
+    @available(*, deprecated, renamed: "response(_body:as:)")
+    public func makeResponse(_ body: LosslessHTTPBodyRepresentable, as contentType: MediaType = .plainText) -> Response {
+        return response(body, as: contentType)
+    }
+}

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -123,7 +123,7 @@ public final class CORSMiddleware: Middleware {
         // Determine if the request is pre-flight.
         // If it is, create empty response otherwise get response from the responder chain.
         let response = request.isPreflight
-            ? request.eventLoop.newSucceededFuture(result: request.makeResponse())
+            ? request.eventLoop.newSucceededFuture(result: request.response())
             : try next.respond(to: request)
         
         return response.map { response in

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -57,7 +57,7 @@ public final class ErrorMiddleware: Middleware, ServiceType {
             }
 
             // create a Response with appropriate status
-            let res = req.makeResponse(http: .init(status: status, headers: headers))
+            let res = req.response(http: .init(status: status, headers: headers))
 
             // attempt to serialize the error to json
             do {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -123,11 +123,11 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     }
 
     // MARK: Response
-
+    
     /// Creates a `Response` on the same container as this `Request`.
     ///
     ///     router.get("greeting2") { req in
-    ///         let res = req.makeResponse()
+    ///         let res = req.response()
     ///         try res.content.encode("hello", as: .plaintext)
     ///         return res
     ///     }
@@ -135,24 +135,24 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     /// - parameters:
     ///     - http: Optional `HTTPResponse` to use.
     /// - returns: A new, empty 200 OK `Response` on the same container as the current `Request`.
-    public func makeResponse(http: HTTPResponse = .init()) -> Response {
+    public func response(http: HTTPResponse = .init()) -> Response  {
         return Response(http: http, using: sharedContainer)
     }
 
     /// Generate a `Response` for a `HTTPBody` convertible object using the supplied `MediaType`.
     ///
     ///     router.get("html") { req in
-    ///         return req.makeResponse("<h1>Hello, world!</h1>", as: .html)
+    ///         return req.response("<h1>Hello, world!</h1>", as: .html)
     ///     }
     ///
     /// - parameters:
     ///     - type: The type of data to return the container with.
-    public func makeResponse(_ body: LosslessHTTPBodyRepresentable, as contentType: MediaType = .plainText) -> Response {
-        let res = makeResponse(http: .init(body: body))
+    public func response(_ body: LosslessHTTPBodyRepresentable, as contentType: MediaType = .plainText) -> Response {
+        let res = response(http: .init(body: body))
         res.http.contentType = contentType
         return res
     }
-
+    
     // MARK: Database
 
     /// See `DatabaseConnectable`.

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -48,7 +48,7 @@ private struct RouterResponder: Responder {
     /// See `Responder`.
     func respond(to req: Request) throws -> Future<Response> {
         guard let responder = router.route(request: req) else {
-            let res = req.makeResponse(http: .init(status: .notFound, body: "Not found"))
+            let res = req.response(http: .init(status: .notFound, body: "Not found"))
             return req.eventLoop.newSucceededFuture(result: res)
         }
 

--- a/Sources/Vapor/Response/BasicResponder.swift
+++ b/Sources/Vapor/Response/BasicResponder.swift
@@ -6,7 +6,7 @@ public struct BasicResponder: Responder {
     /// Create a new `BasicResponder`.
     ///
     ///     let notFound: Responder = BasicResponder { req in
-    ///         let res = req.makeResponse(http: .init(status: .notFound))
+    ///         let res = req.response(http: .init(status: .notFound))
     ///         return req.eventLoop.newSucceededFuture(result: res)
     ///     }
     ///

--- a/Sources/Vapor/Response/Redirect.swift
+++ b/Sources/Vapor/Response/Redirect.swift
@@ -8,7 +8,7 @@ extension Request {
     /// Set type to '.permanently' to allow caching to automatically redirect from browsers.
     /// Defaulting to non-permanent to prevent unexpected caching.
     public func redirect(to location: String, type: RedirectType = .normal) -> Response {
-        let res = makeResponse()
+        let res = response()
         res.http.status = type.status
         res.http.headers.replaceOrAdd(name: .location, value: location)
         return res

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -60,7 +60,7 @@ extension ResponseEncodable {
 extension HTTPResponse: ResponseEncodable {
     /// See `ResponseEncodable`.
     public func encode(for req: Request) throws -> Future<Response> {
-        let new = req.makeResponse()
+        let new = req.response()
         new.http = self
         return req.eventLoop.newSucceededFuture(result: new)
     }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -33,7 +33,7 @@ extension Request {
     ///
     /// See `FileIO` for more information.
     public func streamFile(at path: String) throws -> Future<Response> {
-        let res = makeResponse()
+        let res = response()
         res.http = try fileio().chunkedResponse(file: path, for: http)
         return eventLoop.newSucceededFuture(result: res)
     }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -136,7 +136,7 @@ class ApplicationTests: XCTestCase {
 
         let app = try Application.makeTest { router in
             router.get("encode") { req -> Response in
-                let res = req.makeResponse()
+                let res = req.response()
                 try res.content.encode(FooContent())
                 try res.content.encode(FooContent(), as: .json)
                 try res.content.encode(FooEncodable(), as: .json)
@@ -328,7 +328,7 @@ class ApplicationTests: XCTestCase {
     func testCustomEncode() throws {
         try Application.makeTest { router in
             router.get("custom-encode") { req -> Response in
-                let res = req.makeResponse(http: .init(status: .ok))
+                let res = req.response(http: .init(status: .ok))
                 try res.content.encode(json: ["hello": "world"], using: .custom(format: .prettyPrinted))
                 return res
             }
@@ -525,7 +525,7 @@ class ApplicationTests: XCTestCase {
         // without specific content type
         try Application.makeTest { router in
             router.get("hello") { req in
-                return req.makeResponse("Hello!")
+                return req.response("Hello!")
             }
         }.test(.GET, "hello") { res in
             XCTAssertEqual(res.http.status, .ok)
@@ -535,7 +535,7 @@ class ApplicationTests: XCTestCase {
         // with specific content type
         try Application.makeTest { router in
             router.get("hello-html") { req -> Response in
-                return req.makeResponse("Hey!", as: .html)
+                return req.response("Hey!", as: .html)
             }
         }.test(.GET, "hello-html") { res in
             XCTAssertEqual(res.http.status, .ok)

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -107,7 +107,7 @@ final class LastRequestClient: Client {
     }
     func send(_ req: Request) -> Future<Response> {
         lastReq = req
-        return Future.map(on: req) { req.makeResponse() }
+        return Future.map(on: req) { req.response() }
     }
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

This PR closes #1671, and renames `req.makeResponse()` to `req.response()`. 

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.