### PR TITLE
req.query.decode fix + test res.content.decode added

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -69,7 +69,6 @@ public final class Application {
     }
     
     public func run() throws {
-        defer { self.shutdown() }
         do {
             try self.start()
             try self.running?.onStop.wait()

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -53,10 +53,7 @@ public struct URLEncodedFormDecoder: ContentDecoder, URLQueryDecoder {
     }
     
     public func decode<D>(_ decodable: D.Type, from url: URI) throws -> D where D : Decodable {
-        guard let query = url.query else {
-            throw Abort(.unsupportedMediaType)
-        }
-        return try self.decode(D.self, from: query)
+        return try self.decode(D.self, from: url.query ?? "")
     }
     
 

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -4,6 +4,30 @@ public struct XCTHTTPResponse {
     public var body: Response.Body
 }
 
+extension XCTHTTPResponse {
+    private struct _ContentContainer: ContentContainer {
+        var body: String
+        var headers: HTTPHeaders
+
+        var contentType: HTTPMediaType? {
+            return self.headers.contentType
+        }
+
+        mutating func encode<E>(_ encodable: E, using encoder: ContentEncoder) throws where E : Encodable {
+            fatalError("Encoding to test response is not supported")
+        }
+
+        func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D where D : Decodable {
+            var body = ByteBufferAllocator().buffer(capacity: 0)
+            body.writeString(self.body)
+            return try decoder.decode(D.self, from: body, headers: self.headers)
+        }
+    }
+
+    public var content: ContentContainer {
+        _ContentContainer(body: self.body.string ?? "", headers: self.headers)
+    }
+}
 //    @discardableResult
 //    public func assertStatus(is status: HTTPStatus, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
 //        XCTAssertEqual(self.response.status, status, file: file, line: line)

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -109,14 +109,14 @@ final class ApplicationTests: XCTestCase {
             if case .typeMismatch(_, let context) = error as? DecodingError {
                 XCTAssertEqual(context.debugDescription, "Data found at 'foo' was not Int")
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"DecodingError.typeMismatch\"")
+                XCTFail("Caught error \"\(error)\", but not the expected: \"DecodingError.typeMismatch\"")
             }
         }
         XCTAssertThrowsError(try req.query.get(String.self, at: "bar")) { error in
             if case .valueNotFound(_, let context) = error as? DecodingError {
                 XCTAssertEqual(context.debugDescription, "No String was found at 'bar'")
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"DecodingError.valueNotFound\"")
+                XCTFail("Caught error \"\(error)\", but not the expected: \"DecodingError.valueNotFound\"")
             }
         }
 
@@ -131,10 +131,10 @@ final class ApplicationTests: XCTestCase {
             on: app.eventLoopGroup.next()
         )
         XCTAssertThrowsError(try req.query.get(Int.self, at: "foo")) { error in
-            if let error = error as? Abort {
-                XCTAssertEqual(error.status, .unsupportedMediaType)
+            if let error = error as? DecodingError {
+                XCTAssertEqual(error.status, .badRequest)
             } else {
-                XCTFail("Catched error \"\(error)\", but not the expected: \"\(Abort(.unsupportedMediaType))\"")
+                XCTFail("Caught error \"\(error)\"")
             }
         }
         XCTAssertEqual(req.query[String.self, at: "foo"], nil)


### PR DESCRIPTION
- Fixed a bug where `req.query.decode` would fail if the query string was empty.
- Adds `res.content.decode` to the test responses used by `app.test`.