### PR TITLE
Use FoundationNetworking on Linux for Swift 5.1

### DIFF
--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -1,3 +1,7 @@
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 /// `Client` wrapper around `Foundation.URLSession`.
 public final class FoundationClient: Client, ServiceType {
     /// See `ServiceType`.


### PR DESCRIPTION
In Swift 5.1 on Linux, the network stuff is moved to `FoundationNetworking`. Since 5.1 is still pre-release, i think we should keep this as a PR for now, and when we get close to a 5.1 release, we can push this.

Since a lot of development on Linux happens through Sourcekit-LSP, which only supports Swift 5.1, this will also give a good example for Linux developers.

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
