### PR TITLE
Support HEAD without altering the request.

### DIFF
--- a/Sources/Vapor/HTTP/ApplicationResponder.swift
+++ b/Sources/Vapor/HTTP/ApplicationResponder.swift
@@ -57,8 +57,11 @@ internal struct RoutesResponder: Responder {
         let pathComponents = request.url.path
             .split(separator: "/")
             .map(String.init)
+        
+        let method = (request.method == .HEAD) ? .GET : request.method
+        
         return self.router.route(
-            path: [request.method.string] + pathComponents,
+            path: [method.string] + pathComponents,
             parameters: &request.parameters
         )
     }

--- a/Sources/Vapor/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerHandler.swift
@@ -15,13 +15,6 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let request = self.unwrapInboundIn(data)
         
-        // change HEAD -> GET
-        let originalMethod = request.method
-        switch request.method {
-        case .HEAD: request.method = .GET
-        default: break
-        }
-        
         // query delegate for response
         self.responder.respond(to: request).whenComplete { response in
             switch response {
@@ -30,7 +23,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
                 context.close(promise: nil)
             case .success(let response):
                 let contentLength = response.headers.firstValue(name: .contentLength)
-                if originalMethod == .HEAD {
+                if request.method == .HEAD {
                     response.body = .init()
                 }
                 response.headers.replaceOrAdd(name: .contentLength, value: contentLength ?? "0")

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -743,6 +743,7 @@ final class ApplicationTests: XCTestCase {
     func testHeadRequest() throws {
         let app = Application.create(routes: { r, c in
             r.get("hello") { req -> String in
+                XCTAssertEqual(req.method, .HEAD)
                 return "hi"
             }
         })


### PR DESCRIPTION
Currently HEAD is supported by altering the method in the request in the `HTTPSeverHandler`. This has an unfortunate consequence that in an endpoint closure it's impossible to tell whether a request was a GET or a HEAD.

I've pushed the merging of the HEAD flow into GET further towards the router where it's really necessary and I'm leaving the request intact.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
