### PR TITLE
Environment-Specific DotEnv Files

### DIFF
--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,8 +1,7 @@
 import Vapor
 
 public func configure(_ app: Application) throws {
-    try LoggingSystem.bootstrap(from: &app.environment)
-    
+    print(Environment.get("FOO"))
     app.server.configuration.hostname = "127.0.0.1"
     switch app.environment {
     case .tls:

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,6 +1,11 @@
 import Vapor
 
-let app = try Application(.detect())
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+
+let app = try Application(env)
 defer { app.shutdown() }
+
 try configure(app)
+
 try app.run()


### PR DESCRIPTION
Application now attempts to load an environment-specific dotenv file during init. Any values in this file will override values from the default dotenv (#2159, fixes #2156).

For example, say you have the following files:

`.env`
```env
FOO=bar
```
`.env.development`
```env
FOO=baz
```

If you run your app with `--env development` (or `-e dev`), the app will load both files and use `FOO=baz`. If you run your app with `--env production` (or `-e prod`), then only `.env` will be loaded and you will get `FOO=bar`.

This allows for a useful pattern where `.env` files are committed to git, but `.env.*` files are not. On new machines, or during deployment, you can run the following command to generate a new, local dotenv and easily fill out the required values.

```sh
$ cp .env .env.production
```

Note: Variables already existing in the process environment will not be overridden by dotenv files. For example, the following command will always use `FOO=qux` regardless of dotenv file values.

```sh
$ FOO=qux vapor run serve
// or
$ export FOO=qux
$ vapor run serve
```