### PR TITLE
add HTTP pipelining + compression support to NIOServer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/database-kit.git", from: "1.0.0"),
 
         // 🚀 Non-blocking, event-driven HTTP for Swift built on Swift NIO.
-        .package(url: "https://github.com/vapor/http.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/http.git", .branch("http-pipelining")),
 
         // 🏞 Parses and serializes multipart-encoded data with Codable support.
         .package(url: "https://github.com/vapor/multipart.git", from: "3.0.0"),

--- a/Sources/Vapor/Server/NIOServer.swift
+++ b/Sources/Vapor/Server/NIOServer.swift
@@ -96,6 +96,8 @@ public final class NIOServer: Server, ServiceType {
                 backlog: config.backlog,
                 reuseAddress: config.reuseAddress,
                 tcpNoDelay: config.tcpNoDelay,
+                supportCompression: config.supportCompression,
+                supportPipelining: config.supportPipelining,
                 upgraders: upgraders,
                 on: group
             ) { error in

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -22,6 +22,8 @@ public struct NIOServerConfig: ServiceType {
     ///     - reuseAddress: When `true`, can prevent errors re-binding to a socket after successive server restarts.
     ///     - tcpNoDelay: When `true`, OS will attempt to minimize TCP packet delay.
     ///     - webSocketMaxFrameSize: Number of webSocket maxFrameSize.
+    ///     - supportCompression: When `true`, HTTP server will support gzip and deflate compression.
+    ///     - supportPipelining: When `true`, HTTP server will support pipelined HTTP requests.
     public static func `default`(
         hostname: String = "localhost",
         port: Int = 8080,
@@ -30,7 +32,9 @@ public struct NIOServerConfig: ServiceType {
         maxBodySize: Int = 1_000_000,
         reuseAddress: Bool = true,
         tcpNoDelay: Bool = true,
-        webSocketMaxFrameSize: Int = 1 << 14
+        webSocketMaxFrameSize: Int = 1 << 14,
+        supportCompression: Bool = false,
+        supportPipelining: Bool = false
     ) -> NIOServerConfig {
         return NIOServerConfig(
             hostname: hostname,
@@ -40,7 +44,9 @@ public struct NIOServerConfig: ServiceType {
             maxBodySize: maxBodySize,
             reuseAddress: reuseAddress,
             tcpNoDelay: tcpNoDelay,
-            webSocketMaxFrameSize: webSocketMaxFrameSize
+            webSocketMaxFrameSize: webSocketMaxFrameSize,
+            supportCompression: supportCompression,
+            supportPipelining: supportPipelining
         )
     }
 
@@ -68,6 +74,12 @@ public struct NIOServerConfig: ServiceType {
 
     /// Number of webSocket maxFrameSize.
     public var webSocketMaxFrameSize: Int
+    
+    /// When `true`, HTTP server will support gzip and deflate compression.
+    public var supportCompression: Bool
+    
+    /// When `true`, HTTP server will support pipelined HTTP requests.
+    public var supportPipelining: Bool
 
     /// Creates a new `NIOServerConfig`.
     public init(
@@ -78,7 +90,9 @@ public struct NIOServerConfig: ServiceType {
         maxBodySize: Int,
         reuseAddress: Bool,
         tcpNoDelay: Bool,
-        webSocketMaxFrameSize: Int = 1 << 14
+        webSocketMaxFrameSize: Int = 1 << 14,
+        supportCompression: Bool = false,
+        supportPipelining: Bool = false
     ) {
         self.hostname = hostname
         self.port = port
@@ -88,5 +102,7 @@ public struct NIOServerConfig: ServiceType {
         self.reuseAddress = reuseAddress
         self.tcpNoDelay = tcpNoDelay
         self.webSocketMaxFrameSize = webSocketMaxFrameSize
+        self.supportCompression = supportCompression
+        self.supportPipelining = supportPipelining
     }
 }


### PR DESCRIPTION
- [x] adds `supportCompression` and `supportPipelining` options to `NIOServerConfig`.
- [x] Depends on https://github.com/vapor/http/pull/320.