### PR TITLE
singleton shutdown

### DIFF
--- a/Sources/Vapor/Services/Container.swift
+++ b/Sources/Vapor/Services/Container.swift
@@ -53,7 +53,7 @@ public final class Container {
         
         // check if cached
         if let cached = self.cache.get(service: S.self) {
-            return cached
+            return cached.service
         }
         
         // create service lookup identifier
@@ -65,7 +65,7 @@ public final class Container {
         }
         
         // create the service
-        var instance = try factory.serviceMake(for: self)
+        var instance = try factory.boot(self)
         
         // check for any extensions
         if let extensions = self.services.extensions[id] as? [ServiceExtension<S>], !extensions.isEmpty {
@@ -75,7 +75,8 @@ public final class Container {
         
         // cache if singleton
         if factory.isSingleton {
-            self.cache.set(service: instance)
+            let service = CachedService(service: instance, shutdown: factory.shutdown)
+            self.cache.set(service: service)
         }
         
         // return created and extended instance
@@ -94,7 +95,7 @@ public final class Container {
         for provider in self.providers {
             provider.willShutdown(self)
         }
-        self.cache.clear()
+        self.cache.shutdown()
         self.didShutdown = true
     }
     

--- a/Sources/Vapor/Services/ServiceFactory.swift
+++ b/Sources/Vapor/Services/ServiceFactory.swift
@@ -1,16 +1,15 @@
 struct ServiceFactory<T> {
-    /// Accepts a `Container`, returning an initialized service.
-    let closure: (Container) throws -> T
-    
     let isSingleton: Bool
+    let boot: (Container) throws -> T
+    let shutdown: (T) throws -> ()
     
-    init(isSingleton: Bool, _ closure: @escaping (Container) throws -> T) {
+    init(
+        isSingleton: Bool,
+        boot: @escaping (Container) throws -> T,
+        shutdown: @escaping (T) throws -> ()
+    ) {
         self.isSingleton = isSingleton
-        self.closure = closure
-    }
-    
-    /// See `ServiceFactory`.
-    func serviceMake(for worker: Container) throws -> T {
-        return try closure(worker)
+        self.boot = boot
+        self.shutdown = shutdown
     }
 }

--- a/Tests/VaporTests/XCTestManifests.swift
+++ b/Tests/VaporTests/XCTestManifests.swift
@@ -34,6 +34,7 @@ extension ApplicationTests {
         ("testResponseEncodableStatus", testResponseEncodableStatus),
         ("testRootGet", testRootGet),
         ("testSessionDestroy", testSessionDestroy),
+        ("testSingletonServiceShutdown", testSingletonServiceShutdown),
         ("testStreamFile", testStreamFile),
         ("testStreamFileConnectionClose", testStreamFileConnectionClose),
         ("testSwiftError", testSwiftError),


### PR DESCRIPTION
This PR allows for `singleton` services to register on optional `shutdown` closure that will be called to cleanup the service when the container is shutdown. 