### PR TITLE
ApplicationDelegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Packages
 *.xcodeproj
 DerivedData/
 Package.resolved
+.swiftpm
+

--- a/Sources/Development/app.swift
+++ b/Sources/Development/app.swift
@@ -1,11 +1,20 @@
 import Vapor
 
-public func app(_ environment: Environment) throws -> Application {
-    let app = Application(environment: environment) {
-        var s = Services.default()
-        try configure(&s)
-        return s
+final class Development: ApplicationDelegate {
+    init() { }
+    
+    func configure(_ s: inout Services) {
+        s.extend(Routes.self) { r, c in
+            try routes(r, c)
+        }
+
+        s.register(HTTPServer.Configuration.self) { c in
+            switch c.environment {
+            case .tls:
+                return .init(hostname: "127.0.0.1", port: 8443, tlsConfiguration: tls)
+            default:
+                return .init(hostname: "127.0.0.1", port: 8080)
+            }
+        }
     }
-    try boot(app)
-    return app
 }

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,18 +1,6 @@
 import Vapor
 
 public func configure(_ s: inout Services) throws {
-    s.extend(Routes.self) { r, c in
-        try routes(r, c)
-    }
-    
-    s.register(HTTPServer.Configuration.self) { c in
-        switch c.environment {
-        case .tls:
-            return .init(hostname: "127.0.0.1", port: 8443, tlsConfiguration: tls)
-        default:
-            return .init(hostname: "127.0.0.1", port: 8080)
-        }
-    }
 }
 
 let tls = TLSConfiguration.forServer(

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,2 +1,7 @@
+import Vapor
+
 // normally this would be in a separate target
-try app(.detect()).run()
+try Application(
+    environment: .detect(),
+    delegate: Development()
+).run()


### PR DESCRIPTION
Enhances `Application` to take a conformer to `ApplicationDelegate` instead of a closure for configuring services. This will make it easier for us to add additional protocol requirements in the future as well as providing a more structured way to organize apps. 