### PR TITLE
Fix apt script

### DIFF
--- a/Utilities/apt.sh
+++ b/Utilities/apt.sh
@@ -1,7 +1,7 @@
 function add_vapor_apt() {
     eval "$(cat /etc/lsb-release)"
 
-    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" && "$DISTRIB_CODENAME" != "bionic" && "$DISTRIB_CODENAME" != "cosmic"" ]];
+    if [[ "$DISTRIB_CODENAME" != "xenial" && "$DISTRIB_CODENAME" != "yakkety" && "$DISTRIB_CODENAME" != "trusty" && "$DISTRIB_CODENAME" != "bionic" && "$DISTRIB_CODENAME" != "cosmic" ]];
     then
         echo "Only Ubuntu 14.04, 16.04, 16.10, 18.04 and 18.10 are supported."
         echo "You are running $DISTRIB_RELEASE ($DISTRIB_CODENAME) [`uname`]"


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

I'm currently seeing the following error when running the `Utilities/apt.sh` script:

```bash
bash: line 4: syntax error in conditional expression
bash: line 6: syntax error near `Ubuntu'
bash: line 6: `        echo "Only Ubuntu 14.04, 16.04, 16.10, 18.04 and 18.10 are supported."'
```

It looks to be caused by an extra trailing `"` in `"cosmic""` on line 4.

This PR just removes the extra `"`.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
