### PR TITLE
switching contributor_test to match circleCI docker image 

### DIFF
--- a/Utilities/contributor_test.sh
+++ b/Utilities/contributor_test.sh
@@ -9,7 +9,7 @@ echo "💧  Exporting docker-machine env"
 eval "$(docker-machine env default)"
 
 echo "💧  Running unit tests on Linux"
-docker run -it -v $PWD:/root/code -w /root/code norionomura/swift:swift-4.1-branch /usr/bin/swift test
+docker run -it -v $PWD:/root/code -w /root/code vapor/swift:5.0 /usr/bin/swift test
 LINUX_EXIT=$?
 
 if [[ $MACOS_EXIT == 0 ]];


### PR DESCRIPTION
switching contributor_test to match circleCI docker image for linux contributor tests

I didn't realize this script was here earlier, but once I noticed it after my last PR, I made a small update to it to match the check against swift 5 that CircleCI is configured to use (docker image `vapor/swift:5.0`)

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.