### PR TITLE
Improved Error Reporting in ErrorMiddleware

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -27,6 +27,18 @@ public struct Abort: AbortError {
 
     /// See `AbortError`
     public var reason: String
+
+    /// The file throwing this error
+    public var file: String
+    
+    /// The function throwing this error
+    public var function: String
+    
+    /// The line where the error is thrown
+    public var line: UInt
+    
+    /// The column where the errror is thrown
+    public var column: UInt
     
     public var description: String {
         return "Abort \(self.status.code): \(self.reason)"
@@ -48,5 +60,9 @@ public struct Abort: AbortError {
         self.headers = headers
         self.status = status
         self.reason = reason ?? status.reasonPhrase
+        self.file = file
+        self.function = function
+        self.line = line
+        self.column = column
     }
 }


### PR DESCRIPTION
`Abort` is receiving the `file`, `line`, `function` and `column` information of whatever is throwing the error, however it does not further use that information.

It becomes a problem when an error is being dealt with by `ErrorMiddleware` because the logger is receiving the same information, but not from the initial `Abort` but it defaults to the values from `ErrorMiddleware`. The current output is, when enabling `logLevel` as `debug` only pointing at `ErrorMiddleware` and not the original origin of the error.

In this PR the origin information is stored in `Abort` and `ErrorMiddleware` is forwarding those whenever an.`Abort` instance is found.

Thoughts for discussion: Should the origin information be part of the `AbortError` protocol? If so it will require all other types of this error to include the information as well. It might be worthwhile but is not included in this PR. I also haven't checked if this would require other packages to be updated as this PR itself is not effecting any public API.

