### PR TITLE
ws handler fix

### DIFF
--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -395,18 +395,18 @@ private extension ChannelPipeline {
             dateCache: .eventLoop(self.eventLoop)
         )
         handlers.append(serverResEncoder)
-        
-        // add HTTP upgrade handler
-        let upgrader = HTTPServerUpgradeHandler(
-            httpRequestDecoder: httpReqDecoder,
-            httpHandlers: handlers
-        )
-
         // add server request -> response delegate
         let handler = HTTPServerHandler(
             responder: responder,
             errorHandler: configuration.errorHandler
         )
+
+        // add HTTP upgrade handler
+        let upgrader = HTTPServerUpgradeHandler(
+            httpRequestDecoder: httpReqDecoder,
+            httpHandlers: handlers + [handler]
+        )
+
         handlers.append(upgrader)
         handlers.append(handler)
         

--- a/Tests/VaporTests/XCTestManifests.swift
+++ b/Tests/VaporTests/XCTestManifests.swift
@@ -47,6 +47,7 @@ extension ApplicationTests {
         ("testViewResponse", testViewResponse),
         ("testWebSocket404", testWebSocket404),
         ("testWebSocketClient", testWebSocketClient),
+        ("testWebSocketServer", testWebSocketServer),
     ]
 }
 


### PR DESCRIPTION
Fixes https://github.com/vapor/vapor/issues/2009 

`HTTPServerHandler` was not getting added to `HTTPServerUpgradeHandler`'s list of handlers to remove on successful upgrade.

This put the channel pipeline in an invalid state, which NIO helpfully asserted. 