### PR TITLE
Added array based routing convenience methods

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -35,8 +35,28 @@ extension RoutesBuilder {
     }
     
     @discardableResult
+    public func get<Response>(
+        _ path: [PathComponent],
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.GET, path, use: closure)
+    }
+    
+    @discardableResult
     public func post<Response>(
         _ path: PathComponent...,
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.POST, path, use: closure)
+    }
+    
+    @discardableResult
+    public func post<Response>(
+        _ path: [PathComponent],
         use closure: @escaping (Request) throws -> Response
     ) -> Route
         where Response: ResponseEncodable
@@ -55,6 +75,16 @@ extension RoutesBuilder {
     }
     
     @discardableResult
+    public func patch<Response>(
+        _ path: [PathComponent],
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.PATCH, path, use: closure)
+    }
+    
+    @discardableResult
     public func put<Response>(
         _ path: PathComponent...,
         use closure: @escaping (Request) throws -> Response
@@ -65,8 +95,28 @@ extension RoutesBuilder {
     }
     
     @discardableResult
+    public func put<Response>(
+        _ path: [PathComponent],
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.PUT, path, use: closure)
+    }
+    
+    @discardableResult
     public func delete<Response>(
         _ path: PathComponent...,
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.DELETE, path, use: closure)
+    }
+    
+    @discardableResult
+    public func delete<Response>(
+        _ path: [PathComponent],
         use closure: @escaping (Request) throws -> Response
     ) -> Route
         where Response: ResponseEncodable


### PR DESCRIPTION
Adding array based spellings of the route builder convenience methods. The variadic spellings don't mesh well with some use cases. The loss of these functions is also a regression from Vapor 3.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
