### PR TITLE
Make `ApplicationResponder` public

### DIFF
--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -1,10 +1,10 @@
 /// Vapor's main `Responder` type. Combines configured middleware + router to create a responder.
 public struct ApplicationResponder: Responder, ServiceType {
     /// See `ServiceType`.
-    static var serviceSupports: [Any.Type] { return [Responder.self] }
+    public static var serviceSupports: [Any.Type] { return [Responder.self] }
 
     /// See `ServiceType`.
-    static func makeService(for container: Container) throws -> ApplicationResponder {
+    public static func makeService(for container: Container) throws -> ApplicationResponder {
         // initialize all `[Middleware]` from config
         let middleware = try container
             .make(MiddlewareConfig.self)
@@ -24,12 +24,12 @@ public struct ApplicationResponder: Responder, ServiceType {
     private let responder: Responder
 
     /// Creates a new `ApplicationResponder`.
-    init(_ responder: Responder) {
+    public init(_ responder: Responder) {
         self.responder = responder
     }
 
     /// See `Responder`.
-    func respond(to req: Request) throws -> Future<Response> {
+    public func respond(to req: Request) throws -> Future<Response> {
         return try responder.respond(to: req)
     }
 }

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -14,14 +14,14 @@ public struct ApplicationResponder: Responder, ServiceType {
         let router = try container.make(Router.self)
 
         // return new responder
-        return ApplicationResponder(router, middleware: middleware)
+        return ApplicationResponder(router, middleware)
     }
 
     /// Wrapped `Responder`.
     private let responder: Responder
 
     /// Creates a new `ApplicationResponder`.
-    public init(_ router: Router, middleware: [Middleware]) {
+    public init(_ router: Router, _ middleware: [Middleware] = []) {
         let router = RouterResponder(router: router)
         let wrapped = middleware.makeResponder(chainedto: router)
         self.responder = wrapped

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -11,21 +11,20 @@ public struct ApplicationResponder: Responder, ServiceType {
             .resolve(for: container)
 
         // create router and wrap in a responder
-        let router = try RouterResponder(router: container.make())
-
-        // chain middleware to router
-        let wrapped = middleware.makeResponder(chainedto: router)
+        let router = try container.make(Router.self)
 
         // return new responder
-        return ApplicationResponder(wrapped)
+        return ApplicationResponder(router, middleware: middleware)
     }
 
     /// Wrapped `Responder`.
     private let responder: Responder
 
     /// Creates a new `ApplicationResponder`.
-    public init(_ responder: Responder) {
-        self.responder = responder
+    public init(_ router: Router, middleware: [Middleware]) {
+        let router = RouterResponder(router: router)
+        let wrapped = middleware.makeResponder(chainedto: router)
+        self.responder = wrapped
     }
 
     /// See `Responder`.

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -1,5 +1,5 @@
 /// Vapor's main `Responder` type. Combines configured middleware + router to create a responder.
-internal struct ApplicationResponder: Responder, ServiceType {
+public struct ApplicationResponder: Responder, ServiceType {
     /// See `ServiceType`.
     static var serviceSupports: [Any.Type] { return [Responder.self] }
 

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -26,6 +26,10 @@ public final class EngineRouter: Router {
             self.router.options.insert(.caseInsensitive)
         }
     }
+    
+    public init(type: Responder.Type) {
+        self.router = TrieRouter<Responder>.init(type, options: [])   
+    }
 
     /// See `Router`.
     public func register(route: Route<Responder>) {

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -26,10 +26,6 @@ public final class EngineRouter: Router {
             self.router.options.insert(.caseInsensitive)
         }
     }
-    
-    public init(type: Responder.Protocol) {
-        self.router = TrieRouter<Responder>.init(type, options: [])   
-    }
 
     /// See `Router`.
     public func register(route: Route<Responder>) {

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -27,7 +27,7 @@ public final class EngineRouter: Router {
         }
     }
     
-    public init(type: Responder.Type) {
+    public init(type: Responder.Protocol) {
         self.router = TrieRouter<Responder>.init(type, options: [])   
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->
I'm working on a monitoring module for Vapor over at https://github.com/MrLotU/VaporMonitoring (still a WIP) and for it to properly function I need access to `ApplicationResponder`, thus this PR

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
