### PR TITLE
Add missing supportCompression parameter to NIOServerConfig object

### DIFF
--- a/Sources/Vapor/Server/NIOServer.swift
+++ b/Sources/Vapor/Server/NIOServer.swift
@@ -97,6 +97,7 @@ public final class NIOServer: Server, ServiceType {
                 backlog: config.backlog,
                 reuseAddress: config.reuseAddress,
                 tcpNoDelay: config.tcpNoDelay,
+                supportCompression: config.supportCompression,
                 upgraders: upgraders,
                 on: group
             ) { error in

--- a/Sources/Vapor/Server/NIOServerConfig.swift
+++ b/Sources/Vapor/Server/NIOServerConfig.swift
@@ -30,6 +30,7 @@ public struct NIOServerConfig: ServiceType {
         maxBodySize: Int = 1_000_000,
         reuseAddress: Bool = true,
         tcpNoDelay: Bool = true,
+        supportCompression: Bool = false,
         webSocketMaxFrameSize: Int = 1 << 14
     ) -> NIOServerConfig {
         return NIOServerConfig(
@@ -40,6 +41,7 @@ public struct NIOServerConfig: ServiceType {
             maxBodySize: maxBodySize,
             reuseAddress: reuseAddress,
             tcpNoDelay: tcpNoDelay,
+            supportCompression: supportCompression,
             webSocketMaxFrameSize: webSocketMaxFrameSize
         )
     }
@@ -65,6 +67,9 @@ public struct NIOServerConfig: ServiceType {
 
     /// When `true`, OS will attempt to minimize TCP packet delay.
     public var tcpNoDelay: Bool
+    
+    /// When `true`, HTTP server will support gzip and deflate compression.
+    public var supportCompression: Bool
 
     /// Number of webSocket maxFrameSize.
     public var webSocketMaxFrameSize: Int
@@ -78,6 +83,7 @@ public struct NIOServerConfig: ServiceType {
         maxBodySize: Int,
         reuseAddress: Bool,
         tcpNoDelay: Bool,
+        supportCompression: Bool,
         webSocketMaxFrameSize: Int = 1 << 14
     ) {
         self.hostname = hostname
@@ -87,6 +93,7 @@ public struct NIOServerConfig: ServiceType {
         self.maxBodySize = maxBodySize
         self.reuseAddress = reuseAddress
         self.tcpNoDelay = tcpNoDelay
+        self.supportCompression = supportCompression
         self.webSocketMaxFrameSize = webSocketMaxFrameSize
     }
 }


### PR DESCRIPTION
Closes #1907

Added missing supportCompression parameter to NIOServerConfig. Can be set in `init`, `default` or directly on object (is `var`).

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
