### PR TITLE
fix for percent encoding breaking array parsing

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -10,7 +10,10 @@ internal struct URLEncodedFormParser {
     }
 
     func parse(_ encoded: String) throws -> [String: URLEncodedFormData] {
-        let data = encoded.replacingOccurrences(of: "+", with: " ")
+        guard let data = encoded.replacingOccurrences(of: "+", with: " ").removingPercentEncoding else {
+            throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string value: \(encoded)")
+        }
+        
         var decoded: [String: URLEncodedFormData] = [:]
 
         for pair in data.split(separator: "&") {


### PR DESCRIPTION
I found that when POSTing using url-form-encoding from a form checkbox with a name of "productId[]", the parser was not decoding before checking if the suffix was "]". This meant that, it would not decode arrays from input.

### Checklist

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
