### PR TITLE
Provide a reason when route cannot be found.

### DIFF
--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -47,7 +47,7 @@ private struct RouterResponder: Responder {
     /// See `Responder`.
     func respond(to req: Request) throws -> Future<Response> {
         guard let responder = router.route(request: req) else {
-            return req.eventLoop.newFailedFuture(error: Abort(.notFound))
+            return req.eventLoop.newFailedFuture(error: Abort(.notFound, reason: "Route for resource '\(req.http.urlString)' not found."))
         }
 
         return try responder.respond(to: req)

--- a/Sources/Vapor/Response/ApplicationResponder.swift
+++ b/Sources/Vapor/Response/ApplicationResponder.swift
@@ -47,7 +47,7 @@ private struct RouterResponder: Responder {
     /// See `Responder`.
     func respond(to req: Request) throws -> Future<Response> {
         guard let responder = router.route(request: req) else {
-            return req.eventLoop.newFailedFuture(error: Abort(.notFound, reason: "Route for resource '\(req.http.urlString)' not found."))
+            return req.eventLoop.newFailedFuture(error: Abort(.notFound, reason: req.http.urlString))
         }
 
         return try responder.respond(to: req)

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -77,6 +77,18 @@ class ApplicationTests: XCTestCase {
         try app.clientTest(.GET, "/hello/vapor", equals: "vapor")
         try app.clientTest(.POST, "/hello/vapor") { res in
             XCTAssertEqual(res.http.status, .notFound)
+            
+            struct AbortWithReason: Decodable, Equatable {
+                let error: Bool
+                let reason: String
+            }
+                        
+            let abort = try res.content.syncDecode(AbortWithReason.self)
+            
+            let expected = AbortWithReason(error: true,
+                                           reason: "Route for resource '/hello/vapor' not found.")
+            
+            XCTAssertEqual(abort, expected)
         }
         
         try app.clientTest(.GET, "/raw/vapor/development", equals: "[\"vapor\",\"development\"]")

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -85,8 +85,7 @@ class ApplicationTests: XCTestCase {
                         
             let abort = try res.content.syncDecode(AbortWithReason.self)
             
-            let expected = AbortWithReason(error: true,
-                                           reason: "Route for resource '/hello/vapor' not found.")
+            let expected = AbortWithReason(error: true, reason: "/hello/vapor")
             
             XCTAssertEqual(abort, expected)
         }


### PR DESCRIPTION
Currently when the router cannot find an endpoint for a requested resource the reason in the response is "Not Found". This PR makes the reason more specific which allows the 404 to be easier do diagnose.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
