### PR TITLE
update FoundationClient

### DIFF
--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -49,8 +49,9 @@ public func routes(_ r: Routes, _ c: Container) throws {
         return "done"
     }
 
+    let client = try c.make(Client.self)
     r.get("client") { (req: HTTPRequest, ctx: Context) in
-        return try ctx.client().get("http://httpbin.org/status/201").map { $0.description }
+        return client.get("http://httpbin.org/status/201").map { $0.description }
     }
     
     let users = r.grouped("users")

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,26 +1,8 @@
-extension Context {
-    /// Creates a `Client` for this `Container`.
-    ///
-    ///     let res = try req.client().get("http://vapor.codes")
-    ///     print(res) // Future<Response>
-    ///
-    /// See `Client` for more information.
-    public func client() throws -> Client {
-        return NetClient()
-    }
-}
-
-public struct NetClient: Client {
-    init() { }
-    
-    public func send(_ req: HTTPRequest) -> EventLoopFuture<HTTPResponse> {
-        fatalError()
-    }
-}
-
 public protocol Client {
     func send(_ req: HTTPRequest) -> EventLoopFuture<HTTPResponse>
 }
+
+extension HTTPClient: Client { }
 
 extension Client {
     /// Sends an HTTP `GET` `Request` to a server with an optional configuration closure that will run before sending.

--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -1,70 +1,62 @@
-//import Foundation
-//
-///// `Client` wrapper around `Foundation.URLSession`.
-//#warning("TODO: add functionality via extension to URLSession")
-//public final class FoundationClient {
-//    /// See `Client`.
-//    public var eventLoop: EventLoop
-//
-//    /// The `URLSession` powering this client.
-//    private let urlSession: URLSession
-//
-//    /// Creates a new `FoundationClient`.
-//    public init(_ urlSession: URLSession, eventLoop: EventLoop) {
-//        self.urlSession = urlSession
-//        self.eventLoop = eventLoop
-//    }
-//
-//    /// See `Client`.
-//    public func send(_ req: HTTPRequest) -> EventLoopFuture<HTTPResponse> {
-//        let urlReq = req.convertToFoundationRequest()
-//        let promise = self.eventLoop.makePromise(of: HTTPResponse.self)
-//        self.urlSession.dataTask(with: urlReq) { data, urlResponse, error in
-//            if let error = error {
-//                promise.fail(error: error)
-//                return
-//            }
-//
-//            guard let httpResponse = urlResponse as? HTTPURLResponse else {
-//                let error = VaporError(identifier: "httpURLResponse", reason: "URLResponse was not a HTTPURLResponse.")
-//                promise.fail(error: error)
-//                return
-//            }
-//
-//            let response = HTTPResponse.convertFromFoundationResponse(httpResponse, data: data)
-//            promise.succeed(result: response)
-//        }.resume()
-//        return promise.futureResult
-//    }
-//}
-//
-//// MARK: Private
-//
-//private extension HTTPRequest {
-//    /// Converts an `HTTP.HTTPRequest` to `Foundation.URLRequest`
-//    func convertToFoundationRequest() -> URLRequest {
-//        let http = self
-//        let body = http.body.data ?? Data()
-//        var request = URLRequest(url: http.url)
-//        request.httpMethod = "\(http.method)"
-//        request.httpBody = body
-//        http.headers.forEach { key, val in
-//            request.addValue(val, forHTTPHeaderField: key.description)
-//        }
-//        return request
-//    }
-//}
-//
-//private extension HTTPResponse {
-//    /// Creates an `HTTP.HTTPResponse` to `Foundation.URLResponse`
-//    static func convertFromFoundationResponse(_ httpResponse: HTTPURLResponse, data: Data?) -> HTTPResponse {
-//        var res = HTTPResponse(status: .init(statusCode: httpResponse.statusCode))
-//        if let data = data {
-//            res.body = HTTPBody(data: data)
-//        }
-//        for (key, value) in httpResponse.allHeaderFields {
-//            res.headers.replaceOrAdd(name: "\(key)", value: "\(value)")
-//        }
-//        return res
-//    }
-//}
+/// `Client` wrapper around `Foundation.URLSession`.
+public final class FoundationClient {
+    /// See `Client`.
+    public var eventLoop: EventLoop
+
+    /// The `URLSession` powering this client.
+    private let urlSession: URLSession
+
+    /// Creates a new `FoundationClient`.
+    public init(_ urlSession: URLSession, on eventLoop: EventLoop) {
+        self.urlSession = urlSession
+        self.eventLoop = eventLoop
+    }
+
+    /// See `Client`.
+    public func send(_ req: HTTPRequest) -> EventLoopFuture<HTTPResponse> {
+        let promise = self.eventLoop.makePromise(of: HTTPResponse.self)
+        self.urlSession.dataTask(with: URLRequest(http: req)) { data, urlResponse, error in
+            if let error = error {
+                promise.fail(error)
+                return
+            }
+
+            guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
+                let error = VaporError(
+                    identifier: "httpURLResponse",
+                    reason: "URLResponse was not a HTTPURLResponse."
+                )
+                promise.fail(error)
+                return
+            }
+
+            let res = HTTPResponse(foundation: httpURLResponse, data: data)
+            promise.succeed(res)
+        }.resume()
+        return promise.futureResult
+    }
+}
+
+extension URLRequest {
+    public init(http: HTTPRequest) {
+        let body = http.body.data ?? Data()
+        self.init(url: http.url)
+        self.httpMethod = "\(http.method)"
+        self.httpBody = body
+        http.headers.forEach { key, val in
+            self.addValue(val, forHTTPHeaderField: key.description)
+        }
+    }
+}
+
+extension HTTPResponse {
+    public init(foundation: HTTPURLResponse, data: Data? = nil) {
+        self.init(status: .init(statusCode: foundation.statusCode))
+        if let data = data {
+            self.body = HTTPBody(data: data)
+        }
+        for (key, value) in foundation.allHeaderFields {
+            self.headers.replaceOrAdd(name: "\(key)", value: "\(value)")
+        }
+    }
+}

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -14,6 +14,11 @@ extension HTTPRequest {
     public var http: HTTPRequest {
         get { return self }
     }
+    
+    @available(*, unavailable, message: "Use container to make client: c.make(Client.self)")
+    public func client() -> Client {
+        fatalError()
+    }
 }
 
 extension HTTPResponse {

--- a/Sources/Vapor/Environment.swift
+++ b/Sources/Vapor/Environment.swift
@@ -34,5 +34,3 @@ extension Environment {
         return env
     }
 }
-
-#warning("TODO: consider removing isRelease from environment, only rely on swift build mode")

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -8,13 +8,25 @@ extension Services {
         s.register(HTTPServerConfig.self) { c in
             return HTTPServerConfig()
         }
-
+        
         // client
-        s.register(NetClient.self) { c in
+        s.register(URLSessionConfiguration.self) { c in
+            return .default
+        }
+        s.register(URLSession.self) { c in
+            return try .init(configuration: c.make())
+        }
+        s.register(FoundationClient.self) { c in
+            return try .init(c.make(), on: c.eventLoop)
+        }
+        s.register(HTTPClientConfig.self) { c in
             return .init()
         }
+        s.register(HTTPClient.self) { c in
+            return try .init(config: c.make(), on: c.eventLoop)
+        }
         s.register(Client.self) { c in
-            return try c.make(NetClient.self)
+            return try c.make(HTTPClient.self)
         }
         
         s.register(HTTPServerDelegate.self) { c in


### PR DESCRIPTION
- Updates `FoundationClient` for Vapor 4.
- Publicizes `URLRequest.init(http:)`
- Publicizes `HTTPResponse.init(foundation:)`
