### PR TITLE
Don't ignore user-provided HTTP headers when testing with JSON payloads

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -152,7 +152,10 @@ extension XCTApplicationTester {
         var body = ByteBufferAllocator().buffer(capacity: 0)
         try body.writeBytes(JSONEncoder().encode(json))
         var realHeaders = headers
-        realHeaders.replaceOrAdd(name: .contentType, value: HTTPMediaType.json.serialize())
+        // Allow caller to override the Content-Type for JSON.
+        if !realHeaders.contains(name: .contentType) {
+            realHeaders.add(name: .contentType, value: HTTPMediaType.json.serialize())
+        }
         return try self.test(method, path, headers: realHeaders, body: body, closure: closure)
     }
 }

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -151,8 +151,8 @@ extension XCTApplicationTester {
     {
         var body = ByteBufferAllocator().buffer(capacity: 0)
         try body.writeBytes(JSONEncoder().encode(json))
-        var headers = HTTPHeaders()
-        headers.contentType = .json
-        return try self.test(method, path, headers: headers, body: body, closure: closure)
+        var realHeaders = headers
+        realHeaders.replaceOrAdd(name: .contentType, value: HTTPMediaType.json.serialize())
+        return try self.test(method, path, headers: realHeaders, body: body, closure: closure)
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1129,6 +1129,20 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(res.body.string, "done")
         }
     }
+    
+    func testTestWithJsonPreservesHTTPHeaders() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        app.get("check") { (req: Request) -> String in
+            return req.headers.firstValue(name: .init("X-Test-Value")) ?? "MISSING"
+        }
+        try app.start()
+        
+        try app.testable().test(.GET, "/check", headers: ["X-Test-Value": "PRESENT"], json: ["foo": "bar"], closure: { res in
+            XCTAssertEqual(res.body.string, "PRESENT")
+        })
+    }
 }
 
 private extension ByteBuffer {


### PR DESCRIPTION
`XCTApplicationTester` was accidentally ignoring the headers provided by the caller when invoking the `test(_:_:headers:json:file:line:closure:)` method. It no longer does so. Tests are provided to verify this works correctly and that overriding `Content-Type` also works as expected.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
