### PR TITLE
Accept both %20 and + for url encoding space characters

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -661,7 +661,12 @@ class ApplicationTests: XCTestCase {
         let req = Request(using: app)
         req.http.url = URLComponents().url!
         try req.query.encode(TestQueryStringContainer(name: "Vapor Test"))
-        XCTAssertEqual(req.http.url.query, "name=Vapor%20Test")
+        // TODO: Change this test once URLEncodedForm is updated.
+        XCTAssertTrue(
+            req.http.url.query == "name=Vapor%20Test" ||
+            req.http.url.query == "name=Vapor+Test"
+        )
+        // XCTAssertEqual(req.http.url.query, "name=Vapor+Test")
     }
     
     func testErrorMiddlewareRespondsToNotFoundError() throws {


### PR DESCRIPTION
`+` is the correct way to encode a space character according to the reference (see vapor/url-encoded-form#19). However, we cannot change this test without updating URLEncodedForm first. But URLEncodedForm depends on Vapor for its tests, which means we need to change this test for URLEncodedForm's tests to pass. So this is an intermediate state.