### PR TITLE
Make RFC1123 formatter use en_US_POSIX locale

### DIFF
--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -22,8 +22,11 @@ private final class RFC1123 {
     /// Creates a new RFC1123 helper
     private init() {
         let formatter = DateFormatter()
+        let enUSPosixLocale = Locale(identifier: "en_US_POSIX")
+        formatter.locale = enUSPosixLocale
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+        formatter.calendar = Calendar(identifier: .gregorian)
         self.formatter = formatter
     }
     


### PR DESCRIPTION
Adds more locale specific settings to the DateFormatter to support wider ranges of default system locales. If the application containing the server would declare support for other locales (such as `deDE` or `plPL`) or the default system locale wouldn't be compatible with `enUS` making the RFC1123 formatted string non RFC compliant. This fix makes sure that the formatter always uses the `enUS_POSIX` locale and the Georgian calendar.

### Example

The returned string with default locale set as deDE is `Don, 05 Dez 2019 19:27:05 GMT` instead of `Thu, 05 Dec 2019 19:27:05 GMT` making the first string non RFC compliant.