### PR TITLE
Make `on()` public

### DIFF
--- a/Sources/Vapor/Routing/Router+Method.swift
+++ b/Sources/Vapor/Routing/Router+Method.swift
@@ -165,7 +165,7 @@ extension Router {
     ///     - closure: Creates a `Response` for the incoming `Request`.
     /// - returns: Discardable `Route` that was just created.
     @discardableResult
-    private func on<T>(_ method: HTTPMethod, at path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
+    public func on<T>(_ method: HTTPMethod, at path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder>
         where T: ResponseEncodable
     {
         return _on(method, at: path.convertToPathComponents(), use: closure)


### PR DESCRIPTION
My custom router methods like the one below stopped working! I think this is pretty useful to be private :)

```swift
    @discardableResult public func options<T>(_ path: PathComponentsRepresentable..., use closure: @escaping (Request) throws -> T) -> Route<Responder> where T: ResponseEncodable {
        return self.on(.OPTIONS, at: path, use: closure)
    }
```
