### PR TITLE
cleanup threads in tests

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -140,10 +140,12 @@ public final class Application: Container {
 
     /// Called when the app deinitializes.
     deinit {
-        eventLoopGroup.shutdownGracefully {
-            if let error = $0 {
-                ERROR("shutting down app event loop: \(error)")
-            }
+        do {
+            try eventLoopGroup.syncShutdownGracefully()
+            let threadPool = try make(BlockingIOThreadPool.self)
+            try threadPool.syncShutdownGracefully()
+        } catch {
+            ERROR("shutting down app event loop: \(error)")
         }
     }
 }


### PR DESCRIPTION
- Uses `syncShutdownGracefully` instead of async method to ensure call succeeds.
- `BlockingIOThreadPool` is now also shutdown on app deinit. 
- Fixes #1778

`thread list` now returns much fewer results, indicating the issue has been fixed. 

```
(lldb) thread list
Process 7276 stopped
* thread #1: tid = 0x23580, 0x00007fff718c2a1e libsystem_kernel.dylib`__psynch_cvwait + 10, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  thread #2: tid = 0x23591, 0x00007fff718c3292 libsystem_kernel.dylib`__workq_kernreturn + 10
  thread #3: tid = 0x23592, 0x00007fff718b9246 libsystem_kernel.dylib`semaphore_wait_trap + 10, queue = 'BlockingIOThreadPool thread #1'
  thread #4: tid = 0x23594, 0x00007fff718c2d8a libsystem_kernel.dylib`__semwait_signal + 10, queue = 'shared memory transport listener queue'
  thread #5: tid = 0x23596, 0x00007fff718c3292 libsystem_kernel.dylib`__workq_kernreturn + 10
  thread #6: tid = 0x23598, 0x00007fff718b9246 libsystem_kernel.dylib`semaphore_wait_trap + 10, queue = 'BlockingIOThreadPool thread #0'
  thread #7: tid = 0x235b6, 0x00007fff718c3bf2 libsystem_kernel.dylib`kevent + 10, name = 'NIO-ELT-#0'
  thread #8: tid = 0x235b7, 0x00007fff718c3bf2 libsystem_kernel.dylib`kevent + 10, name = 'NIO-ELT-#0'
  thread #9: tid = 0x235b8, 0x00007fff718c3292 libsystem_kernel.dylib`__workq_kernreturn + 10
```