### PR TITLE
Conform HTTPStatus to Content

### DIFF
--- a/Sources/Vapor/Response/HTTPStatus.swift
+++ b/Sources/Vapor/Response/HTTPStatus.swift
@@ -2,6 +2,7 @@
 public typealias HTTPStatus = HTTPResponseStatus
 
 extension HTTPStatus: Codable {
+    
     /// See [`Decodable.init(from:)`](https://developer.apple.com/documentation/swift/decodable/2894081-init).
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -16,7 +17,13 @@ extension HTTPStatus: Codable {
     }
 }
 
-extension HTTPStatus: ResponseEncodable {
+extension HTTPStatus: Content {
+    
+    /// See `ResponseDecodable`.
+    public static func decode(from res: Response, for req: Request) throws -> Future<HTTPStatus> {
+        return req.future(res.http.status)
+    }
+    
     /// See `ResponseEncodable`.
     public func encode(for req: Request) throws -> Future<Response> {
         let res = Response(http: .init(status: self), using: req)

--- a/Sources/Vapor/Response/HTTPStatus.swift
+++ b/Sources/Vapor/Response/HTTPStatus.swift
@@ -1,10 +1,25 @@
 /// Less verbose typealias for `HTTPResponseStatus`.
 public typealias HTTPStatus = HTTPResponseStatus
 
+extension HTTPStatus: Codable {
+    /// See [`Decodable.init(from:)`](https://developer.apple.com/documentation/swift/decodable/2894081-init).
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let code = try container.decode(Int.self)
+        self = .init(statusCode: code)
+    }
+    
+    /// See [`Encodable.encode(to:)`](https://developer.apple.com/documentation/swift/encodable/2893603-encode).
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.code)
+    }
+}
+
 extension HTTPStatus: ResponseEncodable {
     /// See `ResponseEncodable`.
     public func encode(for req: Request) throws -> Future<Response> {
         let res = Response(http: .init(status: self), using: req)
-        return req.eventLoop.newSucceededFuture(result: res)
+        return req.future(res)
     }
 }


### PR DESCRIPTION
Conforms `HTTPStatus` (which is a typealias for NIO's `HTTPResponseStatus` enum) to the `Codable` and `Content` protocols. The biggest benefit of this is that you can now pass in `HTTPStatus` to a method that requires a type conforming to `Content`. For example, if you have [a method](https://github.com/skelpo/PayPal/blob/develop/Sources/PayPal/API/PayPalClient.swift#L55) that decodes a `Response` object a to `Content` type, `HTTPStatus` is now valid. 

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
