### PR TITLE
remove weak container in FoundationClient

### DIFF
--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -11,15 +11,7 @@ public final class FoundationClient: Client, ServiceType {
     }
 
     /// See `Client`.
-    public var container: Container {
-        guard let c = _container else {
-            fatalError("If you encounter this error, you are holding on to a client after de-initializing your Application. This is usually a bad idea.")
-        }
-        return c
-    }
-    
-    /// The actual container
-    private weak var _container: Container?
+    public var container: Container
 
     /// The `URLSession` powering this client.
     private let urlSession: URLSession
@@ -27,7 +19,7 @@ public final class FoundationClient: Client, ServiceType {
     /// Creates a new `FoundationClient`.
     public init(_ urlSession: URLSession, on container: Container) {
         self.urlSession = urlSession
-        self._container = container
+        self.container = container
     }
 
     /// Creates a `FoundationClient` with default settings.


### PR DESCRIPTION
There was a bug introduced in the latest release. Container in FoundationClient was made weak resulting in it being released and causing a crash when making network requests. This repo highlights the issue: https://github.com/ryanjohnstoneBBC/VaporCrashSample 

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.