### PR TITLE
Add LOG_LEVEL Environment Variable

### DIFF
--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -8,6 +8,7 @@ extension LoggingSystem {
         try LoggingSystem.bootstrap(
             console: Terminal(),
             level: LogSignature(from: &environment.commandInput).level
+                ?? Environment.process.LOG_LEVEL
                 ?? (environment == .production ? .notice: .info)
         )
     }


### PR DESCRIPTION
Allows log level to be set by exporting the `LOG_LEVEL` environment variable.

```sh
export LOG_LEVEL=trace
```

This supports the same values that can be passed to `--log`:

- `trace`
- `debug`
- `info`
- `notice`
- `warning`
- `error`
- `critical`