### PR TITLE
Support configure WebSocketServer MaxFrameSize

### DIFF
--- a/Sources/Vapor/Server/NIOServer.swift
+++ b/Sources/Vapor/Server/NIOServer.swift
@@ -66,7 +66,7 @@ public final class NIOServer: Server, ServiceType {
 
             // web socket upgrade
             if let wss = try? container.make(WebSocketServer.self) {
-                let ws = HTTPServer.webSocketUpgrader(shouldUpgrade: { req in
+                let ws = HTTPServer.webSocketUpgrader(maxFrameSize: config.webSocketMaxFrameSize, shouldUpgrade: { req in
                     guard let subContainer = containerCache.currentValue?.container else {
                         ERROR("[WebSocket Upgrader] Missing container (shouldUpgrade).")
                         return nil

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -78,7 +78,7 @@ public struct NIOServerConfig: ServiceType {
         maxBodySize: Int,
         reuseAddress: Bool,
         tcpNoDelay: Bool,
-        webSocketMaxFrameSize: Int
+        webSocketMaxFrameSize: Int = 1 << 14
     ) {
         self.hostname = hostname
         self.port = port

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -21,6 +21,7 @@ public struct NIOServerConfig: ServiceType {
     ///                    Streaming bodies, like chunked bodies, ignore this maximum.
     ///     - reuseAddress: When `true`, can prevent errors re-binding to a socket after successive server restarts.
     ///     - tcpNoDelay: When `true`, OS will attempt to minimize TCP packet delay.
+    ///     - webSocketMaxFrameSize: Number of webSocket maxFrameSize.
     public static func `default`(
         hostname: String = "localhost",
         port: Int = 8080,

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -28,7 +28,8 @@ public struct NIOServerConfig: ServiceType {
         workerCount: Int = ProcessInfo.processInfo.activeProcessorCount,
         maxBodySize: Int = 1_000_000,
         reuseAddress: Bool = true,
-        tcpNoDelay: Bool = true
+        tcpNoDelay: Bool = true,
+        webSocketMaxFrameSize: Int = 1 << 14
     ) -> NIOServerConfig {
         return NIOServerConfig(
             hostname: hostname,
@@ -37,7 +38,8 @@ public struct NIOServerConfig: ServiceType {
             workerCount: workerCount,
             maxBodySize: maxBodySize,
             reuseAddress: reuseAddress,
-            tcpNoDelay: tcpNoDelay
+            tcpNoDelay: tcpNoDelay,
+            webSocketMaxFrameSize: webSocketMaxFrameSize
         )
     }
 
@@ -63,6 +65,9 @@ public struct NIOServerConfig: ServiceType {
     /// When `true`, OS will attempt to minimize TCP packet delay.
     public var tcpNoDelay: Bool
 
+    /// Number of webSocket maxFrameSize.
+    public var webSocketMaxFrameSize: Int
+
     /// Creates a new `NIOServerConfig`.
     public init(
         hostname: String,
@@ -71,7 +76,8 @@ public struct NIOServerConfig: ServiceType {
         workerCount: Int,
         maxBodySize: Int,
         reuseAddress: Bool,
-        tcpNoDelay: Bool
+        tcpNoDelay: Bool,
+        webSocketMaxFrameSize: Int
     ) {
         self.hostname = hostname
         self.port = port
@@ -80,5 +86,6 @@ public struct NIOServerConfig: ServiceType {
         self.maxBodySize = maxBodySize
         self.reuseAddress = reuseAddress
         self.tcpNoDelay = tcpNoDelay
+        self.webSocketMaxFrameSize = webSocketMaxFrameSize
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -729,7 +729,8 @@ private extension Application {
             workerCount: 1,
             maxBodySize: 128_000,
             reuseAddress: true,
-            tcpNoDelay: true
+            tcpNoDelay: true,
+            webSocketMaxFrameSize: 1 << 14
         )
         services.register(serverConfig)
         let app = try Application.asyncBoot(config: .default(), environment: .xcode, services: services).wait()


### PR DESCRIPTION
Hi

We send In-App Purchase receipt via WebSocket, the empty receipt size is 6KB, the big receipt size is 50KB, the default WebSocketServer MaxFrameSize is 16KB, so we want to configure it.

Please review it. thanks.