### PR TITLE
AllowOriginSetting adjustments

### DIFF
--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -9,6 +9,7 @@ public final class CORSMiddleware: Middleware {
     /// - none: Disallows any origin.
     /// - originBased: Uses value of the origin header in the request.
     /// - all: Uses wildcard to allow any origin.
+    /// - whitelist: Uses a whitelist of allowable origins.
     /// - custom: Uses custom string provided as an associated value.
     public enum AllowOriginSetting {
         /// Disallow any origin.
@@ -19,6 +20,9 @@ public final class CORSMiddleware: Middleware {
 
         /// Uses wildcard to allow any origin.
         case all
+        
+        // Uses a whitelist of allowable origins.
+        case whitelist([String])
 
         /// Uses custom string provided as an associated value.
         case custom(String)
@@ -32,14 +36,17 @@ public final class CORSMiddleware: Middleware {
             case .none: return ""
             case .originBased: return req.headers[.origin].first ?? ""
             case .all: return "*"
-            case .custom(let string):
+            case .whitelist(let origins):
                 guard let origin = req.headers[.origin].first else {
-                    return string
+                    return ""
                 }
-                return string.contains(origin) ? origin : string
+                return origins.contains(origin) ? origin : ""
+            case .custom(let string):
+                return string
             }
         }
     }
+
 
     /// Configuration used for populating headers in response for CORS requests.
     public struct Configuration {


### PR DESCRIPTION
Makes security adjustments to AllowOriginSetting, adding a whitelist origin case and adjusting the custom origin case. 

1. Added a whitelist origin case is to encourage users to provide a list of allowable origins, to project against Arbitrary Reflected Origin attacks, instead of relying on originBased. Ex. `        allowedOrigin: .whitelist(["https://vapor.codes", "https://docs.vapor.codes"])`
2. Adjusted the custom origin case to return the specified allowed origin and not the value from the origin header. Previously  `allowedOrigin: .custom("https://vapor.codes")` would reflect back an access-control-allow-origin of `https://vapor.co`


Security Resources: 
* Tim "lanmaster53" Tomes and Kevin Cody: To CORS The cause of and solution to your SPA problems - [Video - DerbyCon 9](https://www.youtube.com/watch?v=tH-HG4b4GYQ&feature=youtu.be)
* James Kettle (PortSwigger): Exploiting CORS Misconfigurations for Bitcoins and Bounties - [Video - AppSecUSA 2016](https://www.youtube.com/watch?v=22CKQ_xed9s) [Blog](https://portswigger.net/blog/exploiting-cors-misconfigurations-for-bitcoins-and-bounties)
* Evan Johnson: Misconfigured CORS - [Video - AppSecUSA 2016](https://www.youtube.com/watch?v=qHhhg1CEJfY&feature=youtu.be) | [Blog](https://ejj.io/misconfigured-cors)

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.