### PR TITLE
Prevent a crash when decoding a single value from the query container

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -124,6 +124,10 @@ private struct _Decoder: Decoder {
 
     /// See `Decoder`
     func singleValueContainer() throws -> SingleValueDecodingContainer {
+        guard let data = self.data else {
+            throw DecodingError.valueNotFound(Any.self, at: codingPath)
+        }
+
         return SingleValueContainer(data: self.data!, codingPath: codingPath)
     }
     

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -128,7 +128,7 @@ private struct _Decoder: Decoder {
             throw DecodingError.valueNotFound(Any.self, at: codingPath)
         }
 
-        return SingleValueContainer(data: self.data!, codingPath: codingPath)
+        return SingleValueContainer(data: data, codingPath: codingPath)
     }
     
     struct SingleValueContainer: SingleValueDecodingContainer {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -82,6 +82,7 @@ final class ApplicationTests: XCTestCase {
         try XCTAssertEqual(request.query.get(String.self, at: "hello"), "world")
     }
     
+    // https://github.com/vapor/vapor/pull/2163
     func testWrappedSingleValueQueryDecoding() throws {
         let app = Application()
         defer { app.shutdown() }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -78,10 +78,30 @@ final class ApplicationTests: XCTestCase {
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json
         request.url.path = "/foo"
-        print(request.url.string)
         request.url.query = "hello=world"
-        print(request.url.string)
         try XCTAssertEqual(request.query.get(String.self, at: "hello"), "world")
+    }
+    
+    func testWrappedSingleValueQueryDecoding() throws {
+        let app = Application()
+        defer { app.shutdown() }
+
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        request.headers.contentType = .json
+        request.url.path = "/foo"
+        request.url.query = ""
+        
+        // Think of property wrappers, or MongoKitten's ObjectId
+        struct StringWrapper: Decodable {
+            let string: String
+            
+            init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                string = try container.decode(String.self)
+            }
+        }
+        
+        XCTAssertThrowsError(try request.query.get(StringWrapper.self, at: "hello"))
     }
 
     func testQueryGet() throws {


### PR DESCRIPTION
Before this change, decoding a wrapped value from a non-existing query parameter would crash the application. In my usecase, this means that I cannot use ObjectId, but I'm sure there are more libraries implementing wrapped single values like MongoKitten.