### PR TITLE
Import FoundationNetworking when it’s available

### DIFF
--- a/Sources/Vapor/Client/FoundationClient.swift
+++ b/Sources/Vapor/Client/FoundationClient.swift
@@ -1,3 +1,9 @@
+#if swift(>=4.1)
+    #if canImport(FoundationNetworking)
+        import FoundationNetworking
+    #endif
+#endif
+
 /// `Client` wrapper around `Foundation.URLSession`.
 public final class FoundationClient: Client, ServiceType {
     /// See `ServiceType`.


### PR DESCRIPTION
I ran into a problem when compiling Vapor 3.3 using Swift 5.1 - it looks like we need to import FoundationNetworking now, so I've done just that (conditionally, when it's available).

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
