### PR TITLE
fix maxBodySize typo

### DIFF
--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -26,7 +26,7 @@ public struct NIOServerConfig: ServiceType {
         port: Int = 8080,
         backlog: Int = 256,
         workerCount: Int = ProcessInfo.processInfo.activeProcessorCount,
-        maxBodySize: Int = 1_000_0000,
+        maxBodySize: Int = 1_000_000,
         reuseAddress: Bool = true,
         tcpNoDelay: Bool = true
     ) -> NIOServerConfig {


### PR DESCRIPTION
`NIOServerConfig` has `maxBodySize` set to `1_000_0000` – presumed to be a typo and corrected to match the `1_000_000` (1MB) value that exists throughout `vapor/http`

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
