### PR TITLE
add additional route metadata

### DIFF
--- a/Sources/Boilerplate/app.swift
+++ b/Sources/Boilerplate/app.swift
@@ -1,9 +1,11 @@
 import Vapor
 
-public func app(_ env: Environment) -> Application {
-    return Application(env: env) {
+public func app(_ env: Environment) throws -> Application {
+    let app = Application(env: env) {
         var s = Services.default()
         try configure(&s)
         return s
     }
+    try boot(app)
+    return app
 }

--- a/Sources/Boilerplate/boot.swift
+++ b/Sources/Boilerplate/boot.swift
@@ -1,13 +1,24 @@
 import Vapor
 
-public func boot(_ app: Application) {
-//    // your code here
-//    try app.client().webSocket("ws://echo.websocket.org").flatMap { ws -> Future<Void> in
-//        ws.send("hi")
-//        ws.onText { ws, text in
-//            print("rec: \(text)")
-//            ws.close()
-//        }
-//        return ws.onClose
-//    }.wait()
+public func boot(_ app: Application) throws {
+    let test = try app.makeContainer().wait()
+    let routes = try test.make(Routes.self)
+    for route in routes.routes {
+        let path = route.path.map { $0.description }.joined(separator: "/")
+        print("[\(route.method)] /\(path) \(route.requestType) -> \(route.responseType)")
+        for (key, val) in route.userInfo {
+            print("  - \(key) = \(val)")
+        }
+    }
+}
+
+extension PathComponent: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .anything: return ":"
+        case .catchall: return "*"
+        case .constant(let string): return string
+        case .parameter(let string): return ":" + string
+        }
+    }
 }

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -16,7 +16,7 @@ public func routes(_ r: Routes, _ c: Container) throws {
 
     r.get("json") { (req: HTTPRequest, ctx: Context) -> [String: String] in
         return ["foo": "bar"]
-    }
+    }.description("returns some test json")
     
     r.webSocket("ws") { (req: HTTPRequest, ctx: Context, ws: WebSocket) -> () in
         ws.onText { ws, text in

--- a/Sources/Vapor/Routing/Routes.swift
+++ b/Sources/Vapor/Routing/Routes.swift
@@ -149,7 +149,13 @@ extension RoutesBuilder {
                 return try! closure(req, ctx)
             }.encodeResponse(for: req, using: ctx)
         }
-        let route = Route(method: method, path: path, responder: responder)
+        let route = Route(
+            method: method,
+            path: path,
+            responder: responder,
+            requestType: Request.self,
+            responseType: Response.self
+        )
         self.add(route)
         return route
     }
@@ -159,12 +165,31 @@ public final class Route {
     public var method: HTTPMethod
     public var path: [PathComponent]
     public var responder: Responder
+    public var requestType: Any.Type
+    public var responseType: Any.Type
+    
     public var userInfo: [AnyHashable: Any]
     
-    public init(method: HTTPMethod, path: [PathComponent], responder: Responder) {
+    public init(
+        method: HTTPMethod,
+        path: [PathComponent],
+        responder: Responder,
+        requestType: Any.Type,
+        responseType: Any.Type
+    ) {
         self.method = method
         self.path = path
         self.responder = responder
+        self.requestType = requestType
+        self.responseType = responseType
         self.userInfo = [:]
+    }
+}
+
+extension Route {
+    @discardableResult
+    public func description(_ string: String) -> Route {
+        self.userInfo["description"] = string
+        return self
     }
 }


### PR DESCRIPTION
- Adds `requestType` and `responseType` to `Route`.
- Adds `Route.description(...)` for setting `"description"` key on `Route`.
- Prints route info in `BoilerplateRun` for testing

Here's an example route using `description`.

```swift
r.get("json") { (req: HTTPRequest, ctx: Context) -> [String: String] in
    return ["foo": "bar"]
}.description("returns some test json")
```

Here's an example of the route info printed:

```
[GET] /ping HTTPRequest -> StaticString
[POST] /login Creds -> String
[GET] /json HTTPRequest -> Dictionary<String, String>
  - description = returns some test json
[GET] /ws HTTPRequest -> HTTPResponse
[GET] /sessions/get HTTPRequest -> String
[GET] /sessions/set/:string HTTPRequest -> String
[GET] /sessions/del HTTPRequest -> String
[GET] /client HTTPRequest -> EventLoopFuture<String>
[GET] /users HTTPRequest -> String
[GET] /users/:userID HTTPRequest -> String
```

- [ ] Add this additional info to `vapor run routes`
- [ ] Brainstorm any additional useful info