### PR TITLE
Add swift-backtrace

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,9 @@ let package = Package(
 
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0-beta.3"),
+
+        // 💥 Backtraces for Swift on Linux
+        .package(url: "https://github.com/ianpartridge/swift-backtrace.git", from: "1.1.1"),
         
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.2.0"),
@@ -60,6 +63,7 @@ let package = Package(
         .target(name: "Vapor", dependencies: [
             "AsyncHTTPClient",
             "AsyncKit",
+            "Backtrace",
             "CBcrypt",
             "COperatingSystem",
             "CURLParser",

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -50,6 +50,7 @@ public final class Application {
     }
 
     public init(_ environment: Environment = .development) {
+        Backtrace.install()
         self.environment = environment
         self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         self.locks = .init()

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -1,6 +1,7 @@
 @_exported import AsyncKit
 
 @_exported import class AsyncHTTPClient.HTTPClient
+@_exported import enum Backtrace.Backtrace
 
 @_exported import OpenCrypto
 @_exported import RoutingKit


### PR DESCRIPTION
Adds backtraces to error output from `SIGILL` interrupts on Linux.

```diff
Fatal error: 'try!' expression unexpectedly raised an error: Development.Test(): file /home/vapor/vapor/Sources/Development/routes.swift, line 13
Current stack trace:
0    libswiftCore.so                    0x00007f83289f0ea0 swift_reportError + 50
1    libswiftCore.so                    0x00007f8328a61f40 _swift_stdlib_reportFatalErrorInFile + 115
2    libswiftCore.so                    0x00007f8328985eee <unavailable> + 3514094
3    libswiftCore.so                    0x00007f8328986067 <unavailable> + 3514471
4    libswiftCore.so                    0x00007f832877b7cd <unavailable> + 1374157
5    libswiftCore.so                    0x00007f832895ce48 <unavailable> + 3345992
6    libswiftCore.so                    0x00007f83287b3741 <unavailable> + 1603393
7    Development                        0x0000560f8239a4c0 <unavailable> + 3138752
8    Development                        0x0000560f82396204 <unavailable> + 3121668
9    Development                        0x0000560f82397292 <unavailable> + 3125906
10   libc.so.6                          0x00007f8325f01ab0 __libc_start_main + 231
11   Development                        0x0000560f8214c6ea <unavailable> + 722666
+ 0x560f8219b349, closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install() -> () at /home/vapor/vapor/.build/checkouts/swift-backtrace/Sources/Backtrace/Backtrace.swift:53
+ 0x560f8219b368, @objc closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install() -> () at /home/vapor/vapor/<compiler-generated>:0
+ 0x7f832841f88f
+ 0x7f832895ce55
+ 0x7f83287b3740
+ 0x560f8239a4bf, Development.routes(Vapor.Application) throws -> () at /home/vapor/vapor/Sources/Development/routes.swift:13
+ 0x560f82396203, Development.configure(Vapor.Application) throws -> () at /home/vapor/vapor/Sources/Development/configure.swift:24
+ 0x560f82397291, main at /home/vapor/vapor/Sources/Development/main.swift:5
+ 0x7f8325f01b96
+ 0x560f8214c6e9
+ 0xffffffffffffffff
Illegal instruction (core dumped)
```

You may need to pass `-Xswiftc -g` to `swift build` for the names to demangle correctly.

Backtraces can be printed at any time using the `Backtrace` type:

```
Backtrace.print()
```
