### PR TITLE
shutdown on SIGTERM as well as SIGINT

### DIFF
--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -65,18 +65,17 @@ public final class ServeCommand: Command {
         self.console.output(":" + port.description, style: .init(color: .cyan))
         
         let signalQueue = DispatchQueue(label: "codes.vapor.server.shutdown")
-        let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: signalQueue)
-        signalSource.setEventHandler {
-            _ = self.runningServer?.close()
-            signalSource.cancel()
+        func makeSignalSource(_ code: Int32) {
+            let source = DispatchSource.makeSignalSource(signal: code, queue: signalQueue)
+            source.setEventHandler {
+                _ = self.runningServer?.close()
+                source.cancel()
+            }
+            source.resume()
+            signal(code, SIG_IGN)
         }
-        let signalSourceTERM = DispatchSource.makeSignalSource(signal: SIGTERM, queue: signalQueue)
-        signalSourceTERM.setEventHandler {
-            _ = self.runningServer?.close()
-            signalSourceTERM.cancel()
-        }
-        signal(SIGTERM, SIG_IGN)
-        signalSourceTERM.resume()
+        makeSignalSource(SIGTERM)
+        makeSignalSource(SIGINT)
         
         // start the actual HTTPServer
         let server = HTTPServer(config: self.config, on: self.application.eventLoopGroup)

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -70,8 +70,13 @@ public final class ServeCommand: Command {
             _ = self.runningServer?.close()
             signalSource.cancel()
         }
-        signal(SIGINT, SIG_IGN)
-        signalSource.resume()
+        let signalSourceTERM = DispatchSource.makeSignalSource(signal: SIGTERM, queue: signalQueue)
+        signalSourceTERM.setEventHandler {
+            _ = self.runningServer?.close()
+            signalSourceTERM.cancel()
+        }
+        signal(SIGTERM, SIG_IGN)
+        signalSourceTERM.resume()
         
         // start the actual HTTPServer
         let server = HTTPServer(config: self.config, on: self.application.eventLoopGroup)


### PR DESCRIPTION
This adds a signal handler for SIGTERM to "politely" shutdown the server when the process receives that signal. This is a partial (and likely incomplete) addition to https://github.com/vapor/vapor/issues/1889

This is my first contribution to Vapor, and I'm not what I'd call deeply conversant with Swift, so feedback or changes desired are very welcome. I didn't see any existing tests that would exercise the signal handling code to amend into this PR.

I wasn't comfortable enough with all the changes recommended in #1889 to set up a more extensive PR for that issue.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.