### PR TITLE
Removed extra 'p' from helper word and added italic to encode word as…

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -84,7 +84,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
 
     /// Helper for encoding and decoding `Content` from an HTTP message.
     ///
-    /// This helpper can encode data to the HTTP message. Uses the Content's default media type if none is supplied.
+    /// This helper can _encode_ data to the HTTP message. Uses the Content's default media type if none is supplied.
     ///
     ///     try req.content.encode(user)
     ///


### PR DESCRIPTION
… the decode one.

There was an extra 'p' in 'helper' word that was shown in the documentation of the ```content``` method. 

Also made italic the word 'encode' as the 'decode' one, as it looks better.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
