### PR TITLE
Use Discord instead of Slack in CLI help

### DIFF
--- a/Utilities/compatibility.sh
+++ b/Utilities/compatibility.sh
@@ -4,7 +4,7 @@ function help() {
     echo "📖  Visit our docs for step-by-step instructions on installing Swift correctly."
     echo "http://docs.vapor.codes"
     echo ""
-    echo "👋  or Join our Slack and we'll help you get setup."
+    echo "👋  or Join our Discord and we'll help you get setup."
     echo "http://vapor.team"
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

When executing the `--help` command in the CLI it tells you to join the Slack workspace. As Vapor migrated to Discord this should be changed as well. I didn't update anything else than the String so it shouldn't affect the actual code.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
