### PR TITLE
[Don't merge] Use private container to get database connection

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -170,7 +170,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
             return eventLoop.newFailedFuture(error: error)
         }
         hasActiveConnections = true
-        return requestCachedConnection(to: database)
+        return privateContainer.requestCachedConnection(to: database)
     }
 
     // MARK: Request Codable
@@ -188,7 +188,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     /// Called when the `Request` deinitializes.
     deinit {
         if hasActiveConnections {
-            try! releaseCachedConnections()
+            try! privateContainer.releaseCachedConnections()
         }
     }
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -170,7 +170,7 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
             return eventLoop.newFailedFuture(error: error)
         }
         hasActiveConnections = true
-        return privateContainer.requestCachedConnection(to: database)
+        return privateContainer.requestCachedConnection(to: database, poolContainer: self)
     }
 
     // MARK: Request Codable


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->
Multiple requests can grab same database connection.
See [DatabaseKit issue #43](https://github.com/vapor/database-kit/issues/43) for details.

`Request` tries to get database connection from [self (as `Container`)](https://github.com/vapor/vapor/blob/72273607b8b1fa5241b9d77a1e419eed7d5bc73d/Sources/Vapor/Request/Request.swift#L173). Internally the connection is [cached](https://github.com/vapor/database-kit/blob/9ea3fbea959b99560e44a4dfc8ee1f132a23e5a2/Sources/DatabaseKit/Connection/Container%2BCachedConnection.swift#L20) in the container.

But `Request` is `AliasedContainer`, so cache is shared among the requests.
If the server receives two (or more) requests simultaneously, they use the same database connection and it can crash [here](https://github.com/vapor/mysql/blob/8717e4a6389ff1ff56801f4e6411309105945c62/Sources/MySQL/Connection/MySQLConnection.swift#L81) for MySQL, or somewhere else for other DB. 

To make cache not shared, I changed to use `privateContainer` instead of `Request` itself.
There is [similar situation](https://github.com/vapor/vapor/blob/72273607b8b1fa5241b9d77a1e419eed7d5bc73d/Sources/Vapor/Sessions/Request%2BSession.swift#L13) so I think it may work well.

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
