### PR TITLE
MultiThreadedEventLoopGroup Init Fix

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -118,8 +118,7 @@ public final class Application: Container {
         self.services = services
         self.serviceCache = .init()
         self.extend = Extend()
-        self.eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-
+        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
 
     /// Internal method. Boots the application and its providers.

--- a/Sources/Vapor/Server/NIOServer.swift
+++ b/Sources/Vapor/Server/NIOServer.swift
@@ -48,7 +48,7 @@ public final class NIOServer: Server, ServiceType {
             let responderCache = ThreadSpecificVariable<ThreadResponder>()
 
             // create this server's own event loop group
-            let group = MultiThreadedEventLoopGroup(numThreads: config.workerCount)
+            let group = MultiThreadedEventLoopGroup(numberOfThreads: config.workerCount)
             for _ in 0..<config.workerCount {
                 // initialize each event loop
                 let eventLoop = group.next()


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

When I was building Vapor on my machine, I got warnings around `NIO.MultiThreadedEventLoopGroup`'s init method. The parameter changed from `numThreads` to `numberOfThreads`.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.