### PR TITLE
Correctly match upgraded websocket routes

### DIFF
--- a/Sources/Vapor/WebSocket/NIOWebSocketServer.swift
+++ b/Sources/Vapor/WebSocket/NIOWebSocketServer.swift
@@ -65,7 +65,7 @@ public final class NIOWebSocketServer: WebSocketServer, Service {
     ///     - webSocket: The newly connected websocket client. Use this to send and receive messages from the client.
     ///     - request: The HTTP request that initiated the websocket protocol upgrade.
     public func webSocketOnUpgrade(_ webSocket: WebSocket, for request: Request) {
-        let path: [String] = request.http.urlString.split(separator: "/").map { String($0) }
+        let path: [String] = request.http.url.path.split(separator: "/").map { String($0) }
         do {
             guard let route = router.route(path: path, parameters: &request._parameters) else {
                 throw VaporError(identifier: "websocketOnUpgrade", reason: "Could not find route for upgraded WebSocket.")


### PR DESCRIPTION
This PR is similar to #1812 and fixes #1722, which should have been fixed by #1812. However, #1722 was not completely fixed by #1812.

A few lines below the changes in #1812 ( in`webSocketOnUpgrade` – #1812 only changed `webSocketShouldUpgrade`) the route is still matched on the `urlString` of the request instead of `url.path`.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.