### PR TITLE
Fix double percent encoding

### DIFF
--- a/Sources/Vapor/Content/QueryContainer.swift
+++ b/Sources/Vapor/Content/QueryContainer.swift
@@ -27,7 +27,7 @@ public struct QueryContainer {
             throw VaporError(identifier: "parseURL", reason: "Could not parse URL components.")
         }
         let data = try requireDataEncoder().encode(encodable)
-        comps.query = String(data: data, encoding: .utf8)
+        comps.percentEncodedQuery = String(data: data, encoding: .utf8)
         guard let url = comps.url else {
             throw VaporError(identifier: "serializeURL", reason: "Could not serialize URL components.")
         }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -624,6 +624,18 @@ class ApplicationTests: XCTestCase {
         })
     }
 
+    // https://github.com/vapor/vapor/issues/1687
+    func testRequestQueryStringPercentEncoding() throws {
+        struct TestQueryStringContainer: Content {
+            var name: String
+        }
+        let app = try Application()
+        let req = Request(using: app)
+        req.http.url = URLComponents().url!
+        try req.query.encode(TestQueryStringContainer(name: "Vapor Test"))
+        XCTAssertEqual(req.http.url.query, "name=Vapor%20Test")
+    }
+
     static let allTests = [
         ("testContent", testContent),
         ("testComplexContent", testComplexContent),
@@ -650,6 +662,7 @@ class ApplicationTests: XCTestCase {
         ("testDataResponses", testDataResponses),
         ("testMiddlewareOrder", testMiddlewareOrder),
         ("testSessionDestroy", testSessionDestroy),
+        ("testRequestQueryStringPercentEncoding", testRequestQueryStringPercentEncoding),
     ]
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->
Fixes an issue where query strings are percent-encoded twice - making a query string parameter like "Vapor Test" into "Vapor%25%20Test" instead of "Vapor%20Test".

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.