### PR TITLE
Application.run() no longer calls shutdown

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -69,7 +69,6 @@ public final class Application {
     }
     
     public func run() throws {
-        defer { self.shutdown() }
         do {
             try self.start()
             try self.running?.onStop.wait()


### PR DESCRIPTION
Applications are expected to defer application shutdown after initialization:

```swift
let app = try Application(.detect())
defer { app.shutdown() }
```

This prevents scenarios where an error is thrown before the `app.shutdown()` defer block is called which results in an "Application did not shutdown" assertion. 

Because of this, `Application.run()` will no longer attempt to call `shutdown()` which would result in a double shutdown. 