### PR TITLE
server shutdown

### DIFF
--- a/Sources/BoilerplateRun/main.swift
+++ b/Sources/BoilerplateRun/main.swift
@@ -1,5 +1,3 @@
 import Boilerplate
 
-try Boilerplate.app(.detect())
-    .run().wait()
-    .cleanup()
+try app(.detect()).execute().wait()

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -22,3 +22,10 @@ extension HTTPResponse {
         get { return self }
     }
 }
+
+extension Application {
+    @available(*, deprecated, renamed: "running")
+    public var runningServer: Running? {
+        return self.running
+    }
+}

--- a/Sources/Vapor/Server/ServerDelegate.swift
+++ b/Sources/Vapor/Server/ServerDelegate.swift
@@ -1,10 +1,12 @@
-struct ServerDelegate: HTTPServerDelegate {
+final class ServerDelegate: HTTPServerDelegate {
     private let responderCache: ThreadSpecificVariable<ThreadResponder>
     let application: Application
+    var containers: [Container]
     
     init(application: Application) {
         self.application = application
         self.responderCache = .init()
+        self.containers = []
     }
     
     func respond(to req: HTTPRequest, on channel: Channel) -> EventLoopFuture<HTTPResponse> {
@@ -13,6 +15,7 @@ struct ServerDelegate: HTTPServerDelegate {
             return responder.respond(to: req, using: ctx)
         } else {
             return self.application.makeContainer(on: channel.eventLoop).flatMapThrowing { container -> Responder in
+                self.containers.append(container)
                 let responder = try container.make(Responder.self)
                 self.responderCache.currentValue = ThreadResponder(responder: responder)
                 return responder
@@ -20,7 +23,6 @@ struct ServerDelegate: HTTPServerDelegate {
                 return responder.respond(to: req, using: ctx)
             }
         }
-        
     }
 }
 

--- a/Sources/Vapor/Services/VaporProvider.swift
+++ b/Sources/Vapor/Services/VaporProvider.swift
@@ -1,16 +1,16 @@
-/// A normal service `Provider` extended with additional life-cycle hooks for Vapor-specific containers.
-public protocol VaporProvider: ServiceProvider {
-    /// Called before the application runs commands.
-    func willRun(_ worker: Container) throws -> EventLoopFuture<Void>
-
-    /// Called after the application has finished running.
-    /// - note: This may never happen if the server runs infinitely.
-    func didRun(_ worker: Container) throws -> EventLoopFuture<Void>
-}
-
-extension Array where Element == ServiceProvider {
-    /// Returns only the `VaporProvider` service providers.
-    internal var onlyVapor: [VaporProvider] {
-        return compactMap { $0 as? VaporProvider }
-    }
-}
+///// A normal service `Provider` extended with additional life-cycle hooks for Vapor-specific containers.
+//public protocol VaporProvider: ServiceProvider {
+//    /// Called before the application runs commands.
+//    func willRun(_ worker: Container) throws -> EventLoopFuture<Void>
+//
+//    /// Called after the application has finished running.
+//    /// - note: This may never happen if the server runs infinitely.
+//    func didRun(_ worker: Container) throws -> EventLoopFuture<Void>
+//}
+//
+//extension Array where Element == ServiceProvider {
+//    /// Returns only the `VaporProvider` service providers.
+//    internal var onlyVapor: [VaporProvider] {
+//        return compactMap { $0 as? VaporProvider }
+//    }
+//}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -2,7 +2,14 @@ import Vapor
 import XCTest
 
 class ApplicationTests: XCTestCase {
-    func testStub() { }
+    func testApplicationStop() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(env: test) { .default() }
+        app.eventLoopGroup.next().scheduleTask(in: .seconds(1)) {
+            app.running?.stop()
+        }
+        try app.execute().wait()
+    }
 //    func testContent() throws {
 //        let app = try Application()
 //        let req = Request(using: app)
@@ -746,7 +753,7 @@ class ApplicationTests: XCTestCase {
 //    }
     
     static let allTests = [
-        ("testStub", testStub)
+        ("testApplicationStop", testApplicationStop),
     ]
 //
 //    static let allTests = [


### PR DESCRIPTION
Another step toward #1889, this PR adds support for shutting down the HTTP server gracefully. 

- New `Application.execute()` method for easily running + shutting down an application.
- New `Application.running?.stop()` method for stopping any indefinite running tasks, like an HTTP server. 
- `Container.willShutdown()` is now called on all created containers created by HTTPServer, giving them a chance to cleanup resources. 
- `Application` now creates `Application.Worker` as its container. (Name could be improved). This makes it easier to test that everything is cleaned up properly.