### PR TITLE
Add Debuggable properties to Abort

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -32,10 +32,22 @@ public struct Abort: AbortError {
     public var sourceLocation: SourceLocation?
 
     /// See `Debuggable`
-    public var stackTrace: [String]
+    public var stackTrace: [String]?
+
+	/// See `Debuggable`
+	public var possibleCauses: [String]
     
     /// See `Debuggable`
     public var suggestedFixes: [String]
+
+	/// See `Debuggable`
+	public var documentationLinks: [String]
+
+	/// See `Debuggable`
+	public var stackOverflowQuestions: [String]
+
+	/// See `Debuggable`
+	public var gitHubIssues: [String]
 
     /// Create a new `Abort`, capturing current source location info.
     public init(
@@ -43,7 +55,11 @@ public struct Abort: AbortError {
         headers: HTTPHeaders = [:],
         reason: String? = nil,
         identifier: String? = nil,
+		possibleCauses: [String] = [],
         suggestedFixes: [String] = [],
+		documentationLinks: [String] = [],
+		stackOverflowQuestions: [String] = [],
+		gitHubIssues: [String] = [],
         file: String = #file,
         function: String = #function,
         line: UInt = #line,
@@ -53,7 +69,11 @@ public struct Abort: AbortError {
         self.headers = headers
         self.status = status
         self.reason = reason ?? status.reasonPhrase
+		self.possibleCauses = possibleCauses
         self.suggestedFixes = suggestedFixes
+		self.documentationLinks = documentationLinks
+		self.stackOverflowQuestions = stackOverflowQuestions
+		self.gitHubIssues = gitHubIssues
         self.sourceLocation = SourceLocation(file: file, function: function, line: line, column: column, range: nil)
         self.stackTrace = Abort.makeStackTrace()
     }

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -34,20 +34,20 @@ public struct Abort: AbortError {
     /// See `Debuggable`
     public var stackTrace: [String]?
 
-	/// See `Debuggable`
-	public var possibleCauses: [String]
-    
+    /// See `Debuggable`
+    public var possibleCauses: [String]
+
     /// See `Debuggable`
     public var suggestedFixes: [String]
 
-	/// See `Debuggable`
-	public var documentationLinks: [String]
+    /// See `Debuggable`
+    public var documentationLinks: [String]
 
-	/// See `Debuggable`
-	public var stackOverflowQuestions: [String]
+    /// See `Debuggable`
+    public var stackOverflowQuestions: [String]
 
-	/// See `Debuggable`
-	public var gitHubIssues: [String]
+    /// See `Debuggable`
+    public var gitHubIssues: [String]
 
     /// Create a new `Abort`, capturing current source location info.
     public init(
@@ -55,11 +55,11 @@ public struct Abort: AbortError {
         headers: HTTPHeaders = [:],
         reason: String? = nil,
         identifier: String? = nil,
-		possibleCauses: [String] = [],
+        possibleCauses: [String] = [],
         suggestedFixes: [String] = [],
-		documentationLinks: [String] = [],
-		stackOverflowQuestions: [String] = [],
-		gitHubIssues: [String] = [],
+        documentationLinks: [String] = [],
+        stackOverflowQuestions: [String] = [],
+        gitHubIssues: [String] = [],
         file: String = #file,
         function: String = #function,
         line: UInt = #line,
@@ -69,11 +69,11 @@ public struct Abort: AbortError {
         self.headers = headers
         self.status = status
         self.reason = reason ?? status.reasonPhrase
-		self.possibleCauses = possibleCauses
+        self.possibleCauses = possibleCauses
         self.suggestedFixes = suggestedFixes
-		self.documentationLinks = documentationLinks
-		self.stackOverflowQuestions = stackOverflowQuestions
-		self.gitHubIssues = gitHubIssues
+        self.documentationLinks = documentationLinks
+        self.stackOverflowQuestions = stackOverflowQuestions
+        self.gitHubIssues = gitHubIssues
         self.sourceLocation = SourceLocation(file: file, function: function, line: line, column: column, range: nil)
         self.stackTrace = Abort.makeStackTrace()
     }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

Fixes #1804 

Added the following properties to `Abort` so all inherited properties from `Debuggable` are accessible:
- possibleCauses
- suggestedFixes
- documentationLinks
- stackOverflowQuestions
- gitHubIssues

Also made `stackTrace` optional so it conforms to `Debuggable` as discussed in #1804 

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.