### PR TITLE
Add Environment secret extension and test route to routes file (Vapor 4)

### DIFF
--- a/Docs/pull_request_template.md
+++ b/Docs/pull_request_template.md
@@ -1,6 +1,6 @@
-<!-- 🚀 Thank you for contributing! --->
+<!-- 🚀 Thank you for contributing! -->
 
-<!-- When this PR is merged, the title and body will be  -->
-<!-- used to generate a release automatically.  -->
+<!-- When this PR is merged, the title and body will be -->
+<!-- used to generate a release automatically. -->
 
-<!-- So make it pretty and use plenty of examples.  -->
+<!-- Make the change clear and use examples if possible. -->

--- a/Docs/pull_request_template.md
+++ b/Docs/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- 🚀 Thank you for contributing! -->
 
+<!-- Describe your changes clearly and use examples if possible. -->
+
 <!-- When this PR is merged, the title and body will be -->
 <!-- used to generate a release automatically. -->
-
-<!-- Make the change clear and use examples if possible. -->

--- a/Docs/pull_request_template.md
+++ b/Docs/pull_request_template.md
@@ -1,13 +1,6 @@
 <!-- 🚀 Thank you for contributing! --->
 
-<!-- Provide a brief description of the PR here. -->
-<!-- Pretend you are explaining it to a friend, not yourself! -->
+<!-- When this PR is merged, the title and body will be  -->
+<!-- used to generate a release automatically.  -->
 
-### Checklist
-
-<!-- The items on this checklist must be completed to merge. -->
-
-- [ ] Circle CI is passing (code compiles and passes tests).
-- [ ] There are no breaking changes to public API.
-- [ ] New test cases have been added where appropriate.
-- [ ] All new code has been commented with doc blocks `///`.
+<!-- So make it pretty and use plenty of examples.  -->

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.1.1"),
         
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
         
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,9 @@ let package = Package(
 
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0-beta.3"),
+
+        // 💥 Backtraces for Swift on Linux
+        .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.1.1"),
         
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
@@ -60,6 +63,7 @@ let package = Package(
         .target(name: "Vapor", dependencies: [
             "AsyncHTTPClient",
             "AsyncKit",
+            "Backtrace",
             "CBcrypt",
             "COperatingSystem",
             "CURLParser",

--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
         
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),

--- a/Sources/CURLParser/include/urlparser.h
+++ b/Sources/CURLParser/include/urlparser.h
@@ -39,7 +39,7 @@ struct urlparser_field_data {
     uint16_t len;               /* Length of run in buffer */
 };
 
-/* Result structure for http_parser_parse_url().
+/* Result structure for urlparser_parse_url().
  *
  * Callers should index into field_data[] with UF_* values iff field_set
  * has the relevant (1 << UF_*) bit set. As a courtesy to clients (and

--- a/Sources/CURLParser/urlparser.c
+++ b/Sources/CURLParser/urlparser.c
@@ -85,7 +85,7 @@ static const int8_t unhex[256] =
 };
 
 
-#if HTTP_PARSER_STRICT
+#if URLPARSER_STRICT
 # define T(v) 0
 #else
 # define T(v) v
@@ -243,7 +243,7 @@ enum http_host_state
 
 #define STRICT_TOKEN(c)     ((c == ' ') ? 0 : tokens[(unsigned char)c])
 
-#if HTTP_PARSER_STRICT
+#if URLPARSER_STRICT
 #define TOKEN(c)            STRICT_TOKEN(c)
 #define IS_URL_CHAR(c)      (BIT_AT(normal_url_char, (unsigned char)c))
 #define IS_HOST_CHAR(c)     (IS_ALPHANUM(c) || (c) == '.' || (c) == '-')
@@ -257,9 +257,9 @@ enum http_host_state
 
 /* Our URL parser.
  *
- * This is designed to be shared by http_parser_execute() for URL validation,
+ * This is designed to be shared by urlparser_execute() for URL validation,
  * hence it has a state transition + byte-for-byte interface. In addition, it
- * is meant to be embedded in http_parser_parse_url(), which does the dirty
+ * is meant to be embedded in urlparser_parse_url(), which does the dirty
  * work of turning state transitions URL components for its API.
  *
  * This function should only be invoked with non-space characters. It is
@@ -273,7 +273,7 @@ parse_url_char(enum state s, const char ch)
         return s_dead;
     }
 
-#if HTTP_PARSER_STRICT
+#if URLPARSER_STRICT
     if (ch == '\t' || ch == '\f') {
         return s_dead;
     }
@@ -579,7 +579,7 @@ http_parse_host(const char * buf, struct urlparser_url *u, int found_at) {
 }
 
 void
-http_parser_url_init(struct urlparser_url *u) {
+urlparser_url_init(struct urlparser_url *u) {
     memset(u, 0, sizeof(*u));
 }
 

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,7 +1,6 @@
 import Vapor
 
 public func configure(_ app: Application) throws {
-    print(Environment.get("FOO"))
     app.server.configuration.hostname = "127.0.0.1"
     switch app.environment {
     case .tls:

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,8 +1,7 @@
 import Vapor
 
 public func configure(_ app: Application) throws {
-    try LoggingSystem.bootstrap(from: &app.environment)
-    
+    print(Environment.get("FOO"))
     app.server.configuration.hostname = "127.0.0.1"
     switch app.environment {
     case .tls:

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,6 +1,11 @@
 import Vapor
 
-let app = try Application(.detect())
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+
+let app = try Application(env)
 defer { app.shutdown() }
+
 try configure(app)
+
 try app.run()

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -3,7 +3,7 @@ import Vapor
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
 
-let app = try Application(env)
+let app = Application(env)
 defer { app.shutdown() }
 
 try configure(app)

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -159,10 +159,11 @@ public func routes(_ app: Application) throws {
     }
 
     app.directory.viewsDirectory = "/Users/tanner/Desktop"
-    app.get("view") { req in
+    app.get("view") { req -> EventLoopFuture<View> in
         req.view.render("hello.txt", ["name": "world"])
+    }
 
-    r.get("secret") { (req) -> EventLoopFuture<String> in
-        return try Environment.secret(key: "PASSWORD_SECRET", container: c)
+    app.get("secret") { (req) -> EventLoopFuture<String> in
+        return try Environment.secret(key: "PASSWORD_SECRET", fileIO: app.fileio, on: req.eventLoop)
     }
 }

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -164,6 +164,8 @@ public func routes(_ app: Application) throws {
     }
 
     app.get("secret") { (req) -> EventLoopFuture<String> in
-        return try Environment.secret(key: "PASSWORD_SECRET", fileIO: app.fileio, on: req.eventLoop)
+        return Environment
+            .secret(key: "PASSWORD_SECRET", fileIO: req.application.fileio, on: req.eventLoop)
+            .unwrap(or: Abort(.badRequest))
     }
 }

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -157,9 +157,12 @@ public func routes(_ app: Application) throws {
     users.get(":userID") { req in
         return req.parameters.get("userID") ?? "no id"
     }
-    
+
     app.directory.viewsDirectory = "/Users/tanner/Desktop"
     app.get("view") { req in
         req.view.render("hello.txt", ["name": "world"])
+
+    r.get("secret") { (req) -> EventLoopFuture<String> in
+        return try Environment.secret(key: "PASSWORD_SECRET", container: c)
     }
 }

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -69,7 +69,6 @@ public final class Application {
     }
     
     public func run() throws {
-        defer { self.shutdown() }
         do {
             try self.start()
             try self.running?.onStop.wait()

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -79,6 +79,8 @@ public final class Application {
         self.views.initialize()
         self.sessions.initialize()
         self.sessions.use(.memory)
+        self.responder.initialize()
+        self.responder.use(.default)
         self.commands.use(self.server.command, as: "serve", isDefault: true)
         self.commands.use(RoutesCommand(), as: "routes")
         // Load specific .env first since values are not overridden.

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -50,6 +50,7 @@ public final class Application {
     }
 
     public init(_ environment: Environment = .development) {
+        Backtrace.install()
         self.environment = environment
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         self.locks = .init()

--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -39,32 +39,6 @@ extension BearerAuthenticator {
     }
 }
 
-// MARK: User Token
-
-public protocol UserTokenAuthenticator: RequestAuthenticator {
-    associatedtype TokenAuthenticator: RequestAuthenticator where
-        TokenAuthenticator.User: AuthenticationToken,
-        TokenAuthenticator.User.User == User
-
-    var tokenAuthenticator: TokenAuthenticator { get }
-    func authenticate(token: TokenAuthenticator.User, for request: Request) -> EventLoopFuture<User?>
-}
-
-extension UserTokenAuthenticator {
-    public func authenticate(request: Request) -> EventLoopFuture<User?> {
-        return self.tokenAuthenticator.authenticate(request: request).flatMap { token in
-            guard let token = token else {
-                return request.eventLoop.makeSucceededFuture(nil)
-            }
-            return self.authenticate(token: token, for: request)
-        }
-    }
-}
-
-public protocol AuthenticationToken {
-    associatedtype User
-}
-
 // MARK: Credentials
 
 public protocol CredentialsAuthenticator: RequestAuthenticator {

--- a/Sources/Vapor/Client/Request+Client.swift
+++ b/Sources/Vapor/Client/Request+Client.swift
@@ -9,7 +9,7 @@ struct RequestClient: Client {
     let req: Request
 
     var eventLoopGroup: EventLoopGroup {
-        return self.http.eventLoopGroup
+        return self.req.eventLoop
     }
 
     func `for`(_ request: Request) -> Client {

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -10,7 +10,7 @@ public final class ServeCommand: Command {
         var hostname: String?
         
         @Option(name: "port", short: "p", help: "Set the port the server will run on.")
-        var port: String?
+        var port: Int?
         
         @Option(name: "bind", short: "b", help: "Convenience for setting hostname and port together.")
         var bind: String?
@@ -42,7 +42,7 @@ public final class ServeCommand: Command {
         let hostname = signature.hostname
             // 0.0.0.0:8080, 0.0.0.0, parse hostname
             ?? signature.bind?.split(separator: ":").first.flatMap(String.init)
-        let port = signature.port?.fixedPort
+        let port = signature.port
             // 0.0.0.0:8080, :8080, parse port
             ?? signature.bind?.split(separator: ":").last.flatMap(String.init).flatMap(Int.init)
         let server = try context.application.server.start(hostname: hostname, port: port)
@@ -81,16 +81,5 @@ public final class ServeCommand: Command {
     
     deinit {
         assert(self.didShutdown, "ServeCommand did not shutdown before deinit")
-    }
-}
-
-private extension String {
-    // Fixes an issue with Heroku where the port is prefixed with \
-    var fixedPort: Int? {
-        if self.hasPrefix("\\") && self.count >= 2 {
-            return Int(self.dropFirst())
-        } else {
-            return Int(self)
-        }
     }
 }

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -10,7 +10,7 @@ public final class ServeCommand: Command {
         var hostname: String?
         
         @Option(name: "port", short: "p", help: "Set the port the server will run on.")
-        var port: Int?
+        var port: String?
         
         @Option(name: "bind", short: "b", help: "Convenience for setting hostname and port together.")
         var bind: String?
@@ -42,7 +42,7 @@ public final class ServeCommand: Command {
         let hostname = signature.hostname
             // 0.0.0.0:8080, 0.0.0.0, parse hostname
             ?? signature.bind?.split(separator: ":").first.flatMap(String.init)
-        let port = signature.port
+        let port = signature.port?.fixedPort
             // 0.0.0.0:8080, :8080, parse port
             ?? signature.bind?.split(separator: ":").last.flatMap(String.init).flatMap(Int.init)
         let server = try context.application.server.start(hostname: hostname, port: port)
@@ -81,5 +81,16 @@ public final class ServeCommand: Command {
     
     deinit {
         assert(self.didShutdown, "ServeCommand did not shutdown before deinit")
+    }
+}
+
+private extension String {
+    // Fixes an issue with Heroku where the port is prefixed with \
+    var fixedPort: Int? {
+        if self.hasPrefix("\\") && self.count >= 2 {
+            return Int(self.dropFirst())
+        } else {
+            return Int(self)
+        }
     }
 }

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -76,7 +76,8 @@ extension DecodingError: AbortError {
     /// See `AbortError.reason`
     public var reason: String {
         switch self {
-        case .dataCorrupted(let ctx): return ctx.debugDescription
+        case .dataCorrupted(let ctx):
+            return "\(ctx.debugDescription) for key \(ctx.codingPath.dotPath)"
         case .keyNotFound(let key, let ctx):
             let path: String
             if ctx.codingPath.count > 0 {

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -1,6 +1,7 @@
 @_exported import AsyncKit
 
 @_exported import class AsyncHTTPClient.HTTPClient
+@_exported import enum Backtrace.Backtrace
 
 @_exported import OpenCrypto
 @_exported import RoutingKit

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -1,0 +1,187 @@
+import NIO
+
+// Comments on these properties are copied from the mozilla doc URL shown below.
+extension HTTPHeaders {
+    /// Represents the HTTP `Cache-Control` header.
+    /// - See Also:
+    /// [Cache-Control docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+    public struct CacheControl {
+        /// The max-stale option can be present with no value, or be present with a number of seconds.  By using
+        /// a struct you can check the nullability of the `maxStale` variable as well as then check the nullability
+        /// of the `seconds` to differentiate.
+        public struct MaxStale {
+            /// The upper limit of staleness the client will accept.
+            public var seconds: Int?
+        }
+
+        /// Indicates that once a resource becomes stale, caches must not use their stale copy without
+        /// successful [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) on the origin server.
+        public var mustRevalidate: Bool
+
+        /// Caches must check with the origin server for
+        /// [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) before using the cached copy.
+        public var noCache: Bool
+
+        /// The cache **should not store anything** about the client request or server response.
+        public var noStore: Bool
+
+        /// No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified
+        /// by a proxy. A non-transparent proxy or browser feature such as
+        /// [Google's Light Mode](https://support.google.com/webmasters/answer/6211428?hl=en) might, for example, convert between image
+        /// formats in order to save cache space or to reduce the amount of traffic on a slow link. The `no-transform` directive disallows this.
+        public var noTransform: Bool
+
+        /// The response may be cached by any cache, even if the response is normally non-cacheable
+        public var isPublic: Bool
+
+        /// The response is for a single user and **must not** be stored by a shared cache. A private cache (like the user's browser cache) may store the response.
+        public var isPrivate: Bool
+
+        /// Like `must-revalidate`, but only for shared caches (e.g., proxies). Ignored by private caches.
+        public var proxyRevalidate: Bool
+
+        /// Indicates to not retrieve new data. This being the case, the server wishes the client to obtain a response only once and then cache. From this moment the
+        /// client should keep releasing a cached copy and avoid contacting the origin-server to see if a newer copy exists.
+        public var onlyIfCached: Bool
+
+        /// Indicates that the response body **will not change** over time.
+        ///
+        /// The resource, if *unexpired*, is unchanged on the server and therefore the client should
+        /// not send a conditional revalidation for it (e.g. `If-None-Match` or `If-Modified-Since`) to check for updates, even when the user explicitly refreshes
+        /// the page. Clients that aren't aware of this extension must ignore them as per the HTTP specification. In Firefox, immutable is only honored on https:// transactions.
+        /// For more information, see also this [blog post](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html).
+        public var immutable: Bool
+
+        /// The maximum amount of time a resource is considered fresh. Unlike the`Expires` header, this directive is relative to the time of the request.
+        public var maxAge: Int?
+
+        /// Overrides max-age or the Expires header, but only for shared caches (e.g., proxies). Ignored by private caches.
+        public var sMaxAge: Int?
+
+        /// Indicates the client will accept a stale response. An optional value in seconds indicates the upper limit of staleness the client will accept.
+        public var maxStale: MaxStale?
+
+        /// Indicates the client wants a response that will still be fresh for at least the specified number of seconds.
+        public var minFresh: Int?
+
+        /// Indicates the client will accept a stale response, while asynchronously checking in the background for a fresh one. The value indicates how long the client will accept a stale response.
+        public var staleWhileRevalidate: Int?
+
+        /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
+        public var staleIfError: Int?
+
+        public init() {
+            self.mustRevalidate = false
+            self.noCache = false
+            self.noStore = false
+            self.noTransform = false
+            self.isPublic = false
+            self.isPrivate = false
+            self.proxyRevalidate = false
+            self.onlyIfCached = false
+            self.immutable = false
+        }
+
+        private static let exactMatch: [String: WritableKeyPath<Self, Bool>] = [
+            "must-revalidate": \.mustRevalidate,
+            "no-cache": \.noCache,
+            "no-store": \.noStore,
+            "no-transform": \.noTransform,
+            "public": \.isPublic,
+            "private": \.isPrivate,
+            "proxy-revalidate": \.proxyRevalidate,
+            "only-if-cached": \.onlyIfCached
+        ]
+
+        private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
+            "max-age": \.maxAge,
+            "s-maxage": \.sMaxAge,
+            "min-fresh": \.minFresh,
+            "stale-while-revalidate": \.staleWhileRevalidate,
+            "stale-if-error": \.staleIfError
+        ]
+
+        internal static func parse(_ value: String) -> CacheControl? {
+            var set = CharacterSet.whitespacesAndNewlines
+            set.insert(",")
+
+            var foundSomething = false
+
+            var cache = CacheControl()
+
+            value
+                .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: "\t", with: "")
+                .lowercased()
+                .split(separator: ",")
+                .forEach {
+                    let str = String($0)
+
+                    if let keyPath = Self.exactMatch[str] {
+                        cache[keyPath: keyPath] = true
+                        foundSomething = true
+                        return
+                    }
+
+                    if value == "max-stale" {
+                        cache.maxStale = .init()
+                        foundSomething = true
+                        return
+                    }
+
+                    let parts = str.components(separatedBy: "=")
+                    guard parts.count == 2, let seconds = Int(parts[1]), seconds >= 0 else {
+                        return
+                    }
+
+                    if parts[0] == "max-stale" {
+                        cache.maxStale = .init(seconds: seconds)
+                        foundSomething = true
+                        return
+                    }
+
+                    guard let keyPath = Self.prefix[parts[0]] else {
+                        return
+                    }
+
+                    cache[keyPath: keyPath] = seconds
+                    foundSomething = true
+            }
+
+            return foundSomething ? cache : nil
+        }
+
+        /// Generates the header string for this instance.
+        public func serialize() -> String {
+            var options = Self.exactMatch
+                .filter { self[keyPath: $0.value] == true }
+                .map { $0.key }
+
+            var optionsWithSeconds = Self.prefix
+                .filter { self[keyPath: $0.value] != nil }
+                .map { "\($0.key)=\(self[keyPath: $0.value]!)" }
+
+            if let maxStale = self.maxStale {
+                if let seconds = maxStale.seconds {
+                    optionsWithSeconds.append("max-stale=\(seconds)")
+                } else {
+                    options.append("max-stale")
+                }
+            }
+            
+            return (options + optionsWithSeconds).joined(separator: ", ")
+        }
+    }
+
+    /// Gets the value of the `Cache-Control` header, if present.
+    public var cacheControl: CacheControl? {
+        get { self.firstValue(name: .cacheControl).flatMap(CacheControl.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                self.replaceOrAdd(name: .cacheControl, value: new)
+            } else {
+                self.remove(name: .expires)
+            }
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
@@ -50,7 +50,7 @@ extension HTTPHeaders {
     /// ### Note ###
     /// `Expires` is legacy and you should switch to using `CacheControl` if possible.
     public var expires: Expires? {
-        get { firstValue(name: .expires).flatMap(Expires.parse) }
+        get { self.firstValue(name: .expires).flatMap(Expires.parse) }
         set {
             if let new = newValue?.serialize() {
                 self.replaceOrAdd(name: .expires, value: new)

--- a/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
@@ -1,0 +1,62 @@
+import NIO
+
+extension HTTPHeaders {
+    public struct Expires {
+        /// The date represented by the header.
+        public let expires: Date
+
+        internal static func parse(_ dateString: String) -> Expires? {
+            // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
+
+            // Obsolete RFC 850 format
+            fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
+
+            // Obsolete ANSI C asctime() format
+            fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
+
+            return nil
+        }
+
+        init(expires: Date) {
+            self.expires = expires
+        }
+
+        /// Generates the header string for this instance.
+        public func serialize() -> String {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+            return fmt.string(from: expires)
+        }
+    }
+
+    /// Gets the value of the `Expires` header, if present.
+    /// ### Note ###
+    /// `Expires` is legacy and you should switch to using `CacheControl` if possible.
+    public var expires: Expires? {
+        get { firstValue(name: .expires).flatMap(Expires.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                self.replaceOrAdd(name: .expires, value: new)
+            } else {
+                self.remove(name: .expires)
+            }
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPHeaderLastModified.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderLastModified.swift
@@ -1,0 +1,42 @@
+extension HTTPHeaders {
+    /// Represents the HTTP `Last-Modified` header.
+    /// - See Also:
+    /// [Last-Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified)
+    public struct LastModified {
+        public let value: Date
+
+        internal static func parse(_ dateString: String) -> LastModified? {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+            guard let date = fmt.date(from: dateString) else {
+                return nil
+            }
+
+            return .init(value: date)
+        }
+
+        public func serialize() -> String {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+            return fmt.string(from: self.value)
+        }
+    }
+
+    public var lastModified: LastModified? {
+        get { self.firstValue(name: .lastModified).flatMap(LastModified.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                self.replaceOrAdd(name: .lastModified, value: new)
+            } else {
+                self.remove(name: .lastModified)
+            }
+        }
+    }
+}
+

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -1,0 +1,32 @@
+extension HTTPHeaders {
+    /// Determines when the cached data should be expired.
+    ///
+    /// This first checks to see if the `Cache-Control` header is present.  If it is, and `no-store`
+    /// is set, then `nil` is returned.  If `no-store` is not present, and there is a `max-age` then
+    /// the expiration will add that many seconds to `requestSentAt`.
+    ///
+    /// If no `Cache-Control` header is present then it will examine the `Expires` header.
+    ///
+    /// If you need finer grained details about what type of caching, validation, etc... you should instead
+    /// grab the `cacheControl` and `expires` headers yourself.
+    ///
+    /// - Parameter requestSentAt: Should be passed the `Date` when the request was sent.
+    public func expirationDate(requestSentAt: Date) -> Date? {
+        // Cache-Control header takes priority over the Expires header
+        if let cacheControl = cacheControl {
+            guard cacheControl.noStore == false else {
+                return nil
+            }
+
+            if let age = cacheControl.maxAge {
+                return requestSentAt.addingTimeInterval(TimeInterval(age))
+            }
+        }
+
+        if let expires = expires {
+            return expires.expires
+        }
+
+        return nil
+    }
+}

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -8,6 +8,7 @@ extension LoggingSystem {
         try LoggingSystem.bootstrap(
             console: Terminal(),
             level: LogSignature(from: &environment.commandInput).level
+                ?? Environment.process.LOG_LEVEL
                 ?? (environment == .production ? .notice: .info)
         )
     }

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -1,0 +1,71 @@
+extension Application {
+    public var responder: Responder {
+        .init(application: self)
+    }
+
+    public struct Responder {
+        public struct Provider {
+            public static var `default`: Self {
+                .init {
+                    $0.responder.use { $0.responder.default }
+                }
+            }
+
+            let run: (Application) -> ()
+
+            public init(_ run: @escaping (Application) -> ()) {
+                self.run = run
+            }
+        }
+
+        final class Storage {
+            var factory: ((Application) -> Vapor.Responder)?
+            init() { }
+        }
+
+        struct Key: StorageKey {
+            typealias Value = Storage
+        }
+
+        let application: Application
+
+        public var current: Vapor.Responder {
+            guard let factory = self.storage.factory else {
+                fatalError("No responder configured. Configure with app.responder.use(...)")
+            }
+            return factory(self.application)
+        }
+
+        public var `default`: Vapor.Responder {
+            DefaultResponder(
+                routes: self.application.routes,
+                middleware: self.application.middleware.resolve()
+            )
+        }
+
+        public func use(_ provider: Provider) {
+            provider.run(self.application)
+        }
+
+        public func use(_ factory: @escaping (Application) -> (Vapor.Responder)) {
+            self.storage.factory = factory
+        }
+
+        var storage: Storage {
+            guard let storage = self.application.storage[Key.self] else {
+                fatalError("Sessions not configured. Configure with app.sessions.initialize()")
+            }
+            return storage
+        }
+
+        func initialize() {
+            self.application.storage[Key.self] = .init()
+        }
+    }
+}
+
+extension Application.Responder: Responder {
+    public func respond(to request: Request) -> EventLoopFuture<Response> {
+        self.current.respond(to: request)
+    }
+}

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -1,14 +1,5 @@
-extension Application {
-    public var responder: Responder {
-        ApplicationResponder(
-            routes: self.routes,
-            middleware: self.middleware.resolve()
-        )
-    }
-}
-
 /// Vapor's main `Responder` type. Combines configured middleware + router to create a responder.
-internal struct ApplicationResponder: Responder {
+internal struct DefaultResponder: Responder {
     private let router: TrieRouter<Route>
     private let notFoundRoute: Route
 

--- a/Sources/Vapor/Server/Application+Server.swift
+++ b/Sources/Vapor/Server/Application+Server.swift
@@ -49,7 +49,7 @@ extension Application {
             configuration.port = port ?? self.configuration.port
             let server = HTTPServer(
                 application: self.application,
-                responder: self.application.responder,
+                responder: self.application.responder.current,
                 configuration: configuration,
                 on: self.application.eventLoopGroup
             )

--- a/Sources/Vapor/Services/Environment+Secret.swift
+++ b/Sources/Vapor/Services/Environment+Secret.swift
@@ -2,25 +2,25 @@ public extension Environment {
 
     /// Reads a file content for a secret. The secret key represents the name of the environment variable that holds the path for the file containing the secret
     /// - Parameter key: Environment name for the path to the file containing the secret
-    /// - Parameter container: Container for handling the file reading and event loop
+    /// - Parameter fileIO: FileIO handler provided by NIO
+    /// - Parameter on: EventLoop to operate on while opening the file
     /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
-    static func secret(key: String, container: Container) throws -> EventLoopFuture<String> {
+    static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) throws -> EventLoopFuture<String> {
         guard let filePath = self.get(key) else { throw Error.environmentVariableNotFound }
-        return try secret(path: filePath, container: container)
+        return try secret(path: filePath, fileIO: fileIO, on: eventLoop)
     }
 
 
     /// Reads a file content for a secret. The path is a file path to the file that contains the secret in plain text
     /// - Parameter path: Path to the file that contains the secret
-    /// - Parameter container: Container for handling the file reading and event loop
+    /// - Parameter fileIO: FileIO handler provided by NIO
+    /// - Parameter on: EventLoop to operate on while opening the file
     /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
-    static func secret(path: String, container: Container) throws -> EventLoopFuture<String> {
-        let fileio = try container.make(NonBlockingFileIO.self)
-        let eventLoop = container.eventLoop
-        return fileio
+    static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) throws -> EventLoopFuture<String> {
+        return fileIO
             .openFile(path: path, eventLoop: eventLoop)
             .flatMap({ (arg) -> EventLoopFuture<ByteBuffer> in
-                return fileio
+                return fileIO
                     .read(fileRegion: arg.1, allocator: .init(), eventLoop: eventLoop)
                     .map({ (buffer) -> ByteBuffer in
                         try? arg.0.close()

--- a/Sources/Vapor/Services/Environment+Secret.swift
+++ b/Sources/Vapor/Services/Environment+Secret.swift
@@ -1,0 +1,40 @@
+public extension Environment {
+
+    /// Reads a file content for a secret. The secret key represents the name of the environment variable that holds the path for the file containing the secret
+    /// - Parameter key: Environment name for the path to the file containing the secret
+    /// - Parameter container: Container for handling the file reading and event loop
+    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    static func secret(key: String, container: Container) throws -> EventLoopFuture<String> {
+        guard let filePath = self.get(key) else { throw Error.environmentVariableNotFound }
+        return try secret(path: filePath, container: container)
+    }
+
+
+    /// Reads a file content for a secret. The path is a file path to the file that contains the secret in plain text
+    /// - Parameter path: Path to the file that contains the secret
+    /// - Parameter container: Container for handling the file reading and event loop
+    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    static func secret(path: String, container: Container) throws -> EventLoopFuture<String> {
+        let fileio = try container.make(NonBlockingFileIO.self)
+        let eventLoop = container.eventLoop
+        return fileio
+            .openFile(path: path, eventLoop: eventLoop)
+            .flatMap({ (arg) -> EventLoopFuture<ByteBuffer> in
+                return fileio
+                    .read(fileRegion: arg.1, allocator: .init(), eventLoop: eventLoop)
+                    .map({ (buffer) -> ByteBuffer in
+                        try? arg.0.close()
+                        return buffer
+                    })
+            })
+            .map({ (buffer) -> (String) in
+                var buffer = buffer
+                return buffer.readString(length: buffer.writerIndex) ?? ""
+            })
+    }
+
+    enum Error: Swift.Error {
+        case environmentVariableNotFound
+    }
+}
+

--- a/Sources/Vapor/Services/Environment+Secret.swift
+++ b/Sources/Vapor/Services/Environment+Secret.swift
@@ -1,29 +1,31 @@
-public extension Environment {
+extension Environment {
 
     /// Reads a file content for a secret. The secret key represents the name of the environment variable that holds the path for the file containing the secret
-    /// - Parameter key: Environment name for the path to the file containing the secret
-    /// - Parameter fileIO: FileIO handler provided by NIO
-    /// - Parameter on: EventLoop to operate on while opening the file
+    /// - Parameters:
+    ///     - key: Environment name for the path to the file containing the secret
+    ///     - fileIO: FileIO handler provided by NIO
+    ///     - on: EventLoop to operate on while opening the file
     /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
-    static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) throws -> EventLoopFuture<String> {
-        guard let filePath = self.get(key) else { throw Error.environmentVariableNotFound }
-        return try secret(path: filePath, fileIO: fileIO, on: eventLoop)
+    public static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
+        guard let filePath = self.get(key) else { return eventLoop.future(nil) }
+        return self.secret(path: filePath, fileIO: fileIO, on: eventLoop)
     }
 
 
     /// Reads a file content for a secret. The path is a file path to the file that contains the secret in plain text
-    /// - Parameter path: Path to the file that contains the secret
-    /// - Parameter fileIO: FileIO handler provided by NIO
-    /// - Parameter on: EventLoop to operate on while opening the file
+    /// - Parameters:
+    ///     - path: Path to the file that contains the secret
+    ///     - fileIO: FileIO handler provided by NIO
+    ///     - on: EventLoop to operate on while opening the file
     /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
-    static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) throws -> EventLoopFuture<String> {
+    public static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
         return fileIO
             .openFile(path: path, eventLoop: eventLoop)
             .flatMap({ (arg) -> EventLoopFuture<ByteBuffer> in
                 return fileIO
                     .read(fileRegion: arg.1, allocator: .init(), eventLoop: eventLoop)
-                    .map({ (buffer) -> ByteBuffer in
-                        try? arg.0.close()
+                    .flatMapThrowing({ (buffer) -> ByteBuffer in
+                        try arg.0.close()
                         return buffer
                     })
             })
@@ -31,10 +33,12 @@ public extension Environment {
                 var buffer = buffer
                 return buffer.readString(length: buffer.writerIndex) ?? ""
             })
-    }
-
-    enum Error: Swift.Error {
-        case environmentVariableNotFound
+            .map({ (secret) -> (String) in
+                secret.trimmingCharacters(in: .whitespacesAndNewlines)
+            })
+            .recover ({ (_) -> String? in
+                nil
+            })
     }
 }
 

--- a/Sources/Vapor/Sessions/Application+Sessions.swift
+++ b/Sources/Vapor/Sessions/Application+Sessions.swift
@@ -60,8 +60,6 @@ extension Application {
 
         func initialize() {
             self.application.storage[Key.self] = .init()
-            self.use(.memory)
         }
-
     }
 }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -53,10 +53,7 @@ public struct URLEncodedFormDecoder: ContentDecoder, URLQueryDecoder {
     }
     
     public func decode<D>(_ decodable: D.Type, from url: URI) throws -> D where D : Decodable {
-        guard let query = url.query else {
-            throw Abort(.unsupportedMediaType)
-        }
-        return try self.decode(D.self, from: query)
+        return try self.decode(D.self, from: url.query ?? "")
     }
     
 

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -124,7 +124,11 @@ private struct _Decoder: Decoder {
 
     /// See `Decoder`
     func singleValueContainer() throws -> SingleValueDecodingContainer {
-        return SingleValueContainer(data: self.data!, codingPath: codingPath)
+        guard let data = self.data else {
+            throw DecodingError.valueNotFound(Any.self, at: codingPath)
+        }
+
+        return SingleValueContainer(data: data, codingPath: codingPath)
     }
     
     struct SingleValueContainer: SingleValueDecodingContainer {

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -101,12 +101,13 @@ private struct _Decoder: Decoder {
         where Key: CodingKey
     {
         guard let data = self.data else {
-            fatalError()
+            throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
         }
         switch data {
         case .dictionary(let dict):
             return KeyedDecodingContainer(KeyedContainer<Key>(data: dict, codingPath: self.codingPath))
-        default: fatalError()
+        default:
+            throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
         }
     }
 
@@ -118,7 +119,8 @@ private struct _Decoder: Decoder {
         switch data {
         case .array(let arr):
             return UnkeyedContainer(data: arr, codingPath: self.codingPath)
-        default: fatalError()
+        default:
+            throw DecodingError.valueNotFound([Any].self, at: codingPath)
         }
     }
 
@@ -201,23 +203,25 @@ private struct _Decoder: Decoder {
             where NestedKey: CodingKey
         {
             guard let data = self.data[key.stringValue] else {
-                fatalError()
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
             }
             switch data {
             case .dictionary(let dict):
                 return KeyedDecodingContainer(KeyedContainer<NestedKey>(data: dict, codingPath: self.codingPath + [key]))
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
             }
         }
         
         func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
             guard let data = self.data[key.stringValue] else {
-                fatalError()
+                throw DecodingError.valueNotFound([Any].self, at: codingPath)
             }
             switch data {
             case .array(let arr):
                 return UnkeyedContainer(data: arr, codingPath: self.codingPath + [key])
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([Any].self, at: codingPath)
             }
         }
         
@@ -283,7 +287,8 @@ private struct _Decoder: Decoder {
             switch self.data[self.currentIndex] {
             case .dictionary(let dict):
                 return KeyedDecodingContainer(KeyedContainer<NestedKey>(data: dict, codingPath: self.codingPath))
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath + [BasicCodingKey.index(currentIndex)])
             }
         }
         
@@ -292,7 +297,8 @@ private struct _Decoder: Decoder {
             switch self.data[self.currentIndex] {
             case .array(let arr):
                 return UnkeyedContainer(data: arr, codingPath: self.codingPath)
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([Any].self, at: codingPath + [BasicCodingKey.index(currentIndex)])
             }
         }
         

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -101,19 +101,12 @@ internal struct URLEncodedFormParser {
 
     /// Sets mutable form-urlencoded input to a value at the given `[URLEncodedFormEncodedSubKey]` path.
     private func set(_ base: inout URLEncodedFormData, to data: URLEncodedFormData, at path: [URLEncodedFormEncodedSubKey]) {
-        guard path.count >= 1 else {
-            base = data
-            return
-        }
-
-        let first = path[0]
-
         var child: URLEncodedFormData
         switch path.count {
         case 1:
             child = data
         case 2...:
-            switch first {
+            switch path[0] {
             case .array:
                 /// always append to the last element of the array
                 child = base.array?.last ?? .array([])
@@ -122,10 +115,12 @@ internal struct URLEncodedFormParser {
                 child = base.dictionary?[key] ?? .dictionary([:])
                 set(&child, to: data, at: Array(path[1...]))
             }
-        default: fatalError()
+        default:
+            base = data
+            return
         }
 
-        switch first {
+        switch path[0] {
         case .array:
             if case .array(var arr) = base {
                 /// always append

--- a/Sources/Vapor/Utilities/Array+Random.swift
+++ b/Sources/Vapor/Utilities/Array+Random.swift
@@ -25,3 +25,9 @@ extension Array where Element: FixedWidthInteger {
         return array
     }
 }
+
+extension Array where Element == UInt8 {
+    public var base64: String {
+        Data(self).base64EncodedString()
+    }
+}

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -22,8 +22,11 @@ private final class RFC1123 {
     /// Creates a new RFC1123 helper
     private init() {
         let formatter = DateFormatter()
+        let enUSPosixLocale = Locale(identifier: "en_US_POSIX")
+        formatter.locale = enUSPosixLocale
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+        formatter.calendar = Calendar(identifier: .gregorian)
         self.formatter = formatter
     }
     

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -13,12 +13,10 @@ public struct Storage {
         }
     }
     let logger: Logger
-    let sync: Lock
 
     public init(logger: Logger = .init(label: "codes.vapor.storage")) {
         self.storage = [:]
         self.logger = logger
-        self.sync = .init()
     }
 
     public mutating func clear() {

--- a/Sources/Vapor/Validation/Validation.swift
+++ b/Sources/Vapor/Validation/Validation.swift
@@ -12,9 +12,15 @@ public struct Validation {
                 } else {
                     result = ValidatorResults.Skipped()
                 }
+            } catch DecodingError.valueNotFound {
+                result = ValidatorResults.NotFound()
+           } catch DecodingError.typeMismatch(let type, _) {
+                result = ValidatorResults.TypeMismatch(type: type)
+            } catch DecodingError.dataCorrupted(let context) {
+                result = ValidatorResults.Invalid(reason: context.debugDescription)
             } catch {
-                result = ValidatorResults.Codable(error: error)
-            }
+               result = ValidatorResults.Codable(error: error)
+           }
             return .init(key: key, result: result)
         }
     }

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -8,7 +8,7 @@ public struct Validations {
     public mutating func add<T>(
         _ key: ValidationKey,
         as type: T.Type = T.self,
-        is validator: Validator<T>,
+        is validator: Validator<T> = .valid,
         required: Bool = true
     ) {
         let validation = Validation(key: key, required: required, validator: validator)

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -27,3 +27,13 @@ extension ValidationsError: CustomStringConvertible {
             .joined(separator: ", ")
     }
 }
+
+extension ValidationsError: AbortError {
+    public var status: HTTPResponseStatus {
+        .badRequest
+    }
+
+    public var reason: String {
+        self.description
+    }
+}

--- a/Sources/Vapor/Validation/ValidatorResult.swift
+++ b/Sources/Vapor/Validation/ValidatorResult.swift
@@ -7,8 +7,18 @@ public struct ValidatorResults {
 
     public struct Missing { }
 
+    public struct NotFound { }
+
     public struct Codable {
         public let error: Error
+    }
+
+    public struct Invalid {
+        let reason: String
+    }
+
+    public struct TypeMismatch {
+        let type: Any.Type
     }
 }
 
@@ -55,6 +65,49 @@ extension ValidatorResults.Missing: ValidatorResult {
     
     public var failureDescription: String? {
         "is required"
+    }
+}
+
+extension ValidatorResults.Invalid: ValidatorResult {
+    public var isFailure: Bool {
+        true
+    }
+
+    public var successDescription: String? {
+        nil
+    }
+
+    public var failureDescription: String? {
+        "is invalid: \(self.reason)"
+    }
+}
+
+extension ValidatorResults.NotFound: ValidatorResult {
+    public var isFailure: Bool {
+        true
+    }
+
+    public var successDescription: String? {
+        nil
+    }
+
+    public var failureDescription: String? {
+        "cannot be null"
+    }
+}
+
+
+extension ValidatorResults.TypeMismatch: ValidatorResult {
+    public var isFailure: Bool {
+        true
+    }
+
+    public var successDescription: String? {
+        nil
+    }
+
+    public var failureDescription: String? {
+        "is not a(n) \(self.type)"
     }
 }
 

--- a/Sources/Vapor/Validation/Validators/In.swift
+++ b/Sources/Vapor/Validation/Validators/In.swift
@@ -1,4 +1,4 @@
-extension Validator where T: Equatable {
+extension Validator where T: Equatable & CustomStringConvertible {
     /// Validates whether an item is contained in the supplied array.
     public static func `in`(_ array: T...) -> Validator<T> {
         .in(array)
@@ -16,7 +16,7 @@ extension Validator where T: Equatable {
 
 extension ValidatorResults {
     /// `ValidatorResult` of a validator that validates whether an item is contained in the supplied sequence.
-    public struct In<T> where T: Equatable {
+    public struct In<T> where T: Equatable & CustomStringConvertible {
         /// Description of the item.
         public let item: T
         
@@ -32,10 +32,26 @@ extension ValidatorResults.In: ValidatorResult {
     }
     
     public var successDescription: String? {
-        "in \(self.items)"
+        self.makeDescription(not: false)
     }
     
     public var failureDescription: String? {
-        "not in \(self.items)"
+        self.makeDescription(not: true)
+    }
+
+    func makeDescription(not: Bool) -> String {
+        let description: String
+        switch self.items.count {
+        case 1:
+            description = self.items[0].description
+        case 2:
+            description = "\(self.items[0].description) or \(self.items[1].description)"
+        default:
+            let first = self.items[0..<(self.items.count - 1)]
+                .map { $0.description }.joined(separator: ", ")
+            let last = self.items[self.items.count - 1].description
+            description = "\(first), or \(last)"
+        }
+        return "is\(not ? " not" : " ") \(description)"
     }
 }

--- a/Sources/Vapor/Validation/Validators/Nil.swift
+++ b/Sources/Vapor/Validation/Validators/Nil.swift
@@ -30,18 +30,18 @@ extension ValidatorResults.Nil: ValidatorResult {
     public var successDescription: String? {
         switch self.isNil {
         case true:
-            return "not nil"
-        default:
-            return nil
+            return "is not null"
+        case false:
+            return "is null"
         }
     }
     
     public var failureDescription: String? {
         switch self.isNil {
         case true:
-            return "nil"
-        default:
-            return nil
+            return "is null"
+        case false:
+            return "is not null"
         }
     }
 }

--- a/Sources/Vapor/Validation/Validators/Valid.swift
+++ b/Sources/Vapor/Validation/Validators/Valid.swift
@@ -1,0 +1,37 @@
+extension Validator {
+    /// Validates nothing. Can be used as placeholder to validate successful decoding
+    public static var valid: Validator<T> {
+        Valid().validator()
+    }
+    
+    struct Valid { }
+}
+
+extension Validator.Valid: ValidatorType {
+    func validate(_ data: T) -> ValidatorResult {
+        ValidatorResults.Valid()
+    }
+}
+
+
+extension ValidatorResults {
+    /// `ValidatorResult` of a validator that validates that the data is valid`.
+    public struct Valid {
+        /// As this validates nothing, this is always true.
+        public let isValid: Bool = true
+    }
+}
+
+extension ValidatorResults.Valid: ValidatorResult {
+    public var isFailure: Bool {
+        !self.isValid
+    }
+    
+    public var successDescription: String? {
+        "is valid"
+    }
+    
+    public var failureDescription: String? {
+        "is not valid"
+    }
+}

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -4,6 +4,30 @@ public struct XCTHTTPResponse {
     public var body: Response.Body
 }
 
+extension XCTHTTPResponse {
+    private struct _ContentContainer: ContentContainer {
+        var body: String
+        var headers: HTTPHeaders
+
+        var contentType: HTTPMediaType? {
+            return self.headers.contentType
+        }
+
+        mutating func encode<E>(_ encodable: E, using encoder: ContentEncoder) throws where E : Encodable {
+            fatalError("Encoding to test response is not supported")
+        }
+
+        func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D where D : Decodable {
+            var body = ByteBufferAllocator().buffer(capacity: 0)
+            body.writeString(self.body)
+            return try decoder.decode(D.self, from: body, headers: self.headers)
+        }
+    }
+
+    public var content: ContentContainer {
+        _ContentContainer(body: self.body.string ?? "", headers: self.headers)
+    }
+}
 //    @discardableResult
 //    public func assertStatus(is status: HTTPStatus, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
 //        XCTAssertEqual(self.response.status, status, file: file, line: line)

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -104,6 +104,18 @@ final class ApplicationTests: XCTestCase {
         
         XCTAssertThrowsError(try request.query.get(StringWrapper.self, at: "hello"))
     }
+    
+    func testCrashingArrayWithPercentEncoding() throws {
+        let app = Application()
+        defer { app.shutdown() }
+
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        request.headers.contentType = .json
+        request.url.path = "/"
+        request.url.query = "emailsToSearch%5B%5D=xyz"
+        
+        XCTAssertThrowsError(try request.query.get([String].self, at: "emailsToSearch[]"))
+    }
 
     func testQueryGet() throws {
         let app = Application()

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -109,14 +109,14 @@ final class ApplicationTests: XCTestCase {
             if case .typeMismatch(_, let context) = error as? DecodingError {
                 XCTAssertEqual(context.debugDescription, "Data found at 'foo' was not Int")
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"DecodingError.typeMismatch\"")
+                XCTFail("Caught error \"\(error)\", but not the expected: \"DecodingError.typeMismatch\"")
             }
         }
         XCTAssertThrowsError(try req.query.get(String.self, at: "bar")) { error in
             if case .valueNotFound(_, let context) = error as? DecodingError {
                 XCTAssertEqual(context.debugDescription, "No String was found at 'bar'")
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"DecodingError.valueNotFound\"")
+                XCTFail("Caught error \"\(error)\", but not the expected: \"DecodingError.valueNotFound\"")
             }
         }
 
@@ -131,10 +131,10 @@ final class ApplicationTests: XCTestCase {
             on: app.eventLoopGroup.next()
         )
         XCTAssertThrowsError(try req.query.get(Int.self, at: "foo")) { error in
-            if let error = error as? Abort {
-                XCTAssertEqual(error.status, .unsupportedMediaType)
+            if let error = error as? DecodingError {
+                XCTAssertEqual(error.status, .badRequest)
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"\(Abort(.unsupportedMediaType))\"")
+                XCTFail("Caught error \"\(error)\"")
             }
         }
         XCTAssertEqual(req.query[String.self, at: "foo"], nil)

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -2,12 +2,6 @@ import Vapor
 import XCTVapor
 import COperatingSystem
 
-extension ValidationsError: AbortError {
-    public var reason: String { description }
-
-    public var status: HTTPResponseStatus { .unprocessableEntity }
-}
-
 final class ApplicationTests: XCTestCase {
     func testApplicationStop() throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
@@ -607,7 +601,7 @@ final class ApplicationTests: XCTestCase {
             "name": "vapor",
             "email": "foo"
         ]) { res in
-            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "email is not a valid email address")
         }
     }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -1,0 +1,130 @@
+import Vapor
+import XCTest
+
+class CacheTests: XCTestCase {
+    func testNoStoreWithExpires() {
+        let requested = Date()
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "no-store, max-age=12")
+
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testNoStore() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testMaxAge() {
+        let seconds = Int.random(in: 1...3_000_333)
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-age=\(seconds)"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
+    }
+
+    func testNoMatching() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testMissingHeader() {
+        let response = ClientResponse(status: .ok)
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: Date()))
+    }
+
+    private func dateFromFormat(format: String, dateStr: String) -> Date {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = format
+
+        return fmt.date(from: dateStr)!
+    }
+
+    func testPreferredFormat() {
+        let expires = "Sun, 06 Nov 1994 08:49:37 GMT"
+        let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatOne() {
+        let expires = "Sunday, 06-Nov-94 08:49:37 GMT"
+        let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatTwo() {
+        let expires = "Sun Nov  6 08:49:37 1994"
+        let format = "EEE MMM d hh:mm:s yyyy"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testMaxAgeOverridesExpires() {
+        let requested = Date()
+        let seconds = Int.random(in: 1...3_000_333)
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "max-age=\(seconds)")
+
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
+    }
+
+    func testFlags() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertTrue(response.headers.cacheControl!.noStore)
+        XCTAssertFalse(response.headers.cacheControl!.immutable)
+        XCTAssertEqual(response.headers.cacheControl!.maxAge, 12)
+    }
+
+    func textMaxStaleNoValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNil(cache.maxStale?.seconds)
+    }
+
+    func textMaxStaleNoWithValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNotNil(cache.maxStale?.seconds)
+        XCTAssertEqual(cache.maxStale?.seconds, 12)
+    }
+}

--- a/Tests/VaporTests/EnvironmentSecretTests.swift
+++ b/Tests/VaporTests/EnvironmentSecretTests.swift
@@ -1,0 +1,56 @@
+@testable import Vapor
+import XCTVapor
+import COperatingSystem
+
+final class EnvironmentSecretTests: XCTestCase {
+    func testNonExistingSecretFile() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/non-existing-secret"
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(path: path, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertNil(secretContent)
+    }
+
+    func testExistingSecretFile() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(path: path, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testExistingSecretFileFromEnvironmentKey() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let key = "MY_ENVIRONMENT_SECRET"
+        setenv(key, path, 1)
+        let app = Application(.testing)
+        defer {
+            app.shutdown()
+            unsetenv(key)
+        }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(key: key, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testLoadingSecretFromEnvKeyWhichDoesNotExist() throws {
+        let key = "MY_NON_EXISTING_ENVIRONMENT_SECRET"
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(key: key, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertNil(secretContent)
+    }
+}

--- a/Tests/VaporTests/Utilities/my-secret-env-content
+++ b/Tests/VaporTests/Utilities/my-secret-env-content
@@ -1,0 +1,1 @@
+password

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run: echo "Testing is done via GitHub actions"
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test
+


### PR DESCRIPTION
This PR fixes #2006.
Detailed description can be found in the issue.
This extensions to the Environment struct provide functions to extract file contents like a secret. This can be used with docker secrets or other secret management tools.

As discussed in #2122 the dependency to the Container struct has been removed and this PR is against the master branch, integrating this feature into Vapor 4.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
