### PR TITLE
add onStop property to Application.Running

### DIFF
--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -59,8 +59,6 @@ public final class ServeCommand: Command {
         }
         makeSignalSource(SIGTERM)
         makeSignalSource(SIGINT)
-        
-        try self.server.onShutdown.wait()
     }
     
     deinit {

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -11,9 +11,11 @@ extension Services {
         s.register(Client.self) { c in
             return try c.make(HTTPClient.self)
         }
-        s.register(HTTPClient.self) { c in
+        s.singleton(HTTPClient.self, boot: { c in
             return try .init(eventLoopGroupProvider: .shared(c.eventLoop), configuration: c.make())
-        }
+        }, shutdown: { s in
+            try s.syncShutdown()
+        })
 
         // ws client
         s.register(WebSocketClient.Configuration.self) { c in

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -48,7 +48,7 @@ public final class XCTApplication {
             self.container = container
             self.port = port
             self.server = try container.make(Server.self)
-            try server.start(hostname: "localhost", port: port)
+            try server.start(hostname: nil, port: port)
         }
 
         public func shutdown() {


### PR DESCRIPTION
Adds an `onStop` property to `Application.Running`. This allows for users to explicitly wait for the application's currently running process to stop instead of having `Application.start()` block implicitly. 