### PR TITLE
Minor typo

### DIFF
--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -6,7 +6,7 @@
 /// - `RequestEncodable`
 /// - `RequestDecodable`
 ///
-/// If adding conformance in an extension, you must ensure the type already exists to `Codable`.
+/// If adding conformance in an extension, you must ensure the type already conforms to `Codable`.
 ///
 ///     struct Hello: Content {
 ///         let message = "Hello!"


### PR DESCRIPTION
Hey there! Just noticed this seemingly tiny typo. Wasn't sure if it _is_ indeed a mistake, but thought it wouldn't hurt to check :) 

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
