### PR TITLE
revert #1878 and #1896

### DIFF
--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,4 +1,4 @@
-extension Application {
+extension Container {
     /// Creates a `Client` for this `Container`.
     ///
     ///     let res = try app.client().get("http://vapor.codes")
@@ -9,31 +9,6 @@ extension Application {
         return try make()
     }
 }
-
-extension Request {
-    /// Creates a `Client` for this `Container`.
-    ///
-    ///     let res = try req.client().get("http://vapor.codes")
-    ///     print(res) // Future<Response>
-    ///
-    /// See `Client` for more information.
-    public func client() throws -> Client {
-        return try self.sharedContainer.make()
-    }
-}
-
-extension Response {
-    /// Creates a `Client` for this `Container`.
-    ///
-    ///     let res = try req.client().get("http://vapor.codes")
-    ///     print(res) // Future<Response>
-    ///
-    /// See `Client` for more information.
-    public func client() throws -> Client {
-        return try self.sharedContainer.make()
-    }
-}
-
 
 /// Connects to remote HTTP servers and sends HTTP requests receiving HTTP responses.
 ///

--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -11,15 +11,7 @@ public final class FoundationClient: Client, ServiceType {
     }
 
     /// See `Client`.
-    public var container: Container {
-        guard let c = _container else {
-            fatalError("If you encounter this error, you are holding on to a client after its container has de-initialized.")
-        }
-        return c
-    }
-    
-    /// The actual container
-    private weak var _container: Container?
+    public let container: Container
 
     /// The `URLSession` powering this client.
     private let urlSession: URLSession
@@ -27,7 +19,7 @@ public final class FoundationClient: Client, ServiceType {
     /// Creates a new `FoundationClient`.
     public init(_ urlSession: URLSession, on container: Container) {
         self.urlSession = urlSession
-        self._container = container
+        self.container = container
     }
 
     /// Creates a `FoundationClient` with default settings.


### PR DESCRIPTION
The changes in #1896 may not completely fix #1894. If any providers wrap a `Client`, creating that client wrapper on a request (`req.make(MyClient.self)`) will result in the same issue. 

Because of this, we need to fully revert #1896. We'll have to look into another way to fix the leaks there. 