### PR TITLE
Innocuous typos in comments and whitespace

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -58,7 +58,7 @@ public final class Application: Container {
     /// - parameters:
     ///     - config: Configuration preferences for this service container.
     ///     - environment: Application's environment type (i.e., testing, production).
-    ///                    Different environments can trigger different application behavior (for example, supressing verbose logs in production mode).
+    ///                    Different environments can trigger different application behavior (for example, suppressing verbose logs in production mode).
     ///     - services: Application's available services. A copy of these services will be passed to all sub event-loops created by this Application.
     public convenience init(
         config: Config = .default(),

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -129,7 +129,7 @@ extension Client {
     ///     - beforeSend: An optional closure that can mutate the `Request` before it is sent.
     /// - returns: A `Future` containing the requested `Response` or an `Error`.
     public func delete(_ url: URLRepresentable, headers: HTTPHeaders = [:], beforeSend: (Request) throws -> () = { _ in }) -> Future<Response> {
-    return send(.DELETE, headers: headers, to: url, beforeSend: beforeSend)
+        return send(.DELETE, headers: headers, to: url, beforeSend: beforeSend)
     }
 
     /// Sends an HTTP `Request` to a server with an optional configuration closure that will run before sending.

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -7,7 +7,7 @@
 ///     | GET  | /hash/:string    |
 ///     +------+------------------+
 ///
-/// A colon preceeding a path component indicates a variable parameter. A colon with no text following
+/// A colon preceding a path component indicates a variable parameter. A colon with no text following
 /// is a parameter whose result will be discarded.
 ///
 /// An asterisk indicates a catch-all. Any path components after a catch-all will be discarded and ignored.

--- a/Sources/Vapor/Content/ContentConfig.swift
+++ b/Sources/Vapor/Content/ContentConfig.swift
@@ -89,7 +89,7 @@ public struct ContentConfig: Service, ServiceType {
 
     // MARK: Message & Data
 
-    /// Adds an `HTTPMessage` and `Data` `Encoder` for the specified `MediaType`.
+    /// Adds an `HTTPMessage` and `DataEncoder` for the specified `MediaType`.
     ///
     ///     contentConfig.use(encoder: JSONEncoder(), for: .json)
     ///
@@ -101,7 +101,7 @@ public struct ContentConfig: Service, ServiceType {
         use(dataEncoder: encoder, for: mediaType)
     }
 
-    /// Adds an `HTTPMessage` and `Data` `Decoder` for the specified `MediaType`.
+    /// Adds an `HTTPMessage` and `DataDecoder` for the specified `MediaType`.
     ///
     ///     contentConfig.use(decoder: JSONDecoder(), for: .json)
     ///
@@ -113,7 +113,7 @@ public struct ContentConfig: Service, ServiceType {
         use(dataDecoder: decoder, for: mediaType)
     }
 
-    /// Adds an `HTTPMessage` and `Data` `Encoder` by type for the specified `MediaType`.
+    /// Adds an `HTTPMessage` and `DataEncoder` by type for the specified `MediaType`.
     /// - note: The type will be resolved from the service-container at boot.
     ///
     ///     contentConfig.use(encoder: JSONEncoder.self, for: .json)
@@ -126,7 +126,7 @@ public struct ContentConfig: Service, ServiceType {
         use(dataEncoder: encoder, for: mediaType)
     }
 
-    /// Adds an `HTTPMessage` and `Data` `Decoder` by type for the specified `MediaType`.
+    /// Adds an `HTTPMessage` and `DataDecoder` by type for the specified `MediaType`.
     /// - note: The type will be resolved from the service-container at boot.
     ///
     ///     contentConfig.use(decoder: JSONDecoder.self, for: .json)
@@ -146,7 +146,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(httpEncoder: JSONEncoder(), for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `HTTPMessageEncoder` to use.
+    ///     - httpEncoder: `HTTPMessageEncoder` to use.
     ///     - mediaType: `HTTPMessageEncoder` will be used to encode this `MediaType`.
     public mutating func use(httpEncoder: HTTPMessageEncoder, for mediaType: MediaType) {
         self.httpEncoders[mediaType] = { container in
@@ -159,7 +159,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(httpDecoder: JSONDecoder(), for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `HTTPMessageDecoder` to use.
+    ///     - httpDecoder: `HTTPMessageDecoder` to use.
     ///     - mediaType: `HTTPMessageDecoder` will be used to decode this `MediaType`.
     public mutating func use(httpDecoder: HTTPMessageDecoder, for mediaType: MediaType) {
         self.httpDecoders[mediaType] = { container in
@@ -172,7 +172,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(httpEncoder: JSONEncoder.self, for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `HTTPMessageEncoder` type to use.
+    ///     - httpEncoder: `HTTPMessageEncoder` type to use.
     ///     - mediaType: `HTTPMessageEncoder` will be used to encode this `MediaType`.
     public mutating func use<B>(httpEncoder: B.Type, for mediaType: MediaType) where B: HTTPMessageEncoder {
         self.httpEncoders[mediaType] = { container in
@@ -185,7 +185,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(httpDecoder: JSONDecoder.self, for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `HTTPMessageDecoder` type to use.
+    ///     - httpDecoder: `HTTPMessageDecoder` type to use.
     ///     - mediaType: `HTTPMessageDecoder` will be used to decode this `MediaType`.
     public mutating func use<B>(httpDecoder: B.Type, for mediaType: MediaType) where B: HTTPMessageDecoder {
         self.httpDecoders[mediaType] = { container in
@@ -200,7 +200,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(dataEncoder: JSONEncoder(), for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `DataEncoder` to use.
+    ///     - dataEncoder: `DataEncoder` to use.
     ///     - mediaType: `DataEncoder` will be used to encode this `MediaType`.
     public mutating func use(dataEncoder: DataEncoder, for mediaType: MediaType) {
         self.dataEncoders[mediaType] = { container in
@@ -213,7 +213,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(dataDecoder: JSONDecoder(), for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `DataDecoder` to use.
+    ///     - dataDecoder: `DataDecoder` to use.
     ///     - mediaType: `DataDecoder` will be used to decode this `MediaType`.
     public mutating func use(dataDecoder: DataDecoder, for mediaType: MediaType) {
         self.dataDecoders[mediaType] = { container in
@@ -226,7 +226,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(dataEncoder: JSONEncoder.self, for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `DataEncoder` type to use.
+    ///     - dataEncoder: `DataEncoder` type to use.
     ///     - mediaType: `DataEncoder` will be used to encode this `MediaType`.
     public mutating func use<D>(dataEncoder: D.Type, for mediaType: MediaType) where D: DataEncoder {
         self.dataEncoders[mediaType] = { container in
@@ -239,7 +239,7 @@ public struct ContentConfig: Service, ServiceType {
     ///     contentConfig.use(dataDecoder: JSONDecoder.self, for: .json)
     ///
     /// - parameters:
-    ///     - encoder: `DataDecoder` type to use.
+    ///     - dataDecoder: `DataDecoder` type to use.
     ///     - mediaType: `DataDecoder` will be used to decode this `MediaType`.
     public mutating func use<D>(dataDecoder: D.Type, for mediaType: MediaType) where D: DataDecoder {
         self.dataDecoders[mediaType] = { container in

--- a/Sources/Vapor/Content/ContentContainer.swift
+++ b/Sources/Vapor/Content/ContentContainer.swift
@@ -39,7 +39,7 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
         try encode(json, using: encoder)
     }
 
-    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously
+    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously.
     /// See `syncDecode(_:)` for the non-streaming, synchronous version.
     ///
     ///     let user = req.content.decode(json: User.self, using: .custom(dates: .iso8601))
@@ -93,8 +93,8 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
     public func encode<E>(_ encodable: E, using encoder: HTTPMessageEncoder) throws where E: Encodable {
         try encoder.encode(encodable, to: &container.http, on: container)
     }
-    
-    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously
+
+    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously.
     /// See `syncDecode(_:)` for the non-streaming, synchronous version.
     ///
     ///     let user = try req.content.decode(User.self)
@@ -111,7 +111,7 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
         return try decode(D.self, maxSize: maxSize, using: requireHTTPDecoder())
     }
 
-    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously
+    /// Parses a `Decodable` type from this HTTP message. This method supports streaming HTTP bodies (chunked) and can run asynchronously.
     /// See `syncDecode(_:)` for the non-streaming, synchronous version.
     ///
     ///     let user = req.content.decode(json: User.self, using: JSONDecoder())
@@ -234,7 +234,7 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
 
     // MARK: Sync
 
-    /// Parses a `Decodable` type from this HTTP message. This method does _not_ support streaming HTTP bodies (chunked) and runs synchronously.
+    /// Parses a `Decodable` type from this HTTP message. This method does _not_ support streaming HTTP bodies (chunked) and runs synchronously.
     /// See `decode(_:maxSize:)` for the streaming version.
     ///
     ///     let user = try req.content.syncDecode(User.self)
@@ -244,7 +244,7 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
     ///
     /// - parameters:
     ///     - content: `Decodable` type to decode from this HTTP message.
-    /// - returns: Instace of the `Decodable` type.
+    /// - returns: Instance of the `Decodable` type.
     /// - throws: Any errors making the decoder for this media type or parsing the message.
     ///           An error will also be thrown if this HTTP message's body type is streaming.
     public func syncDecode<D>(_ content: D.Type) throws -> D where D: Decodable {
@@ -299,7 +299,7 @@ public struct ContentContainer<M> where M: HTTPMessageContainer {
             throw VaporError(
                 identifier: "syncGet",
                 reason: "Cannot use sync decode on a streaming body.",
-                suggestedFixes: [ "Use `get` instead of `syncGet`."]
+                suggestedFixes: ["Use `get` instead of `syncGet`."]
             )
         }
         return try requireDataDecoder().get(at: keyPath.makeBasicKeys(), from: data)

--- a/Sources/Vapor/Content/HTTPMessageContainer.swift
+++ b/Sources/Vapor/Content/HTTPMessageContainer.swift
@@ -3,6 +3,6 @@ public protocol HTTPMessageContainer: Container {
     /// Associated `HTTPMessage` type.
     associatedtype HTTPMessageType: HTTPMessage
 
-    /// This `Container`'s mutable `HTTPMesage`.
+    /// This `Container`'s mutable `HTTPMessage`.
     var http: HTTPMessageType { get set }
 }

--- a/Sources/Vapor/Content/JSONCoder+Custom.swift
+++ b/Sources/Vapor/Content/JSONCoder+Custom.swift
@@ -1,4 +1,4 @@
-/* FIXME: add key strategy support once avaialble on Linux */
+/* FIXME: add key strategy support once available on Linux */
 
 extension JSONEncoder {
     /// Convenience for creating a customized `JSONEncoder`.

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -34,7 +34,7 @@ public final class PlaintextEncoder: DataEncoder, HTTPMessageEncoder {
     }
 }
 
-/// MARK: Private
+// MARK: Private
 
 private final class _DataEncoder: Encoder {
     public var codingPath: [CodingKey]

--- a/Sources/Vapor/Content/QueryContainer.swift
+++ b/Sources/Vapor/Content/QueryContainer.swift
@@ -12,7 +12,7 @@ public struct QueryContainer {
 
     // MARK: Content
 
-    /// Serializes an `Encodable` type to this HTTP request query string.
+    /// Serializes an `Encodable` type to this HTTP request query string.
     ///
     ///     let flags: Flags ...
     ///     try req.query.encode(flags)
@@ -34,7 +34,7 @@ public struct QueryContainer {
         req.http.url = url
     }
 
-    /// Parses a `Decodable` type from this HTTP request query string.
+    /// Parses a `Decodable` type from this HTTP request query string.
     ///
     ///     let flags = try req.query.decode(Flags.self)
     ///     print(flags) // Flags
@@ -140,7 +140,7 @@ public struct QueryContainer {
         return try req.make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
     }
 
-    /// Gets the`DataEncoder` or throws an error.
+    /// Gets the `DataEncoder` or throws an error.
     private func requireDataEncoder() throws -> DataEncoder {
         return try req.make(ContentCoders.self).requireDataEncoder(for: .urlEncodedForm)
     }

--- a/Sources/Vapor/Content/SingleValueGet.swift
+++ b/Sources/Vapor/Content/SingleValueGet.swift
@@ -2,7 +2,6 @@ extension DataDecoder {
     /// Gets a single decodable value at the supplied key path from the data.
     internal func get<D>(at keyPath: [BasicKey], from data: Data) throws -> D where D: Decodable {
         return try self.decode(SingleValueDecoder.self, from: data).get(at: keyPath)
-
     }
 }
 
@@ -25,7 +24,7 @@ private struct SingleValueDecoder: Decodable {
     init(from decoder: Decoder) throws {
         self.decoder = decoder
     }
-    
+
     func get<D>(at keyPath: [BasicKey]) throws -> D where D: Decodable {
         let unwrapper = self
         var state = try ContainerState.keyed(unwrapper.decoder.container(keyedBy: BasicKey.self))
@@ -77,7 +76,7 @@ private enum ContainerState {
 }
 
 private extension UnkeyedDecodingContainer {
-     mutating func skip(to count: Int) throws -> UnkeyedDecodingContainer {
+    mutating func skip(to count: Int) throws -> UnkeyedDecodingContainer {
         for _ in 0..<count {
             _ = try nestedContainer(keyedBy: BasicKey.self)
         }

--- a/Sources/Vapor/Logging/Logger+LogError.swift
+++ b/Sources/Vapor/Logging/Logger+LogError.swift
@@ -34,6 +34,5 @@ extension Logger {
                 debug("Conform `\(type(of: e))` to `Debuggable` for better debug info.")
             }
         }
-
     }
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -48,7 +48,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     ///     let authCache = try req.privateContainer.make(AuthCache.self)
     ///
     public let privateContainer: SubContainer
-    
+
     /// `true` if this request has active connections. This is used to avoid unnecessarily
     /// invoking cached connections release.
     internal var hasActiveConnections: Bool
@@ -156,7 +156,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     // MARK: Database
 
     /// See `DatabaseConnectable`.
-    public func databaseConnection<D>(to database: DatabaseIdentifier<D>?) -> Future<D.Connection>{
+    public func databaseConnection<D>(to database: DatabaseIdentifier<D>?) -> Future<D.Connection> {
         guard let database = database else {
             let error = VaporError(
                 identifier: "defaultDB",

--- a/Sources/Vapor/Response/Redirect.swift
+++ b/Sources/Vapor/Response/Redirect.swift
@@ -15,7 +15,6 @@ extension Request {
     }
 }
 
-
 /// Specifies the type of redirect that the client should receive.
 public enum RedirectType {
     /// A cacheable redirect.

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -48,7 +48,7 @@ public final class Response: ContainerAlias, HTTPMessageContainer, ResponseCodab
 
     /// Helper for encoding and decoding `Content` from an HTTP message.
     ///
-    /// This helpper can encode data to the HTTP message. Uses the Content's default media type if none is supplied.
+    /// This helper can encode data to the HTTP message. Uses the Content's default media type if none is supplied.
     ///
     ///     try res.content.encode(user)
     ///

--- a/Sources/Vapor/Routing/Router+Function.swift
+++ b/Sources/Vapor/Routing/Router+Function.swift
@@ -55,6 +55,6 @@ private class MiddlewareFunction: Middleware {
 
     /// See `Middleware`.
     func respond(to request: Request, chainingTo next: Responder) throws -> Future<Response> {
-        return try self.respond(request,next)
+        return try self.respond(request, next)
     }
 }

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -54,7 +54,7 @@ public struct NIOServerConfig: ServiceType {
     /// Should be equal to the number of logical cores.
     public var workerCount: Int
 
-    /// Requests containing bodies larger than this maximum will be rejected, closign the connection.
+    /// Requests containing bodies larger than this maximum will be rejected, closing the connection.
     public var maxBodySize: Int
 
     /// When `true`, can prevent errors re-binding to a socket after successive server restarts.

--- a/Sources/Vapor/Server/RunningServer.swift
+++ b/Sources/Vapor/Server/RunningServer.swift
@@ -16,7 +16,7 @@ extension Application {
     }
 }
 
-/// A context for the currently running `Server` protocol. When a `Server` succesfully boots,
+/// A context for the currently running `Server` protocol. When a `Server` successfully boots,
 /// it sets one of these on the `runningServer` property of the `Application`.
 ///
 /// This struct can be used to close the server.

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -1,7 +1,7 @@
 import Crypto
 
 extension Services {
-    /// Vapor's default services. This includes many services required to succesfully
+    /// Vapor's default services. This includes many services required to successfully
     /// boot an Application. Only for special use cases should you create an empty `Services` struct.
     public static func `default`() -> Services {
         var services = Services()
@@ -98,5 +98,5 @@ extension PlaintextRenderer: Service { }
 extension Terminal: Service { }
 extension DirectoryConfig: Service { }
 extension ConsoleLogger: Service { }
-extension PrintLogger: Service {}
+extension PrintLogger: Service { }
 extension BCryptDigest: Service { }

--- a/Sources/Vapor/Services/VaporProvider.swift
+++ b/Sources/Vapor/Services/VaporProvider.swift
@@ -8,7 +8,6 @@ public protocol VaporProvider: Provider {
     func didRun(_ worker: Container) throws -> Future<Void>
 }
 
-
 extension Array where Element == Provider {
     /// Returns only the `VaporProvider` service providers.
     internal var onlyVapor: [VaporProvider] {

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -98,7 +98,7 @@ public struct FileIO {
     ///
     /// - parameters:
     ///     - file: Path to file on the disk.
-    ///     - chunkSize: Maxiumum size for the file data chunks.
+    ///     - chunkSize: Maximum size for the file data chunks.
     ///     - onRead: Closure to be called sequentially for each file data chunk.
     /// - returns: `Future` that will complete when the file read is finished.
     public func readChunked(file: String, chunkSize: Int = NonBlockingFileIO.defaultChunkSize, onRead: @escaping (Data) -> Void) -> Future<Void> {
@@ -123,7 +123,7 @@ public struct FileIO {
     /// - parameters:
     ///     - file: Path to file on the disk.
     ///     - req: `HTTPRequest` to parse `"If-None-Match"` header from.
-    ///     - chunkSize: Maxiumum size for the file data chunks.
+    ///     - chunkSize: Maximum size for the file data chunks.
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.
     public func chunkedResponse(file: String, for req: HTTPRequest, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) -> HTTPResponse {
         // Get file attributes for this file.
@@ -174,7 +174,7 @@ public struct FileIO {
     ///
     /// - parameters:
     ///     - file: Path to file on the disk.
-    ///     - chunkSize: Maxiumum size for the file data chunks.
+    ///     - chunkSize: Maximum size for the file data chunks.
     /// - returns: An `HTTPChunkedStream` containing the file stream.
     public func chunkedStream(file: String, chunkSize: Int = NonBlockingFileIO.defaultChunkSize) -> HTTPChunkedStream {
         let chunkStream = HTTPChunkedStream(on: eventLoop)

--- a/Sources/Vapor/Utilities/Thread.swift
+++ b/Sources/Vapor/Utilities/Thread.swift
@@ -6,7 +6,7 @@ extension Thread {
                 work()
             }
         } else {
-            ERROR("Thead.async requires macOS 10.12 or greater")
+            ERROR("Thread.async requires macOS 10.12 or greater")
         }
     }
 }

--- a/Sources/Vapor/WebSocket/NIOWebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/NIOWebSocketServer.swift
@@ -10,10 +10,10 @@
 /// (including middleware). Should an HTTP upgrade request be accepted, no other parts of Vapor's pipeline will be invoked.
 /// Should the HTTP upgrade request be denied, the request will continue through Vapor's HTTP pipeline normally.
 ///
-/// Note: The `WebSocketServer` _always_ runs behind an HTTP server and will only be invoked when HTTP requests request an uprade.
+/// Note: The `WebSocketServer` _always_ runs behind an HTTP server and will only be invoked when HTTP requests request an upgrade.
 public final class NIOWebSocketServer: WebSocketServer, Service {
     /// The internal trie-node router backing this server.
-    /// This will be used to register and retreive all websocket responding routes.
+    /// This will be used to register and retrieve all websocket responding routes.
     private let router: TrieRouter<WebSocketResponder>
 
     /// All websocket responder routes that have been added to this `NIOWebSocketServer`.
@@ -87,7 +87,7 @@ extension NIOWebSocketServer {
     ///     - path: Dynamic path to associate with this websocket upgrade closure.
     ///             HTTP upgrade requests that contain a matching path will invoke the supplied on upgrade
     ///             closure when the websocket client connects.
-    ///             Any parameterized values can be retreived from the HTTP request supplied to the closure.
+    ///             Any parameterized values can be retrieved from the HTTP request supplied to the closure.
     ///     - closure: Websocket on upgrade closure. Accepts newly upgraded websocket connections.
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.
@@ -108,7 +108,7 @@ extension NIOWebSocketServer {
     ///     - path: Dynamic path to associate with this websocket upgrade closure.
     ///             HTTP upgrade requests that contain a matching path will invoke the supplied on upgrade
     ///             closure when the websocket client connects.
-    ///             Any parameterized values can be retreived from the HTTP request supplied to the closure.
+    ///             Any parameterized values can be retrieved from the HTTP request supplied to the closure.
     ///     - closure: Websocket on upgrade closure. Accepts newly upgraded websocket connections.
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.
@@ -123,7 +123,7 @@ extension NIOWebSocketServer {
     ///     - path: Dynamic path to associate with this websocket upgrade closure.
     ///             HTTP upgrade requests that contain a matching path will invoke the supplied on upgrade
     ///             closure when the websocket client connects.
-    ///             Any parameterized values can be retreived from the HTTP request supplied to the closure.
+    ///             Any parameterized values can be retrieved from the HTTP request supplied to the closure.
     ///     - closure: Websocket on upgrade closure. Accepts newly upgraded websocket connections.
     ///
     /// - returns: Discardable websocket responder route. Use this route reference to append metadata to the route.

--- a/Sources/Vapor/WebSocket/WebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/WebSocketServer.swift
@@ -7,7 +7,7 @@
 /// (including middleware). Should an HTTP upgrade request be accepted, no other parts of Vapor's pipeline will be invoked.
 /// Should the HTTP upgrade request be denied, the request will continue through Vapor's HTTP pipeline normally.
 ///
-/// Note: The `WebSocketServer` _always_ runs behind an HTTP server and will only be invoked when HTTP requests request an uprade.
+/// Note: The `WebSocketServer` _always_ runs behind an HTTP server and will only be invoked when HTTP requests request an upgrade.
 public protocol WebSocketServer {
     /// Determines whether the HTTP request should be upgraded or not.
     /// Only HTTP requests that have requested websocket protocol upgrade will be supplied to this method.


### PR DESCRIPTION
Corrected some innocuous typos in comments, extra or missing whitespace and removed some invisible characters.

### Checklist

- [√ ] There are no breaking changes to public API.
