### PR TITLE
Fix: Identifier not used in Abort init

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -65,7 +65,7 @@ public struct Abort: AbortError {
         line: UInt = #line,
         column: UInt = #column
     ) {
-        self.identifier = status.code.description
+        self.identifier = identifier ?? status.code.description
         self.headers = headers
         self.status = status
         self.reason = reason ?? status.reasonPhrase


### PR DESCRIPTION
After spending some time wondering why my errors being thrown with a custom `AbortError` did not have the correct identifier, I found that the `Abort` initializer never uses the `identifier` parameter. 

This is a simple fix that lets the initializer use the identifier parameter, falling back to `status.code.description` if there is no id specified. 

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [X] There are no breaking changes to public API.
- [X] New test cases have been added where appropriate.
- [X] All new code has been commented with doc blocks `///`.