### PR TITLE
fix websocket 404 crash

### DIFF
--- a/Sources/Vapor/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerHandler.swift
@@ -47,8 +47,8 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
             response.headers.add(name: .connection, value: request.isKeepAlive ? "keep-alive" : "close")
             let done = context.write(self.wrapOutboundOut(response))
             if !request.isKeepAlive {
-                _ = done.flatMap {
-                    return context.close()
+                done.whenComplete { _ in
+                    context.close(promise: nil)
                 }
             }
         }

--- a/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
@@ -17,15 +17,15 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
     
     private var upgradeState: UpgradeState
     let httpRequestDecoder: ByteToMessageHandler<HTTPRequestDecoder>
-    let otherHTTPHandlers: [RemovableChannelHandler]
+    let httpHandlers: [RemovableChannelHandler]
     
     init(
         httpRequestDecoder: ByteToMessageHandler<HTTPRequestDecoder>,
-        otherHTTPHandlers: [RemovableChannelHandler]
+        httpHandlers: [RemovableChannelHandler]
     ) {
         self.upgradeState = .ready
         self.httpRequestDecoder = httpRequestDecoder
-        self.otherHTTPHandlers = otherHTTPHandlers
+        self.httpHandlers = httpHandlers
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -34,11 +34,8 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
         // check if request is upgrade
         let connectionHeaders = Set(req.headers[canonicalForm: "connection"].map { $0.lowercased() })
         if connectionHeaders.contains("upgrade") {
-            // remove http decoder
             let buffer = UpgradeBufferHandler()
-            _ = context.channel.pipeline.addHandler(buffer, position: .after(self.httpRequestDecoder)).flatMap {
-                return context.channel.pipeline.removeHandler(self.httpRequestDecoder)
-            }
+            _ = context.channel.pipeline.addHandler(buffer, position: .before(self.httpRequestDecoder))
             self.upgradeState = .pending(req, buffer)
         }
         
@@ -80,7 +77,7 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
                         res.headers = headers
                         context.write(self.wrapOutboundOut(res), promise: promise)
                     }.flatMap {
-                        let handlers: [RemovableChannelHandler] = [self] + self.otherHTTPHandlers
+                        let handlers: [RemovableChannelHandler] = [self] + self.httpHandlers
                         return .andAllComplete(handlers.map { handler in
                             return context.pipeline.removeHandler(handler)
                         }, on: context.eventLoop)
@@ -93,9 +90,8 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
             } else {
                 // reset handlers
                 self.upgradeState = .ready
-                _ = context.channel.pipeline.addHandler(self.httpRequestDecoder, position: .after(buffer)).flatMap {
-                    return context.channel.pipeline.removeHandler(buffer)
-                }
+                context.channel.pipeline.removeHandler(buffer, promise: nil)
+                context.write(self.wrapOutboundOut(res), promise: promise)
             }
         case .ready, .upgraded:
             context.write(self.wrapOutboundOut(res), promise: promise)

--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -1,10 +1,14 @@
 import CURLParser
 
-public struct URI: ExpressibleByStringLiteral {
+public struct URI: ExpressibleByStringLiteral, CustomStringConvertible {
     public var string: String
 
     public init(string: String = "/") {
         self.string = string
+    }
+
+    public var description: String {
+        return self.string
     }
 
     public init(

--- a/Tests/VaporTests/XCTestManifests.swift
+++ b/Tests/VaporTests/XCTestManifests.swift
@@ -43,6 +43,7 @@ extension ApplicationTests {
         ("testVaporProvider", testVaporProvider),
         ("testVaporURI", testVaporURI),
         ("testViewResponse", testViewResponse),
+        ("testWebSocket404", testWebSocket404),
         ("testWebSocketClient", testWebSocketClient),
     ]
 }


### PR DESCRIPTION
Fixes an issue that caused HTTPServerUpgradeHandler to re-add an existing HTTP request decoder if WebSocket upgrade failed. Now, the HTTPServerUpgradeHandler only adds the buffer handler when an upgrade attempt is made. Only if the upgrade succeeds does the HTTP request decoder get removed. 

Additionally, new methods on `app.testable().live()` have been added to start/shutdown a running server manually.