### PR TITLE
Migrate the crypto library to Swift Crypto

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "vapor",
     platforms: [
-       .macOS(.v10_14)
+       .macOS(.v10_15)
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0-beta.2"),
 
         // 🔑 Hashing (BCrypt, SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
-        .package(url: "https://github.com/vapor/open-crypto.git", from: "4.0.0-beta.2"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
 
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0-beta.3"),
@@ -79,7 +79,7 @@ let package = Package(
             "NIOHTTP2",
             "NIOSSL",
             "NIOWebSocket",
-            "OpenCrypto",
+            "Crypto",
             "RoutingKit",
             "WebSocketKit",
         ]),

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -3,7 +3,7 @@
 @_exported import class AsyncHTTPClient.HTTPClient
 @_exported import enum Backtrace.Backtrace
 
-@_exported import OpenCrypto
+@_exported import Crypto
 @_exported import RoutingKit
 @_exported import ConsoleKit
 @_exported import Foundation


### PR DESCRIPTION
Migrate from Vapor's OpenCrypto library to Apple's new Swift Crypto library. This reduces the burden on Vapor on having to maintain a crypto library and completely removes OpenSSL as a dependency 🎉

The downside of this is that Vapor 4 will require macOS 10.15, but the tradeoff is worth it.
