### PR TITLE
add ErrorSource struct

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -40,6 +40,10 @@ public struct Abort: AbortError {
     /// The column where the errror is thrown
     public var column: UInt
     
+    public var source: ErrorSource? {
+        return .init(file: self.file, line: self.line, function: self.function)
+    }
+    
     public var description: String {
         return "Abort \(self.status.code): \(self.reason)"
     }

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -40,6 +40,8 @@ public struct Abort: AbortError {
     /// The column where the errror is thrown
     public var column: UInt
     
+    /// Wrap this error's source location into a usable struct for
+    /// the `AbortError` protocol.
     public var source: ErrorSource? {
         return .init(file: self.file, line: self.line, function: self.function)
     }

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -17,6 +17,20 @@ public protocol AbortError: LocalizedError, CustomStringConvertible {
 
     /// The human-readable (and hopefully understandable) reason for this error.
     var reason: String { get }
+    
+    var source: ErrorSource? { get }
+}
+
+public struct ErrorSource {
+    public let file: String
+    public let line: UInt
+    public let function: String
+    
+    public init(file: String = #file, line: UInt = #line, function: String = #function) {
+        self.file = file
+        self.line = line
+        self.function = function
+    }
 }
 
 extension AbortError {
@@ -27,6 +41,10 @@ extension AbortError {
 
     public var errorDescription: String? {
         return self.description
+    }
+    
+    public var source: ErrorSource? {
+        return nil
     }
 }
 


### PR DESCRIPTION
Builds upon https://github.com/vapor/vapor/pull/2086 adding a new `ErrorSource` structure to the `AbortError` protocol. 