### PR TITLE
add Services.global

### DIFF
--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -12,7 +12,19 @@ public func configure(_ s: inout Services) {
     s.register(HTTPServer.Configuration.self) { c in
         switch c.environment {
         case .tls:
-            return .init(hostname: "127.0.0.1", port: 8443, tlsConfiguration: tls)
+            return try .init(
+                hostname: "127.0.0.1",
+                port: 8443,
+                tlsConfiguration: .forServer(
+                    certificateChain: [
+                        .certificate(.init(
+                            file: "/Users/tanner0101/dev/vapor/net-kit/certs/cert.pem",
+                            format: .pem
+                        ))
+                    ],
+                    privateKey: .file("/Users/tanner0101/dev/vapor/net-kit/certs/key.pem")
+                )
+            )
         default:
             return .init(hostname: "127.0.0.1", port: 8080)
         }
@@ -40,16 +52,6 @@ final class MemoryCache {
         self.storage[key] = value
     }
 }
-
-let tls = try! TLSConfiguration.forServer(
-    certificateChain: [
-        .certificate(.init(
-            file: "/Users/tanner0101/dev/vapor/net-kit/certs/cert.pem",
-            format: .pem
-        ))
-    ],
-    privateKey: .file("/Users/tanner0101/dev/vapor/net-kit/certs/key.pem")
-)
 
 extension Environment {
     static var tls: Environment {

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,8 +1,12 @@
 import Vapor
 
-public func configure(_ s: inout Services) throws {
+public func configure(_ s: inout Services) {
     s.extend(Routes.self) { r, c in
         try routes(r, c)
+    }
+
+    s.global(MemoryCache.self) { _ in
+        return .init()
     }
     
     s.register(HTTPServer.Configuration.self) { c in
@@ -15,8 +19,35 @@ public func configure(_ s: inout Services) throws {
     }
 }
 
-let tls = TLSConfiguration.forServer(
-    certificateChain: [.file("/Users/tanner0101/dev/vapor/net-kit/certs/cert.pem")],
+final class MemoryCache {
+    var storage: [String: String]
+    var lock: Lock
+
+    init() {
+        self.storage = [:]
+        self.lock = .init()
+    }
+
+    func get(_ key: String) -> String? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage[key]
+    }
+
+    func set(_ key: String, to value: String?) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.storage[key] = value
+    }
+}
+
+let tls = try! TLSConfiguration.forServer(
+    certificateChain: [
+        .certificate(.init(
+            file: "/Users/tanner0101/dev/vapor/net-kit/certs/cert.pem",
+            format: .pem
+        ))
+    ],
     privateKey: .file("/Users/tanner0101/dev/vapor/net-kit/certs/key.pem")
 )
 

--- a/Sources/Vapor/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerHandler.swift
@@ -5,11 +5,9 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     typealias OutboundOut = Response
     
     let responder: Responder
-    let errorHandler: (Error) -> ()
     
-    init(responder: Responder, errorHandler: @escaping (Error) -> ()) {
+    init(responder: Responder) {
         self.responder = responder
-        self.errorHandler = errorHandler
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -19,8 +17,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
         self.responder.respond(to: request).whenComplete { response in
             switch response {
             case .failure(let error):
-                self.errorHandler(error)
-                context.close(promise: nil)
+                self.errorCaught(context: context, error: error)
             case .success(let response):
                 let contentLength = response.headers.firstValue(name: .contentLength)
                 if request.method == .HEAD {

--- a/Sources/Vapor/Services/ServiceFactory.swift
+++ b/Sources/Vapor/Services/ServiceFactory.swift
@@ -1,14 +1,20 @@
 struct ServiceFactory<T> {
-    let isSingleton: Bool
+    enum Cache {
+        case application
+        case container
+        case none
+    }
+    
+    let cache: Cache
     let boot: (Container) throws -> T
     let shutdown: (T) throws -> ()
     
     init(
-        isSingleton: Bool,
+        cache: Cache,
         boot: @escaping (Container) throws -> T,
         shutdown: @escaping (T) throws -> ()
     ) {
-        self.isSingleton = isSingleton
+        self.cache = cache
         self.boot = boot
         self.shutdown = shutdown
     }

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -133,7 +133,7 @@ extension Services {
             return try ConsoleLogger(console: container.make())
         }
         s.register(Logger.self) { c in
-            return try c.application.logger
+            return c.application.logger
         }
 
         // view

--- a/Sources/Vapor/Services/Services+Default.swift
+++ b/Sources/Vapor/Services/Services+Default.swift
@@ -54,18 +54,8 @@ extension Services {
         s.register(MemorySessions.self) { c in
             return try MemorySessions(storage: c.make(), on: c.eventLoop)
         }
-        s.register(MemorySessions.Storage.self) { c in
-            let app = try c.make(Application.self)
-            app.sync.lock()
-            defer { app.sync.unlock() }
-            let key = "memory-sessions-storage"
-            if let existing = app.userInfo[key] as? MemorySessions.Storage {
-                return existing
-            } else {
-                let new = MemorySessions.Storage()
-                app.userInfo[key] = new
-                return new
-            }
+        s.global(MemorySessions.Storage.self) { app in
+            return .init()
         }
         
         s.register(SessionsConfig.self) { c in
@@ -101,7 +91,7 @@ extension Services {
             return try c.make(HTTPServer.self)
         }
         s.register(HTTPServer.self) { c in
-            return try .init(application: c.make(), configuration: c.make())
+            return try .init(application: c.application, configuration: c.make())
         }
         s.register(Responder.self) { c in
             // initialize all `[Middleware]` from config
@@ -143,7 +133,7 @@ extension Services {
             return try ConsoleLogger(console: container.make())
         }
         s.register(Logger.self) { c in
-            return try c.make(Application.self).logger
+            return try c.application.logger
         }
 
         // view
@@ -160,7 +150,7 @@ extension Services {
 
         // file
         s.register(NonBlockingFileIO.self) { c in
-            return try .init(threadPool: c.make())
+            return .init(threadPool: c.application.threadPool)
         }
         s.register(FileIO.self) { c in
             return try .init(io: c.make(), allocator: c.make(), on: c.eventLoop)

--- a/Sources/Vapor/Utilities/Lock.swift
+++ b/Sources/Vapor/Utilities/Lock.swift
@@ -1,6 +1,6 @@
 public struct Lock {
     private let nslock: NSLock
-    init() {
+    public init() {
         self.nslock = .init()
     }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -5,8 +5,9 @@ final class ApplicationTests: XCTestCase {
     func testApplicationStop() throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
         let app = Application(environment: test)
-        try app.boot()
-        try app.start()
+        defer { app.shutdown() }
+        try! app.boot()
+        try! app.start()
         guard let running = app.running else {
             XCTFail("app started without setting 'running'")
             return
@@ -1216,11 +1217,11 @@ final class ApplicationTests: XCTestCase {
 extension Application {
     static func create(
         environment: Environment = .testing,
-        configure: @escaping (inout Services) throws -> () = { _ in },
+        configure: @escaping (inout Services) -> () = { _ in },
         routes: @escaping (inout Routes, Container) throws -> () = { _, _ in }
     ) -> Application {
         let app = Application(environment: environment) { s in
-            try configure(&s)
+            configure(&s)
             s.extend(Routes.self) { r, c in
                 try routes(&r, c)
             }

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ jobs:
       - run: swift build -c release
   bionic:
     docker:
-      - image: vapor/swift:5.1-bionic
+      - image: swift:5.1-bionic
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
@@ -26,18 +26,33 @@ jobs:
       - run: swift test
   bionic-release:
     docker:
-      - image: vapor/swift:5.1-bionic
+      - image: swift:5.1-bionic
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
       - run: swift build -c release
   bionic-thread:
     docker:
-      - image: vapor/swift:5.1-bionic
+      - image: swift:5.1-bionic
     steps:
       - checkout
       - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
       - run: swift test --sanitize=thread
+  xenial:
+    docker:
+      - image: swift:5.1-xenial
+    steps:
+      - checkout
+      - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
+      - run: swift build
+      - run: swift test
+  xenial-release:
+    docker:
+      - image: swift:5.1-xenial
+    steps:
+      - checkout
+      - run: apt-get update; apt-get install -y libssl-dev zlib1g-dev
+      - run: swift build -c release
 
 workflows:
   version: 2
@@ -48,3 +63,5 @@ workflows:
       - bionic
       - bionic-release
       - bionic-thread
+      - xenial
+      - xenial-release


### PR DESCRIPTION
Adds a new service registration option: `global`. This registration method allows for a singleton service to be shared between all containers on a given application. 

With this addition, we now have:

- `register`: This factory will be called each time the service is made.
- `singleton`:  This factory will be called only once per container. 
- `global`: This factory will be called only once per application. 

--- 

Example:

Assume a thread-safe service named `MemoryCache`:

```swift
final class MemoryCache {
    var storage: [String: String]
    var lock: Lock

    init() {
        self.storage = [:]
        self.lock = .init()
    }

    func get(_ key: String) -> String? {
        self.lock.lock()
        defer { self.lock.unlock() }
        return self.storage[key]
    }

    func set(_ key: String, to value: String?) {
        self.lock.lock()
        defer { self.lock.unlock() }
        self.storage[key] = value
    }
}
```

The service can be registered globally:

```swift
public func configure(_ s: inout Services) {
    ...
    s.global(MemoryCache.self) { _ in
        return .init()
    }
}
```

The same instance of `MemoryCache` is now shared across containers:

```swift
public func routes(_ r: Routes, _ c: Container) throws {
    ...
    let cache = try c.make(MemoryCache.self)
    r.get("cache", "get", ":key") { req -> String in
        guard let key = req.parameters.get("key") else {
            throw Abort(.internalServerError)
        }
        return "\(key) = \(cache.get(key) ?? "nil")"
    }
    r.get("cache", "set", ":key", ":value") { req -> String in
        guard let key = req.parameters.get("key") else {
            throw Abort(.internalServerError)
        }
        guard let value = req.parameters.get("value") else {
            throw Abort(.internalServerError)
        }
        cache.set(key, to: value)
        return "\(key) = \(value)"
    }
}
```

This results in the cached values being accessible from across event loops. 