### PR TITLE
Allow nested route building to throw and rethrow

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+Group.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Group.swift
@@ -28,8 +28,8 @@ extension RoutesBuilder {
     /// - parameters:
     ///     - path: Group path components separated by commas.
     ///     - configure: Closure to configure the newly created `Router`.
-    public func group(_ path: PathComponent..., configure: (RoutesBuilder) -> ()) {
-        configure(HTTPRoutesGroup(root: self, path: path))
+    public func group(_ path: PathComponent..., configure: (RoutesBuilder) throws -> ()) rethrows {
+        try configure(HTTPRoutesGroup(root: self, path: path))
     }
 }
 

--- a/Sources/Vapor/Routing/RoutesBuilder+Middleware.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Middleware.swift
@@ -24,8 +24,8 @@ extension RoutesBuilder {
     /// - parameters:
     ///     - middleware: Variadic `Middleware` to wrap `Router` in.
     ///     - configure: Closure to configure the newly created `Router`.
-    public func group(_ middleware: Middleware..., configure: (RoutesBuilder) -> ()) {
-        return self.group(middleware, configure: configure)
+    public func group(_ middleware: Middleware..., configure: (RoutesBuilder) throws -> ()) rethrows {
+        return try self.group(middleware, configure: configure)
     }
 
     /// Creates a new `Router` wrapped in the supplied array of `Middleware`.
@@ -54,8 +54,8 @@ extension RoutesBuilder {
     /// - parameters:
     ///     - middleware: Array of `[Middleware]` to wrap `Router` in.
     ///     - configure: Closure to configure the newly created `Router`.
-    public func group(_ middleware: [Middleware], configure: (RoutesBuilder) -> ()) {
-        configure(MiddlewareGroup(root: self, middleware: middleware))
+    public func group(_ middleware: [Middleware], configure: (RoutesBuilder) throws -> ()) rethrows {
+        try configure(MiddlewareGroup(root: self, middleware: middleware))
     }
 }
 


### PR DESCRIPTION
This PR changes the signature of the `RoutesBuilder.group(_:configure:)` methods to rethrow if the `configure` function throws.

### Rationale

The `RoutesBuilder.register(collection:)` method throws. However, the `configure` function used in the `RoutesBuilder.group(_:configure:)` methods does not throw.

Therefore the following example doesn't currently work:
```swift
let middleware = MyMiddleware()
let controller = MyController()
let routes = Routes()
// error: Invalid conversion from throwing function of type '(_) throws -> ()' to non-throwing function type '(RoutesBuilder) -> ()'
routes.group(middleware) { router in
    try router.register(collection: controller)
}
```

We can use `try!` or `try?` but I think it would be better to just rethrow the error:
```swift
try routes.group(middleware) { router in
    try router.register(collection: controller)
}
```

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.

### Breaking changes

The change *may* break existing code.

This example **does not break**:
```swift
routes.group(middleware) { router in
    nonThrowingFunction(router)
}
```

But this one **does break**:
```swift
let function: ([Middleware], (RoutesBuilder) -> ()) -> ()
// error: Invalid conversion from throwing function of type '([Middleware], (RoutesBuilder) throws -> ()) throws -> ()' to non-throwing function type '([Middleware], (RoutesBuilder) -> ()) -> ()'
function = routes.group(_:configure:)
```
However it is very unlikely to occur in the wild.