### PR TITLE
Add support for Ubuntu 18.0.4 (bionic) in apt utility script

### DIFF
--- a/Utilities/apt.sh
+++ b/Utilities/apt.sh
@@ -1,9 +1,9 @@
 function add_vapor_apt() {
     eval "$(cat /etc/lsb-release)"
 
-    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" ]];
+    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" && "$DISTRIB_CODENAME" != "bionic" ]];
     then
-        echo "Only Ubuntu 14.04, 16.04, and 16.10 are supported."
+        echo "Only Ubuntu 14.04, 16.04, 16.10 and 18.0.4 are supported."
         echo "You are running $DISTRIB_RELEASE ($DISTRIB_CODENAME) [`uname`]"
         return 1;
     fi


### PR DESCRIPTION
I believe Ubuntu 18.0.4 is now supported by Swift and Vapor. So this just updates the apt utility script to reflect that.

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
