### PR TITLE
renamed 'chainedto' to 'chainingTo' to match the middleware makeResponder(chainingTo:) 

### DIFF
--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -36,3 +36,13 @@ extension MemorySessions {
         self.init()
     }
 }
+
+extension Array where Element == Middleware {
+    /// Wraps a `Responder` in an array of `Middleware` creating a new `Responder`.
+    /// - note: The array of middleware must be `[Middleware]` not `[M] where M: Middleware`.
+    @available(*, deprecated, message: "label 'chainedto' was renamed 'chainingTo'.")
+    public func makeResponder(chainedto responder: Responder) -> Responder {
+        return makeResponder(chainingTo: responder)
+    }
+}
+

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -17,7 +17,7 @@ public protocol Middleware {
 extension Array where Element == Middleware {
     /// Wraps a `Responder` in an array of `Middleware` creating a new `Responder`.
     /// - note: The array of middleware must be `[Middleware]` not `[M] where M: Middleware`.
-    public func makeResponder(chainedTo responder: Responder) -> Responder {
+    public func makeResponder(chainingTo responder: Responder) -> Responder {
         var responder = responder
         for middleware in reversed() {
             responder = middleware.makeResponder(chainingTo: responder)

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -17,7 +17,7 @@ public protocol Middleware {
 extension Array where Element == Middleware {
     /// Wraps a `Responder` in an array of `Middleware` creating a new `Responder`.
     /// - note: The array of middleware must be `[Middleware]` not `[M] where M: Middleware`.
-    public func makeResponder(chainedto responder: Responder) -> Responder {
+    public func makeResponder(chainedTo responder: Responder) -> Responder {
         var responder = responder
         for middleware in reversed() {
             responder = middleware.makeResponder(chainingTo: responder)

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -23,7 +23,7 @@ public struct ApplicationResponder: Responder, ServiceType {
     /// Creates a new `ApplicationResponder`.
     public init(_ router: Router, _ middleware: [Middleware] = []) {
         let router = RouterResponder(router: router)
-        let wrapped = middleware.makeResponder(chainedto: router)
+        let wrapped = middleware.makeResponder(chainedTo: router)
         self.responder = wrapped
     }
 

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -23,7 +23,7 @@ public struct ApplicationResponder: Responder, ServiceType {
     /// Creates a new `ApplicationResponder`.
     public init(_ router: Router, _ middleware: [Middleware] = []) {
         let router = RouterResponder(router: router)
-        let wrapped = middleware.makeResponder(chainedTo: router)
+        let wrapped = middleware.makeResponder(chainingTo: router)
         self.responder = wrapped
     }
 

--- a/Sources/Vapor/Routing/Router+Middleware.swift
+++ b/Sources/Vapor/Routing/Router+Middleware.swift
@@ -83,7 +83,7 @@ private final class MiddlewareGroup: Router {
     /// See `Router`.
     func register(route: Route<Responder>) {
         // chain the output to this middleware
-        route.output = middleware.makeResponder(chainedTo: route.output)
+        route.output = middleware.makeResponder(chainingTo: route.output)
         // then register
         root.register(route: route)
     }

--- a/Sources/Vapor/Routing/Router+Middleware.swift
+++ b/Sources/Vapor/Routing/Router+Middleware.swift
@@ -83,7 +83,7 @@ private final class MiddlewareGroup: Router {
     /// See `Router`.
     func register(route: Route<Responder>) {
         // chain the output to this middleware
-        route.output = middleware.makeResponder(chainedto: route.output)
+        route.output = middleware.makeResponder(chainedTo: route.output)
         // then register
         root.register(route: route)
     }


### PR DESCRIPTION
Refactored label 'chainedto' to 'chainedTo' in vapor/vapor.
Apparently no occurrences found in vapor/vapor dependencies.

Caution: might break the API in existing code.

