### PR TITLE
Make ErrorResponse public

### DIFF
--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -12,15 +12,6 @@ public final class ErrorMiddleware: Middleware, ServiceType {
     ///     - environment: The environment to respect when presenting errors.
     ///     - log: Log destination.
     public static func `default`(environment: Environment, log: Logger) -> ErrorMiddleware {
-        /// Structure of `ErrorMiddleware` default response.
-        struct ErrorResponse: Encodable {
-            /// Always `true` to indicate this is a non-typical JSON response.
-            var error: Bool
-
-            /// The reason for the error.
-            var reason: String
-        }
-
         return .init { req, error in
             // log the error
             log.report(error: error, verbose: !environment.isRelease)
@@ -96,4 +87,13 @@ public final class ErrorMiddleware: Middleware, ServiceType {
             return self.closure(req, error)
         }
     }
+}
+
+/// Structure of `ErrorMiddleware` default response.
+public struct ErrorResponse: Encodable, Decodable {
+    /// Always `true` to indicate this is a non-typical JSON response.
+    var error: Bool
+
+    /// The reason for the error.
+    var reason: String
 }

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -1,5 +1,14 @@
 /// Captures all errors and transforms them into an internal server error HTTP response.
 public final class ErrorMiddleware: Middleware, ServiceType {
+    /// Structure of `ErrorMiddleware` default response.
+    public struct ErrorResponse: Encodable, Decodable {
+        /// Always `true` to indicate this is a non-typical JSON response.
+        var error: Bool
+
+        /// The reason for the error.
+        var reason: String
+    }
+
     /// See `ServiceType`.
     public static func makeService(for worker: Container) throws -> ErrorMiddleware {
         return try .default(environment: worker.environment, log: worker.make())
@@ -87,13 +96,4 @@ public final class ErrorMiddleware: Middleware, ServiceType {
             return self.closure(req, error)
         }
     }
-}
-
-/// Structure of `ErrorMiddleware` default response.
-public struct ErrorResponse: Encodable, Decodable {
-    /// Always `true` to indicate this is a non-typical JSON response.
-    var error: Bool
-
-    /// The reason for the error.
-    var reason: String
 }

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -1,7 +1,7 @@
 /// Captures all errors and transforms them into an internal server error HTTP response.
 public final class ErrorMiddleware: Middleware, ServiceType {
     /// Structure of `ErrorMiddleware` default response.
-    internal struct ErrorResponse: Encodable, Decodable {
+    internal struct ErrorResponse: Codable {
         /// Always `true` to indicate this is a non-typical JSON response.
         var error: Bool
 

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -1,7 +1,7 @@
 /// Captures all errors and transforms them into an internal server error HTTP response.
 public final class ErrorMiddleware: Middleware, ServiceType {
     /// Structure of `ErrorMiddleware` default response.
-    public struct ErrorResponse: Encodable, Decodable {
+    internal struct ErrorResponse: Encodable, Decodable {
         /// Always `true` to indicate this is a non-typical JSON response.
         var error: Bool
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
This makes `ErrorResponse` internal and Decodable, useful for testing error responses xD 
<!-- Pretend you are explaining it to a friend, not yourself! -->

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
