### PR TITLE
Add .valid for decoding only validation

### DIFF
--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -8,7 +8,7 @@ public struct Validations {
     public mutating func add<T>(
         _ key: ValidationKey,
         as type: T.Type = T.self,
-        is validator: Validator<T>,
+        is validator: Validator<T> = .valid,
         required: Bool = true
     ) {
         let validation = Validation(key: key, required: required, validator: validator)

--- a/Sources/Vapor/Validation/Validators/Valid.swift
+++ b/Sources/Vapor/Validation/Validators/Valid.swift
@@ -1,0 +1,37 @@
+extension Validator {
+    /// Validates nothing. Can be used as placeholder to validate successful decoding
+    public static var valid: Validator<T> {
+        Valid().validator()
+    }
+    
+    struct Valid { }
+}
+
+extension Validator.Valid: ValidatorType {
+    func validate(_ data: T) -> ValidatorResult {
+        ValidatorResults.Valid()
+    }
+}
+
+
+extension ValidatorResults {
+    /// `ValidatorResult` of a validator that validates that the data is valid`.
+    public struct Valid {
+        /// As this validates nothing, this is always true.
+        public let isValid: Bool = true
+    }
+}
+
+extension ValidatorResults.Valid: ValidatorResult {
+    public var isFailure: Bool {
+        !self.isValid
+    }
+    
+    public var successDescription: String? {
+        "is valid"
+    }
+    
+    public var failureDescription: String? {
+        "is not valid"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vapor/vapor/issues/2154.
- Adding a validation `.valid` which does not actually validate something except the automatically thrown decoding errors. 
- Adding `.valid` as default validation if no validation is provided.

```swift
// OLD (+ workaround for bool)
validations.add("foo", as: Bool.self, is: .in([true, false])) 

// NEW 
validations.add("foo", as: Bool.self, is: .valid)
validations.add("foo", as: Bool.self) // is: can be omitted
validations.add("foo", as: Date.self) // works for all kind of properties
```