### PR TITLE
Unwanted caching headers on Client requests

### DIFF
--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -17,10 +17,10 @@ public final class FoundationClient: Client, ServiceType {
     private let urlSession: URLSession
     
     /// Default caching policy
-    public let cachePolicy: URLRequest.CachePolicy
+    public let cachePolicy: URLRequest.CachePolicy?
 
     /// Creates a new `FoundationClient`.
-    public init(_ urlSession: URLSession, cachePolicy: URLRequest.CachePolicy = .reloadIgnoringLocalAndRemoteCacheData, on container: Container) {
+    public init(_ urlSession: URLSession, cachePolicy: URLRequest.CachePolicy? = nil, on container: Container) {
         self.urlSession = urlSession
         self.cachePolicy = cachePolicy
         self.container = container
@@ -58,13 +58,15 @@ public final class FoundationClient: Client, ServiceType {
 
 private extension HTTPRequest {
     /// Converts an `HTTP.HTTPRequest` to `Foundation.URLRequest`
-    func convertToFoundationRequest(defaultCachePolicy cachePolicy: URLRequest.CachePolicy) -> URLRequest {
+    func convertToFoundationRequest(defaultCachePolicy cachePolicy: URLRequest.CachePolicy?) -> URLRequest {
         let http = self
         let body = http.body.data ?? Data()
         var request = URLRequest(url: http.url)
         request.httpMethod = "\(http.method)"
         request.httpBody = body
-        request.cachePolicy = cachePolicy
+        if let cachePolicy = cachePolicy {
+            request.cachePolicy = cachePolicy
+        }
         http.headers.forEach { key, val in
             request.addValue(val, forHTTPHeaderField: key.description)
         }

--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -60,6 +60,7 @@ private extension HTTPRequest {
         var request = URLRequest(url: http.url)
         request.httpMethod = "\(http.method)"
         request.httpBody = body
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         http.headers.forEach { key, val in
             request.addValue(val, forHTTPHeaderField: key.description)
         }


### PR DESCRIPTION
When the default caching is set I get additional headers to the request that I can not control like `If-None-Match` and `If-Modified-Since` especially the second one is causing a 501 error on DELETE S3 requests with error message: 'A header you provided implies functionality that is not implemented`

So I think we should have this set by default in order to have our clients in full control of what is being sent out ... obviously the best solution would be to allow user to set their caching preference globally from configure and additionally to allow for an optional parameter caching on the convenience request methods too ... happy to make another PR if/after/or this get's approved

This took me to the solution (been struggling with that for a while):
https://github.com/AFNetworking/AFNetworking/issues/1362
