### PR TITLE
Update Contrib Tests to 4.2

### DIFF
--- a/Utilities/contributor_test.sh
+++ b/Utilities/contributor_test.sh
@@ -9,7 +9,7 @@ echo "💧  Exporting docker-machine env"
 eval "$(docker-machine env default)"
 
 echo "💧  Running unit tests on Linux"
-docker run -it -v $PWD:/root/code -w /root/code norionomura/swift:swift-4.1-branch /usr/bin/swift test
+docker run -it -v $PWD:/root/code -w /root/code swift:4.2 /usr/bin/swift test
 LINUX_EXIT=$?
 
 if [[ $MACOS_EXIT == 0 ]];


### PR DESCRIPTION
Switches the contrib tests over to use Swift 4.2 from the official Swift docker image