### PR TITLE
Immediately decoding a Future<Response>

### DIFF
--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -93,7 +93,7 @@ public final class Response: ContainerAlias, HTTPMessageContainer, ResponseCodab
 
 extension Future where T: Response {
     /// Convenience function for immediatly decoding `Future<Response>` objects.
-    func decode<U: Decodable>(_ type: U.Type) -> Future<U> {
+    public func decode<U: Decodable>(_ type: U.Type) -> Future<U> {
         return self.flatMap(to: type) { response in
             return try response.content.decode(type)
         }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -90,3 +90,11 @@ public final class Response: ContainerAlias, HTTPMessageContainer, ResponseCodab
         return req.eventLoop.newSucceededFuture(result: self)
     }
 }
+
+extension Future where T: Response {
+    func decode<U: Decodable>(_ type: U.Type) -> Future<U> {
+        return self.flatMap(to: type) { response in
+            return try response.content.decode(type)
+        }
+    }
+}

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -92,6 +92,7 @@ public final class Response: ContainerAlias, HTTPMessageContainer, ResponseCodab
 }
 
 extension Future where T: Response {
+    /// Convenience function for immediatly decoding `Future<Response>` objects.
     func decode<U: Decodable>(_ type: U.Type) -> Future<U> {
         return self.flatMap(to: type) { response in
             return try response.content.decode(type)


### PR DESCRIPTION
As discussed in #1915, this is an extension to `Future<Response>` which flatmaps the response and decodes the content of that response and returns it as a Future.

This addition allows for writing cleaner code when sending requests from for example a `Client` object. Provided you only want to decode the response to that request. Since you no longer have to flatMap the response and then call flatMap on the `response.content.decode()` it saves writing a closure for another future.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.