### PR TITLE
Expose readable path from TrieRouter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/multipart.git", from: "3.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing.git", from: "3.0.0"),
+        .package(url: "../routing-kit", from: "3.0.0"),
 
         // 📦 Dependency injection / inversion of control framework.
         .package(url: "https://github.com/vapor/service.git", from: "1.0.0"),

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -36,6 +36,10 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     ///
     public var http: HTTPRequest
     
+    /// The readable path for the request
+    ///
+    ///     print(req.readablePath) // "GET/users/:userId"
+    ///
     public var readablePath: String?
 
     // MARK: Services

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -35,6 +35,8 @@ public final class Request: ContainerAlias, DatabaseConnectable, HTTPMessageCont
     ///     print(req.http.url.path) // "/hello"
     ///
     public var http: HTTPRequest
+    
+    public var readablePath: String?
 
     // MARK: Services
 

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -39,7 +39,10 @@ public final class EngineRouter: Router {
         let path: [Substring] = request.http.urlString
             .split(separator: "?", maxSplits: 1)[0]
             .split(separator: "/")
-        return router.route(path: [request.http.method.substring] + path, parameters: &request._parameters)
+        let result: (Responder?, String?) = router.route(path: [request.http.method.substring] + path, parameters: &request._parameters)
+        let responder = result.0
+        request.readablePath = result.1
+        return responder
     }
 }
 

--- a/Sources/Vapor/Routing/EngineRouter.swift
+++ b/Sources/Vapor/Routing/EngineRouter.swift
@@ -39,7 +39,7 @@ public final class EngineRouter: Router {
         let path: [Substring] = request.http.urlString
             .split(separator: "?", maxSplits: 1)[0]
             .split(separator: "/")
-        let result: (Responder?, String?) = router.route(path: [request.http.method.substring] + path, parameters: &request._parameters)
+        let result = router.getOutputAndPath(for: [request.http.method.substring] + path, parameters: &request._parameters)
         let responder = result.0
         request.readablePath = result.1
         return responder


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

Depends on https://github.com/vapor/routing-kit/pull/80

For http://github.com/vapor-community/VaporMonitoring we would like to be able to get a hold of the [PathComponent].readable to group our metrics by. This PR picks up the changes from the routing-kit PR to expose this data as an extra (optional) property on the request.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
