### PR TITLE
make client response codable

### DIFF
--- a/Sources/Vapor/HTTP/HTTPHeaders.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders.swift
@@ -1,29 +1,3 @@
-///// An HTTP message.
-///// This is the basis of `HTTPRequest` and `HTTPResponse`. It has the general structure of:
-/////
-/////     <status line> HTTP/1.1
-/////     Content-Length: 5
-/////     Foo: Bar
-/////
-/////     hello
-/////
-///// - note: The status line contains information that differentiates requests and responses.
-/////         If the status line contains an HTTP method and URI it is a request.
-/////         If the status line contains an HTTP status code it is a response.
-/////
-///// This protocol is useful for adding methods to both requests and responses, such as the ability to serialize
-///// content to both message types.
-//public protocol HTTPMessage: CustomStringConvertible, CustomDebugStringConvertible {
-//    /// The HTTP version of this message.
-//    var version: HTTPVersion { get set }
-//
-//    /// The HTTP headers.
-//    var headers: HTTPHeaders { get set }
-//
-//    /// The optional HTTP body.
-//    var body: HTTPBody { get set }
-//}
-
 extension HTTPHeaders {
     /// `MediaType` specified by this message's `"Content-Type"` header.
     public var contentType: HTTPMediaType? {
@@ -49,5 +23,24 @@ extension HTTPHeaders {
     ///
     public var accept: [HTTPMediaTypePreference] {
         return self.firstValue(name: .accept).flatMap([HTTPMediaTypePreference].parse) ?? []
+    }
+}
+
+extension HTTPHeaders: Codable {
+    public init(from decoder: Decoder) throws {
+        let dictionary = try decoder.singleValueContainer().decode([String: String].self)
+        self.init()
+        for (name, value) in dictionary {
+            self.add(name: name, value: value)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var dictionary: [String: String] = [:]
+        for (name, value) in self {
+            dictionary[name] = value
+        }
+        var container = encoder.singleValueContainer()
+        try container.encode(dictionary)
     }
 }

--- a/Sources/Vapor/HTTP/HTTPStatus.swift
+++ b/Sources/Vapor/HTTP/HTTPStatus.swift
@@ -8,3 +8,15 @@ extension HTTPStatus: ResponseEncodable {
         return request.eventLoop.makeSucceededFuture(response)
     }
 }
+
+extension HTTPStatus: Codable {
+    public init(from decoder: Decoder) throws {
+        let code = try decoder.singleValueContainer().decode(Int.self)
+        self = .init(statusCode: code)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.code)
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1218,6 +1218,18 @@ final class ApplicationTests: XCTestCase {
 
         XCTAssertEqual(res.status, .seeOther)
     }
+
+    func testClientResponseCodable() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let res = try app.client.get("https://httpbin.org/json").wait()
+
+        let encoded = try JSONEncoder().encode(res)
+        let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
+        
+        XCTAssertEqual(res, decoded)
+    }
 }
 
 private extension ByteBuffer {


### PR DESCRIPTION
- makes `ClientResponse` `Codable` to help simplify saving / caching instance
- makes `ClientResponse` `ResponseEncodable` which allows it to be returned from route handlers
- `HTTPStatus` and `HTTPHeaders` are now also `Codable`