### PR TITLE
Created XCTVapor library to export the XCTVapor target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),
+        .library(name: "XCTVapor", targets: ["XCTVapor"])
     ],
     dependencies: [
         // Sugary extensions for the SwiftNIO library


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

It turns out that there was no way to access the `XCTVapor` target outside of the project because it wasn't exported anywhere. To fix I created an `XCTVapor` library product that has the `XCTVapor` product as its target.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
