### PR TITLE
make body collect max optional

### DIFF
--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -33,15 +33,6 @@ extension Request {
             }
         }
         
-        /// Consumes the body if it is a stream. Otherwise, returns the same value as the `data` property.
-        ///
-        ///     let data = try httpRes.body.consumeData(max: 1_000_000, on: ...).wait()
-        ///
-        /// - parameters:
-        ///     - max: The maximum streaming body size to allow.
-        ///            This only applies to streaming bodies, like chunked streams.
-        ///            Defaults to 1MB.
-        ///     - eventLoop: The event loop to perform this async work on.
         public func collect(max: Int? = nil) -> EventLoopFuture<ByteBuffer?> {
             switch self.request.bodyStorage {
             case .stream(let stream):

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -42,7 +42,7 @@ extension Request {
         ///            This only applies to streaming bodies, like chunked streams.
         ///            Defaults to 1MB.
         ///     - eventLoop: The event loop to perform this async work on.
-        public func collect(max: Int = 1_000_000) -> EventLoopFuture<ByteBuffer?> {
+        public func collect(max: Int? = nil) -> EventLoopFuture<ByteBuffer?> {
             switch self.request.bodyStorage {
             case .stream(let stream):
                 return stream.consume(max: max, on: self.request.eventLoop).map { buffer in

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -1,16 +1,8 @@
 extension Request {
     final class BodyStream: BodyStreamWriter {
-        /// Handles an incoming `HTTPChunkedStreamResult`.
         typealias Handler = (BodyStreamResult, EventLoopPromise<Void>?) -> ()
-        
-        /// If `true`, this `HTTPChunkedStream` has already sent an `end` chunk.
         private(set) var isClosed: Bool
-        
-        /// This stream's `HTTPChunkedHandler`, if one is set.
         private var handler: Handler?
-        
-        /// If a `handler` has not been set when `write(_:)` is called, this property
-        /// is used to store the waiting data.
         private var buffer: [(BodyStreamResult, EventLoopPromise<Void>?)]
 
         let eventLoop: EventLoop
@@ -20,16 +12,7 @@ extension Request {
             self.isClosed = false
             self.buffer = []
         }
-        
-        /// Sets a handler for reading `HTTPChunkedStreamResult`s from the stream.
-        ///
-        ///     chunkedStream.read { res, stream in
-        ///         print(res) // prints the chunk
-        ///         return .done(on: stream) // you can do async work or just return done
-        ///     }
-        ///
-        /// - parameters:
-        ///     - handler: `HTTPChunkedHandler` to use for receiving chunks from this stream.
+
         func read(_ handler: @escaping Handler) {
             self.handler = handler
             for (result, promise) in self.buffer {
@@ -37,17 +20,7 @@ extension Request {
             }
             self.buffer = []
         }
-        
-        /// Writes a `HTTPChunkedStreamResult` to the stream.
-        ///
-        ///     try chunkedStream.write(.end).wait()
-        ///
-        /// You must wait for the returned `Future` to complete before writing additional data.
-        ///
-        /// - parameters:
-        ///     - chunk: A `HTTPChunkedStreamResult` to write to the stream.
-        /// - returns: A `Future` that will be completed when the write was successful.
-        ///            You must wait for this future to complete before calling `write(_:)` again.
+
         func write(_ chunk: BodyStreamResult, promise: EventLoopPromise<Void>?) {
             if case .end = chunk {
                 self.isClosed = true
@@ -59,24 +32,14 @@ extension Request {
                 self.buffer.append((chunk, promise))
             }
         }
-        
-        /// Reads all `HTTPChunkedStreamResult`s from this stream until `end` is received.
-        /// The output is combined into a single `Data`.
-        ///
-        ///     let data = try stream.drain(max: ...).wait()
-        ///     print(data) // Data
-        ///
-        /// - parameters:
-        ///     - max: The maximum number of bytes to allow before throwing an error.
-        ///            Use this to prevent using excessive memory on your server.
-        /// - returns: `Future` containing the collected `Data`.
-        func consume(max: Int, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+
+        func consume(max: Int?, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
             let promise = eventLoop.makePromise(of: ByteBuffer.self)
             var data = ByteBufferAllocator().buffer(capacity: 0)
             self.read { chunk, next in
                 switch chunk {
                 case .buffer(var buffer):
-                    if data.readableBytes + buffer.readableBytes >= max {
+                    if let max = max, data.readableBytes + buffer.readableBytes >= max {
                         promise.fail(Abort(.payloadTooLarge))
                     } else {
                         data.writeBuffer(&buffer)

--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -1,9 +1,26 @@
+/// Determines how an incoming HTTP request's body is collected. 
 public enum HTTPBodyStreamStrategy {
+    /// The HTTP request's body will be collected into memory before the route handler is
+    /// called. The HTTP server's max body size will determine how much data can be
+    /// collected.
+    ///
+    /// See `collect(maxSize:)` to set a lower max body size.
     public static var collect: HTTPBodyStreamStrategy {
-        return .collect(maxSize: 2 << 14)
+        return .collect(maxSize: nil)
     }
+
+    /// The HTTP request's body will not be collected first before the route handler is called
+    /// and will arrive in zero or more chunks.
     case stream
-    case collect(maxSize: Int)
+
+    /// The HTTP request's body will be collected into memory before the route handler is
+    /// called.
+    ///
+    /// If a `maxSize` is supplied, the request body size in bytes will be limited. Requests
+    /// exceeding that size will result in an error. If no `maxSize` is supplied, the HTTP
+    /// server may still enforce a max body size limit. Note that the HTTP server's max body
+    /// size limit will take precedent over the value supplied here.
+    case collect(maxSize: Int?)
 }
 
 extension RoutesBuilder {

--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -76,7 +76,7 @@ public final class HTTPServer: Server {
             hostname: String = "127.0.0.1",
             port: Int = 8080,
             backlog: Int = 256,
-            maxBodySize: Int = 1_000_000,
+            maxBodySize: Int = 1 << 14,
             reuseAddress: Bool = true,
             tcpNoDelay: Bool = true,
             webSocketMaxFrameSize: Int = 1 << 14,


### PR DESCRIPTION
This change makes `HTTPBodyStreamStrategy.collect`'s max body size `nil` by default, allowing for routes to rely on the `HTTPServer.Configuration` max body size value. 

`HTTPServer.Configuration`'s max body size has also been decreased to `1 << 14`. 