### PR TITLE
Smal Auth/c Patch

### DIFF
--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -39,32 +39,6 @@ extension BearerAuthenticator {
     }
 }
 
-// MARK: User Token
-
-public protocol UserTokenAuthenticator: RequestAuthenticator {
-    associatedtype TokenAuthenticator: RequestAuthenticator where
-        TokenAuthenticator.User: AuthenticationToken,
-        TokenAuthenticator.User.User == User
-
-    var tokenAuthenticator: TokenAuthenticator { get }
-    func authenticate(token: TokenAuthenticator.User, for request: Request) -> EventLoopFuture<User?>
-}
-
-extension UserTokenAuthenticator {
-    public func authenticate(request: Request) -> EventLoopFuture<User?> {
-        return self.tokenAuthenticator.authenticate(request: request).flatMap { token in
-            guard let token = token else {
-                return request.eventLoop.makeSucceededFuture(nil)
-            }
-            return self.authenticate(token: token, for: request)
-        }
-    }
-}
-
-public protocol AuthenticationToken {
-    associatedtype User
-}
-
 // MARK: Credentials
 
 public protocol CredentialsAuthenticator: RequestAuthenticator {

--- a/Sources/Vapor/Utilities/Array+Random.swift
+++ b/Sources/Vapor/Utilities/Array+Random.swift
@@ -25,3 +25,9 @@ extension Array where Element: FixedWidthInteger {
         return array
     }
 }
+
+extension Array where Element == UInt8 {
+    public var base64: String {
+        Data(self).base64EncodedString()
+    }
+}


### PR DESCRIPTION
Removes `UserTokenAuthenticator` since this is redundant with what Fluent now offers. Adds `base64` convenience to `[UInt8]` for generating base-64 encoded strings. 

```swift
[UInt8].random(count: 16).base64
```