### PR TITLE
add DotEnvFile type for loading .env (dotenv) files

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -99,20 +99,6 @@ public final class Application {
 
     // MARK: Run
 
-    /// Asynchronously runs the `Application`'s commands. This method will call the `willRun(_:)` methods of all
-    /// registered `VaporProvider's` before running.
-    ///
-    /// Normally this command will boot an `HTTPServer`. However, depending on configuration and command-line arguments/flags, this method may run a different command.
-    /// See `CommandConfig` for more information about customizing the commands that this method runs.
-    ///
-    ///     try app.run().wait()
-    ///
-    /// Note: When running a server, `asyncRun()` will return when the server has finished _booting_. Use the `runningServer` property on `Application` to wait
-    /// for the server to close. The synchronous `run()` method will call this automatically.
-    ///
-    ///     try app.runningServer?.onClose().wait()
-    ///
-    /// All `VaporProvider`'s `didRun(_:)` methods will be called before finishing.
     public func run() -> EventLoopFuture<Void> {
         let eventLoop = self.eventLoopGroup.next()
         return self.loadDotEnv(on: eventLoop).flatMap {
@@ -154,7 +140,6 @@ public final class Application {
         try self.eventLoopGroup.syncShutdownGracefully()
         try self.threadPool.syncShutdownGracefully()
         self.didShutdown = true
-
     }
     
     deinit {

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -114,8 +114,9 @@ public final class Application {
     ///
     /// All `VaporProvider`'s `didRun(_:)` methods will be called before finishing.
     public func run() -> EventLoopFuture<Void> {
+        let eventLoop = self.eventLoopGroup.next()
         return self.loadDotEnv(on: eventLoop).flatMap {
-            return self.makeContainer()
+            return self.makeContainer(on: eventLoop)
         }.flatMapThrowing { c -> (Console, CommandGroup, Container) in
             let command = try c.make(Commands.self).group()
             let console = try c.make(Console.self)

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -122,14 +122,14 @@ public final class CORSMiddleware: Middleware {
         
         // Determine if the request is pre-flight.
         // If it is, create empty response otherwise get response from the responder chain.
-        let res = req.http.isPreflight
+        let res = req.isPreflight
             ? ctx.eventLoop.makeSucceededFuture(.init())
             : next.respond(to: req, using: ctx)
         
         return res.map { res in
             var res = res
             // Modify response headers based on CORS settings
-            res.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: self.configuration.allowedOrigin.header(forRequest: req.http))
+            res.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: self.configuration.allowedOrigin.header(forRequest: req))
             res.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: self.configuration.allowedHeaders)
             res.headers.replaceOrAdd(name: .accessControlAllowMethods, value: self.configuration.allowedMethods)
             

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -4,7 +4,7 @@ import Glibc
 import Darwin
 #endif
 
-/// Reads `.env` (dotenv) files and loads them into the current process.
+/// Reads dotenv (`.env`) files and loads them into the current process.
 ///
 ///     let fileio: NonBlockingFileIO
 ///     let elg: EventLoopGroup

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -1,0 +1,159 @@
+public struct DotEnv {
+    public struct Line: CustomStringConvertible {
+        public let key: String
+        public let value: String
+        
+        public var description: String {
+            return "\(self.key)=\(self.value)"
+        }
+    }
+    
+    struct Parser {
+        var source: ByteBuffer
+        init(source: ByteBuffer) {
+            self.source = source
+        }
+        
+        mutating func parse() -> [Line] {
+            var lines: [Line] = []
+            while let next = self.parseNext() {
+                lines.append(next)
+            }
+            return lines
+        }
+        
+        private mutating func parseNext() -> Line? {
+            self.skipSpaces()
+            guard let peek = self.peek() else {
+                return nil
+            }
+            switch peek {
+            case .octothorpe:
+                // comment following, skip it
+                self.skipComment()
+                // then parse next
+                return self.parseNext()
+            case .newLine:
+                // empty line, skip
+                self.pop() // \n
+                // then parse next
+                return self.parseNext()
+            default:
+                // this is a valid line, parse it
+                return self.parseLine()
+            }
+        }
+        
+        private mutating func skipComment() {
+            guard let commentLength = self.countDistance(to: .newLine) else {
+                return
+            }
+            self.source.moveReaderIndex(forwardBy: commentLength + 1) // include newline
+        }
+        
+        private mutating func parseLine() -> Line? {
+            guard let keyLength = self.countDistance(to: .equal) else {
+                return nil
+            }
+            guard let key = self.source.readString(length: keyLength) else {
+                return nil
+            }
+            self.pop() // =
+            guard let value = self.parseLineValue() else {
+                return nil
+            }
+            self.pop() // \n
+            return Line(key: key, value: value)
+        }
+        
+        private mutating func parseLineValue() -> String? {
+            guard let valueLength = self.countDistance(to: .newLine) else {
+                return nil
+            }
+            guard let value = self.source.readString(length: valueLength) else {
+                return nil
+            }
+            guard let first = value.first, let last = value.last else {
+                return value
+            }
+            switch (first, last) {
+            case ("\"", "\""):
+                return value.dropFirst().dropLast()
+                    .replacingOccurrences(of: "\\n", with: "\n")
+            case ("'", "'"):
+                return value.dropFirst().dropLast() + ""
+            default: return value
+            }
+        }
+        
+        private mutating func skipSpaces() {
+            scan: while let next = self.peek() {
+                switch next {
+                case .space: self.pop()
+                default: break scan
+                }
+            }
+        }
+        
+        private func peek() -> UInt8? {
+            return self.source.getInteger(at: self.source.readerIndex)
+        }
+        
+        private mutating func pop() {
+            self.source.moveReaderIndex(forwardBy: 1)
+        }
+        
+        private func countDistance(to byte: UInt8) -> Int? {
+            var copy = self.source
+            scan: while let next = copy.readInteger(as: UInt8.self) {
+                if next == byte {
+                    break scan
+                }
+            }
+            let distance = copy.readerIndex - source.readerIndex
+            guard distance != 0 else {
+                return nil
+            }
+            return distance - 1
+        }
+    }
+    
+    public let file: NonBlockingFileIO
+    public let eventLoop: EventLoop
+    public init(file: NonBlockingFileIO, on eventLoop: EventLoop) {
+        self.file = file
+        self.eventLoop = eventLoop
+    }
+    
+    public func load(path: String) -> EventLoopFuture<[Line]> {
+        return self.file.openFile(path: path, eventLoop: self.eventLoop).flatMap { arg -> EventLoopFuture<ByteBuffer> in
+            return self.file.read(fileRegion: arg.1, allocator: .init(), eventLoop: self.eventLoop)
+                .flatMapThrowing
+                { buffer in
+                    try arg.0.close()
+                    return buffer
+            }
+            }.map { buffer in
+                var parser = Parser(source: buffer)
+                return parser.parse()
+        }
+    }
+}
+
+private extension UInt8 {
+    static var newLine: UInt8 {
+        return 0xA
+    }
+    
+    static var space: UInt8 {
+        return 0x20
+    }
+    
+    static var octothorpe: UInt8 {
+        return 0x23
+    }
+    
+    static var equal: UInt8 {
+        return 0x3D
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -745,8 +745,39 @@ class ApplicationTests: XCTestCase {
 //        })
 //    }
     
+    func testDotEnvLoad() throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let pool = BlockingIOThreadPool(numberOfThreads: 1)
+        pool.start()
+        let file = NonBlockingFileIO(threadPool: pool)
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/test.env"
+        let lines = try DotEnv(file: file, on: elg.next()).load(path: path).wait()
+        let test = lines.map { $0.description }.joined(separator: "\n")
+        XCTAssertEqual(test, """
+        NODE_ENV=development
+        BASIC=basic
+        AFTER_LINE=after_line
+        UNDEFINED_EXPAND=$TOTALLY_UNDEFINED_ENV_KEY
+        EMPTY=
+        SINGLE_QUOTES=single_quotes
+        DOUBLE_QUOTES=double_quotes
+        EXPAND_NEWLINES=expand\nnewlines
+        DONT_EXPAND_NEWLINES_1=dontexpand\\nnewlines
+        DONT_EXPAND_NEWLINES_2=dontexpand\\nnewlines
+        EQUAL_SIGNS=equals==
+        RETAIN_INNER_QUOTES={"foo": "bar"}
+        RETAIN_INNER_QUOTES_AS_STRING={"foo": "bar"}
+        INCLUDE_SPACE=some spaced out string
+        USERNAME=therealnerdybeast@example.tld
+        """)
+        try pool.syncShutdownGracefully()
+        try elg.syncShutdownGracefully()
+    }
+    
+    
     static let allTests = [
-        ("testStub", testStub)
+        ("testDotEnvLoad", testDotEnvLoad)
     ]
 //
 //    static let allTests = [

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -745,15 +745,15 @@ class ApplicationTests: XCTestCase {
 //        })
 //    }
     
-    func testDotEnvLoad() throws {
+    func testDotEnvRead() throws {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let pool = BlockingIOThreadPool(numberOfThreads: 1)
         pool.start()
-        let file = NonBlockingFileIO(threadPool: pool)
+        let fileio = NonBlockingFileIO(threadPool: pool)
         let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/test.env"
-        let lines = try DotEnv(file: file, on: elg.next()).load(path: path).wait()
-        let test = lines.map { $0.description }.joined(separator: "\n")
+        let file = try DotEnvFile.read(path: path, fileio: fileio, on: elg.next()).wait()
+        let test = file.lines.map { $0.description }.joined(separator: "\n")
         XCTAssertEqual(test, """
         NODE_ENV=development
         BASIC=basic
@@ -777,7 +777,7 @@ class ApplicationTests: XCTestCase {
     
     
     static let allTests = [
-        ("testDotEnvLoad", testDotEnvLoad)
+        ("testDotEnvRead", testDotEnvRead)
     ]
 //
 //    static let allTests = [

--- a/Tests/VaporTests/Utilities/test.env
+++ b/Tests/VaporTests/Utilities/test.env
@@ -1,0 +1,18 @@
+NODE_ENV=development
+BASIC=basic
+
+# previous line intentionally left blank
+AFTER_LINE=after_line
+UNDEFINED_EXPAND=$TOTALLY_UNDEFINED_ENV_KEY
+EMPTY=
+SINGLE_QUOTES='single_quotes'
+DOUBLE_QUOTES="double_quotes"
+EXPAND_NEWLINES="expand\nnewlines"
+DONT_EXPAND_NEWLINES_1=dontexpand\nnewlines
+DONT_EXPAND_NEWLINES_2='dontexpand\nnewlines'
+# COMMENTS=work
+EQUAL_SIGNS=equals==
+RETAIN_INNER_QUOTES={"foo": "bar"}
+RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+INCLUDE_SPACE=some spaced out string
+USERNAME="therealnerdybeast@example.tld"

--- a/Tests/VaporTests/Utilities/test.env
+++ b/Tests/VaporTests/Utilities/test.env
@@ -1,3 +1,4 @@
+# Source: https://github.com/motdotla/dotenv/blob/master/tests/.env
 NODE_ENV=development
 BASIC=basic
 


### PR DESCRIPTION
- Adds a new `DotEnvFile` type that can read and load `.env` (dotenv) files.
- Adds logic to load `.env` file from current working directory on app boot.
- `DotEnvFile.Parser` uses `ByteBuffer` with minimal string operations. 
- Fixes #1885. 

### Data structure

```swift
public struct DotEnvFile {
    public struct Line {
        public let key: String
        public let value: String
    }

    public let lines: [Line]
}
```

### Usage

```swift
let fileio: NonBlockingFileIO
let elg: EventLoopGroup
let file = try DotEnvFile.read(path: ".env", fileio: fileio, on: elg.next()).wait()
for line in file.lines {
    print("\(line.key)=\(line.value)")
}
file.load(overwrite: true) // loads all lines into the process
```

### Edge-case support

Here is the test file used ([source](https://github.com/motdotla/dotenv/blob/master/tests/.env)):

```env
NODE_ENV=development
BASIC=basic

# previous line intentionally left blank
AFTER_LINE=after_line
UNDEFINED_EXPAND=$TOTALLY_UNDEFINED_ENV_KEY
EMPTY=
SINGLE_QUOTES='single_quotes'
DOUBLE_QUOTES="double_quotes"
EXPAND_NEWLINES="expand\nnewlines"
DONT_EXPAND_NEWLINES_1=dontexpand\nnewlines
DONT_EXPAND_NEWLINES_2='dontexpand\nnewlines'
# COMMENTS=work
EQUAL_SIGNS=equals==
RETAIN_INNER_QUOTES={"foo": "bar"}
RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
INCLUDE_SPACE=some spaced out string
USERNAME="therealnerdybeast@example.tld"
```

### Todo

- [ ] Backport to Vapor 3
- [x] Add doc blocks