### PR TITLE
configurable body streaming

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         // .package(url: "https://github.com/vapor/crypto.git", from: "3.0.0"),
 
         // 🚀 Non-blocking, event-driven HTTP for Swift built on Swift NIO.
-        .package(url: "https://github.com/vapor/http.git", .branch("master")),
+        .package(url: "https://github.com/vapor/http.git", .branch("streaming-body")),
 
         // 🏞 Parses and serializes multipart-encoded data with Codable support.
         // .package(url: "https://github.com/vapor/multipart.git", from: "3.0.0"),

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -27,7 +27,7 @@ public func routes(_ r: Routes, _ c: Container) throws {
         ws.send(text: "Hello 👋 \(ip)")
     }
     
-    r.on(.POST, at: "file", streaming: true) { (req: HTTPRequest, ctx: Context) -> EventLoopFuture<String> in
+    r.on(.POST, to: "file", bodyStream: .allow) { (req: HTTPRequest, ctx: Context) -> EventLoopFuture<String> in
         guard let stream = req.body.stream else {
             return ctx.eventLoop.makeFailedFuture(Abort(.badRequest, reason: "Expected streaming body."))
         }

--- a/Sources/Boilerplate/routes.swift
+++ b/Sources/Boilerplate/routes.swift
@@ -26,6 +26,24 @@ public func routes(_ r: Routes, _ c: Container) throws {
         let ip = ctx.channel.remoteAddress?.description ?? "<no ip>"
         ws.send(text: "Hello 👋 \(ip)")
     }
+    
+    r.on(.POST, at: "file", streaming: true) { (req: HTTPRequest, ctx: Context) -> EventLoopFuture<String> in
+        guard let stream = req.body.stream else {
+            return ctx.eventLoop.makeFailedFuture(Abort(.badRequest, reason: "Expected streaming body."))
+        }
+        let promise = ctx.eventLoop.makePromise(of: String.self)
+        stream.read { result, stream in
+            switch result {
+            case .chunk(let chunk):
+                debugPrint(chunk)
+            case .error(let error):
+                promise.fail(error)
+            case .end:
+                promise.succeed("Done")
+            }
+        }
+        return promise.futureResult
+    }
 
 //    r.get("hello", String.parameter) { req in
 //        return try req.parameters.next(String.self)


### PR DESCRIPTION
This PR adds a new `bodyStream` option to the `Routes.on` method. This option allows you to opt out of HTTP body stream collection so that you can choose how to handle incoming body chunks.

- Relies on https://github.com/vapor/http/pull/333. 

### Example

```swift
r.on(.POST, at: "file", bodyStream: .allow) { (req: HTTPRequest, ctx: Context) -> EventLoopFuture<String> in
    guard let stream = req.body.stream else {
        return ctx.eventLoop.makeFailedFuture(Abort(.badRequest, reason: "Expected streaming body."))
    }
    let promise = ctx.eventLoop.makePromise(of: String.self)
    stream.read { result, stream in
        switch result {
        case .chunk(let chunk):
            debugPrint(chunk)
        case .error(let error):
            promise.fail(error)
        case .end:
            promise.succeed("Done")
        }
    }
    return promise.futureResult
}
```