### PR TITLE
Add Request Decompression Support

### DIFF
--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -344,8 +344,11 @@ private extension ChannelPipeline {
         
         // add response compressor if configured
         if configuration.supportCompression {
-            let compressionHandler = HTTPResponseCompressor()
-            handlers.append(compressionHandler)
+            let requestDecompressionHandler = NIOHTTPRequestDecompressor(limit: .none)
+            let responseComressoionHandler = HTTPResponseCompressor()
+
+            handlers.append(responseComressoionHandler)
+            handlers.append(requestDecompressionHandler)
         }
         
         // add NIO -> HTTP request decoder


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

This adds the `NIOHTTPRequestDecompressor` channel handler to the `HTTPServer` channel pipeline. This automatically expands request bodies that have been compressed.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
