### PR TITLE
Make session cookie `HttpOnly` by default

### DIFF
--- a/Sources/Vapor/Sessions/SessionsConfig.swift
+++ b/Sources/Vapor/Sessions/SessionsConfig.swift
@@ -32,7 +32,7 @@ public struct SessionsConfig {
                 domain: nil,
                 path: "/",
                 isSecure: false,
-                isHTTPOnly: false,
+                isHTTPOnly: true,
                 sameSite: nil
             )
         }

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -147,6 +147,7 @@ final class AuthenticationTests: XCTestCase {
                 let cookie = cookies["vapor-session"]
             {
                 sessionCookie = cookie
+                XCTAssertTrue(cookie.isHTTPOnly)
             } else {
                 XCTFail("No set cookie header")
             }


### PR DESCRIPTION
It is [good practice](https://www.owasp.org/index.php/HttpOnly) to mark session cookies as `HttpOnly`. This PR set `httpOnly: true` for the default cookie factory for session cookies.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.