### PR TITLE
add XCTVapor module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
             // "URLEncodedForm",
             // "Validation",
         ]),
-        .testTarget(name: "VaporTests", dependencies: ["Vapor"]),
+        .target(name: "XCTVapor", dependencies: ["Vapor"]),
+        .testTarget(name: "VaporTests", dependencies: ["XCTVapor"]),
     ]
 )

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -48,6 +48,10 @@ public final class Application {
         self.threadPool.start()
     }
     
+    public func _makeServices() throws -> Services {
+        return try self.configure()
+    }
+    
     public func makeContainer() -> EventLoopFuture<Container> {
         return self.makeContainer(on: self.eventLoopGroup.next())
     }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -198,7 +198,7 @@ public struct FileIO {
                 throw VaporError(identifier: "fileSize", reason: "Could not determine file size of: \(file).")
             }
 
-            let fd = try FileHandle(path: file)
+            let fd = try NIOFileHandle(path: file)
             let done = io.readChunked(fileHandle: fd, byteCount: fileSize.intValue, chunkSize: chunkSize, allocator: allocator, eventLoop: eventLoop) { chunk in
                 return onRead(chunk)
             }

--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,0 +1,3 @@
+@_exported import XCTest
+@_exported import Vapor
+

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -14,7 +14,7 @@ public final class XCTApplication {
     }
     
     @discardableResult
-    public func assert(
+    public func test(
         _ method: HTTPMethod,
         to string: String,
         file: StaticString = #file,
@@ -24,7 +24,7 @@ public final class XCTApplication {
         let res = try self.c.make(Responder.self).respond(
             to: .init(method: .GET, urlString: string),
             using: .init(channel: EmbeddedChannel())
-            ).wait()
+        ).wait()
         try closure(.init(response: res))
         return self
     }

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -7,10 +7,24 @@ extension Application {
 
 public final class XCTApplication {
     public let app: Application
-    private var c: Container
+    private var serviceOverrides: [(inout Services) -> ()]
+    
+    private var _container: Container?
     public init(app: Application) {
         self.app = app
-        self.c = try! app.makeContainer().wait()
+        self.serviceOverrides = []
+    }
+    
+    @discardableResult
+    public func override<T>(service: T.Type, with value: T) -> XCTApplication {
+        return self.override(service: T.self) { _ in value }
+    }
+    
+    public func override<T>(service: T.Type, with factory: @escaping (Container) throws -> T) -> XCTApplication {
+        self.serviceOverrides.append({ services in
+            services.register(T.self, factory)
+        })
+        return self
     }
     
     @discardableResult
@@ -19,9 +33,9 @@ public final class XCTApplication {
         to string: String,
         file: StaticString = #file,
         line: UInt = #line,
-        closure: (XCTHTTPResponse) throws -> ()
+        closure: (XCTHTTPResponse) throws -> () = { _ in }
     ) throws -> XCTApplication {
-        let res = try self.c.make(Responder.self).respond(
+        let res = try self.container().make(Responder.self).respond(
             to: .init(method: method, urlString: string),
             using: .init(channel: EmbeddedChannel())
         ).wait()
@@ -29,7 +43,25 @@ public final class XCTApplication {
         return self
     }
     
+    private func container() throws -> Container {
+        if let existing = self._container {
+            return existing
+        } else {
+            var services = try self.app._makeServices()
+            for override in self.serviceOverrides {
+                override(&services)
+            }
+            let new = try Container.boot(
+                env: app.env,
+                services: services,
+                on: app.eventLoopGroup.next()
+                ).wait()
+            self._container = new
+            return new
+        }
+    }
+    
     deinit {
-        try! self.c.shutdown().wait()
+        try! self._container?.shutdown().wait()
     }
 }

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -22,7 +22,7 @@ public final class XCTApplication {
         closure: (XCTHTTPResponse) throws -> ()
     ) throws -> XCTApplication {
         let res = try self.c.make(Responder.self).respond(
-            to: .init(method: .GET, urlString: string),
+            to: .init(method: method, urlString: string),
             using: .init(channel: EmbeddedChannel())
         ).wait()
         try closure(.init(response: res))

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -1,0 +1,35 @@
+extension Application {
+    public func xctest() -> XCTApplication {
+        return .init(app: self)
+    }
+}
+
+
+public final class XCTApplication {
+    public let app: Application
+    private var c: Container
+    public init(app: Application) {
+        self.app = app
+        self.c = try! app.makeContainer().wait()
+    }
+    
+    @discardableResult
+    public func assert(
+        _ method: HTTPMethod,
+        to string: String,
+        file: StaticString = #file,
+        line: UInt = #line,
+        closure: (XCTHTTPResponse) throws -> ()
+    ) throws -> XCTApplication {
+        let res = try self.c.make(Responder.self).respond(
+            to: .init(method: .GET, urlString: string),
+            using: .init(channel: EmbeddedChannel())
+            ).wait()
+        try closure(.init(response: res))
+        return self
+    }
+    
+    deinit {
+        try! self.c.shutdown().wait()
+    }
+}

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -1,0 +1,38 @@
+public final class XCTHTTPResponse {
+    public let response: HTTPResponse
+    public init(response: HTTPResponse) {
+        self.response = response
+    }
+    
+    @discardableResult
+    public func assertStatus(is status: HTTPStatus, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
+        XCTAssertEqual(self.response.status, status, file: file, line: line)
+        return self
+    }
+    
+    @discardableResult
+    public func assertBody(contains string: String, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
+        let bodyString = self.response.body.description
+        if !bodyString.contains(string) {
+            XCTFail("body contains check: (\(string.debugDescription)) does not appear in (\(bodyString.debugDescription))", file: file, line: line)
+        }
+        return self
+    }
+    
+    @discardableResult
+    public func assertBody(isEmpty: Bool, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
+        if isEmpty != self.response.body.isEmpty {
+            XCTFail("body empty check: body.isEmpty = \(self.response.body.isEmpty)", file: file, line: line)
+        }
+        return self
+    }
+}
+
+extension HTTPBody {
+    var isEmpty: Bool {
+        switch self.count {
+        case .none: return true
+        case .some(let count): return count == 0
+        }
+    }
+}

--- a/Sources/XCTVapor/XCTVaporTests.swift
+++ b/Sources/XCTVapor/XCTVaporTests.swift
@@ -1,0 +1,17 @@
+public var app: (() throws -> Application) = {
+    fatalError("implement static app generator")
+}
+
+open class XCTVaporTests: XCTestCase {
+    open var app: Application!
+    
+    open override func setUp() {
+        super.setUp()
+        self.app = try! XCTVapor.app()
+    }
+    
+    open override func tearDown() {
+        super.tearDown()
+        try! self.app.shutdown()
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1,7 +1,7 @@
 import XCTVapor
 
 extension Application {
-    static func build(
+    static func create(
         configure: @escaping (inout Services) throws -> () = { _ in },
         routes: @escaping (inout Routes, Container) throws -> () = { _, _ in }
     ) -> Application {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -36,15 +36,15 @@ class ApplicationTests: XCTestCase {
         })
             
         try app.xctest()
-            .assert(.GET, to: "/client") { res in
+            .test(.GET, to: "/client") { res in
                 res.assertStatus(is: .ok)
                     .assertBody(contains: "Vapor (Server-side Swift)")
             }
-            .assert(.GET, to: "/foo") { res in
+            .test(.GET, to: "/foo") { res in
                 res.assertStatus(is: .notFound)
                     .assertBody(contains: "Not Found")
         }
-        
+
         try app.shutdown()
     }
 //    func testContent() throws {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -28,7 +28,7 @@ class ApplicationTests: XCTestCase {
     
     
     func testClientRoute() throws {
-        let app = Application.build(routes: { r, c in
+        let app = Application.create(routes: { r, c in
             let client = try c.make(Client.self)
             r.get("client") { req, _ in
                 return client.get("http://vapor.codes")


### PR DESCRIPTION
Adds a new `XCTVapor` testing module. This module revolves around an `XCTApplication` class that wraps a Vapor `Application` and provides utilities for testing.

```swift
import App
import XCTVapor

XCTVapor.app = { try App.app(.testing) }

class MyApplicationTests: XCTVaporTests {
    func testExample() throws {
        print(self.app) // Application
        try self.app.xctest()
            .test(.GET, to: "/") { res in
                res.assertStatus(is: .ok)
                    .assertBody(contains: "It works")
            }
            .test(.GET, to: "/hello") { res in
                res.assertStatus(is: .ok)
                    .assertBody(contains: "Hello, world")
            }
            .test(.GET, to: "/foo") { res in
                res.assertStatus(is: .notFound)
                    .assertBody(contains: "Not Found")
        }
    }
}
```

There are just some basic assertions here at the moment, as a proof of concept. 

Some additional ideas that I would like to implement:

-  Live option, where tests will be made against a running server instead of in-memory responder

```swift
try self.app.xctest(live: true)
    .test(.GET, to: "/") { ... }
```

