### PR TITLE
Make request property public on ParametersContainer

### DIFF
--- a/Sources/Vapor/Routing/ParametersContainer.swift
+++ b/Sources/Vapor/Routing/ParametersContainer.swift
@@ -4,7 +4,7 @@
 ///
 public struct ParametersContainer {
     /// Private `Request`.
-    private let request: Request
+    public let request: Request
 
     /// The `ParameterValue`s that this request collected as it was being routed.
     public var values: [ParameterValue] {

--- a/Sources/Vapor/Routing/ParametersContainer.swift
+++ b/Sources/Vapor/Routing/ParametersContainer.swift
@@ -3,7 +3,7 @@
 ///     let id = try req.parameters.next(Int.self)
 ///
 public struct ParametersContainer {
-    /// Private `Request`.
+    /// Public `Request`.
     public let request: Request
 
     /// The `ParameterValue`s that this request collected as it was being routed.


### PR DESCRIPTION
Make request property public on ParametersContainer to make it more extendable.

<!-- 🚀 Thank you for contributing! --->

As described in the issue #2119 this would increase the extendability of this structure for own implementations that provides project specific requirements.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
