### PR TITLE
Return a failed future if hitting a route that has not been registered

### DIFF
--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -47,8 +47,7 @@ private struct RouterResponder: Responder {
     /// See `Responder`.
     func respond(to req: Request) throws -> Future<Response> {
         guard let responder = router.route(request: req) else {
-            let res = req.response(http: .init(status: .notFound, body: "Not found"))
-            return req.eventLoop.newSucceededFuture(result: res)
+            return req.eventLoop.newFailedFuture(error: Abort(.notFound))
         }
 
         return try responder.respond(to: req)

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -75,7 +75,7 @@ class ApplicationTests: XCTestCase {
         }
 
         try app.clientTest(.GET, "/hello/vapor", equals: "vapor")
-        try app.clientTest(.POST, "/hello/vapor", equals: "Not found")
+        try app.clientTest(.POST, "/hello/vapor", equals: "{\"error\":true,\"reason\":\"Not Found\"}")
         
         try app.clientTest(.GET, "/raw/vapor/development", equals: "[\"vapor\",\"development\"]")
     }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -21,7 +21,9 @@ class MiddlewareTests : XCTestCase {
         let app = try Application(services: services)
 
         let req = Request(using: app)
-        _ = try app.make(Responder.self).respond(to: req).wait()
+        do {
+            _ = try app.make(Responder.self).respond(to: req).wait()
+        } catch {}
         XCTAssert(myMiddleware.flag == true)
     }
 


### PR DESCRIPTION
Resolves #1839 so non-registered routes can be caught by error middleware etc

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
