### PR TITLE
Adds CacheControl and Expires helpers to HTTPHeaders

### DIFF
--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -124,7 +124,7 @@ extension HTTPHeaders {
                     }
 
                     let parts = str.components(separatedBy: "=")
-                    guard parts.count == 2, let seconds = Int(parts[1]) else {
+                    guard parts.count == 2, let seconds = Int(parts[1]), seconds >= 0 else {
                         return
                     }
 

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -16,33 +16,33 @@ extension HTTPHeaders {
 
         /// Indicates that once a resource becomes stale, caches must not use their stale copy without
         /// successful [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) on the origin server.
-        public var mustRevalidate = false
+        public var mustRevalidate: Bool
 
         /// Caches must check with the origin server for
         /// [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) before using the cached copy.
-        public var noCache = false
+        public var noCache: Bool
 
         /// The cache **should not store anything** about the client request or server response.
-        public var noStore = false
+        public var noStore: Bool
 
         /// No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified
         /// by a proxy. A non-transparent proxy or browser feature such as
         /// [Google's Light Mode](https://support.google.com/webmasters/answer/6211428?hl=en) might, for example, convert between image
         /// formats in order to save cache space or to reduce the amount of traffic on a slow link. The `no-transform` directive disallows this.
-        public var noTransform = false
+        public var noTransform: Bool
 
         /// The response may be cached by any cache, even if the response is normally non-cacheable
-        public var isPublic = false
+        public var isPublic: Bool
 
         /// The response is for a single user and **must not** be stored by a shared cache. A private cache (like the user's browser cache) may store the response.
-        public var isPrivate = false
+        public var isPrivate: Bool
 
         /// Like `must-revalidate`, but only for shared caches (e.g., proxies). Ignored by private caches.
-        public var proxyRevalidate = false
+        public var proxyRevalidate: Bool
 
         /// Indicates to not retrieve new data. This being the case, the server wishes the client to obtain a response only once and then cache. From this moment the
         /// client should keep releasing a cached copy and avoid contacting the origin-server to see if a newer copy exists.
-        public var onlyIfCached = false
+        public var onlyIfCached: Bool
 
         /// Indicates that the response body **will not change** over time.
         ///
@@ -50,7 +50,7 @@ extension HTTPHeaders {
         /// not send a conditional revalidation for it (e.g. `If-None-Match` or `If-Modified-Since`) to check for updates, even when the user explicitly refreshes
         /// the page. Clients that aren't aware of this extension must ignore them as per the HTTP specification. In Firefox, immutable is only honored on https:// transactions.
         /// For more information, see also this [blog post](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html).
-        public var immutable = false
+        public var immutable: Bool
 
         /// The maximum amount of time a resource is considered fresh. Unlike the`Expires` header, this directive is relative to the time of the request.
         public var maxAge: Int?
@@ -69,6 +69,18 @@ extension HTTPHeaders {
 
         /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
         public var staleIfError: Int?
+
+        public init() {
+            self.mustRevalidate = false
+            self.noCache = false
+            self.noStore = false
+            self.noTransform = false
+            self.isPublic = false
+            self.isPrivate = false
+            self.proxyRevalidate = false
+            self.onlyIfCached = false
+            self.immutable = false
+        }
 
         private static let exactMatch: [String: WritableKeyPath<Self, Bool>] = [
             "must-revalidate": \.mustRevalidate,
@@ -163,12 +175,12 @@ extension HTTPHeaders {
 
     /// Gets the value of the `Cache-Control` header, if present.
     public var cacheControl: CacheControl? {
-        get { firstValue(name: .cacheControl).flatMap(CacheControl.parse) }
+        get { self.firstValue(name: .cacheControl).flatMap(CacheControl.parse) }
         set {
             if let new = newValue?.serialize() {
-                replaceOrAdd(name: .cacheControl, value: new)
+                self.replaceOrAdd(name: .cacheControl, value: new)
             } else {
-                remove(name: .expires)
+                self.remove(name: .expires)
             }
         }
     }

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -1,0 +1,152 @@
+import NIO
+
+// Comments on these properties are copied from the mozilla doc URL shown below.
+
+/// Represents the HTTP `Cache-Control` header.
+/// - See Also:
+/// [Cache-Control docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+public struct HTTPHeaderCacheControl: OptionSet, ExpressibleByStringLiteral {
+    // MARK: - Option Values
+
+    /// Indicates that once a resource becomes stale, caches must not use their stale copy without
+    /// successful [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) on the origin server.
+    public static let mustRevalidate = Self(rawValue: 1 << 0)
+
+    /// Caches must check with the origin server for
+    /// [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) before using the cached copy.
+    public static let noCache = Self(rawValue: 1 << 1)
+
+    /// The cache **should not store anything** about the client request or server response.
+    public static let noStore = Self(rawValue: 1 << 2)
+
+    /// No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified
+    /// by a proxy. A non-transparent proxy or browser feature such as
+    /// [Google's Light Mode](https://support.google.com/webmasters/answer/6211428?hl=en) might, for example, convert between image
+    /// formats in order to save cache space or to reduce the amount of traffic on a slow link. The `no-transform` directive disallows this.
+    public static let noTransform = Self(rawValue: 1 << 3)
+
+    /// The response may be cached by any cache, even if the response is normally non-cacheable
+    public static let isPublic = Self(rawValue: 1 << 4)
+
+    /// The response is for a single user and **must not** be stored by a shared cache. A private cache (like the user's browser cache) may store the response.
+    public static let isPrivate = Self(rawValue: 1 << 5)
+
+    /// Like `must-revalidate`, but only for shared caches (e.g., proxies). Ignored by private caches.
+    public static let proxyRevalidate = Self(rawValue: 1 << 6)
+
+    /// Indicates to not retrieve new data. This being the case, the server wishes the client to obtain a response only once and then cache. From this moment the
+    /// client should keep releasing a cached copy and avoid contacting the origin-server to see if a newer copy exists.
+    public static let onlyIfCached = Self(rawValue: 1 << 7)
+
+    /// Indicates the client will accept a stale response.  If the `maxStale` property is set, indicates the upper limit of staleness the client will accept.
+    public static let maxStale = Self(rawValue: 1 << 8)
+
+    /// Indicates that the response body **will not change** over time.
+    ///
+    /// The resource, if *unexpired*, is unchanged on the server and therefore the client should
+    /// not send a conditional revalidation for it (e.g. `If-None-Match` or `If-Modified-Since`) to check for updates, even when the user explicitly refreshes
+    /// the page. Clients that aren't aware of this extension must ignore them as per the HTTP specification. In Firefox, immutable is only honored on https:// transactions.
+    /// For more information, see also this [blog post](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html).
+    public static let immutable = Self(rawValue: 1 << 9)
+
+    // MARK: - Properties
+    public var rawValue = 0
+
+    /// The maximum amount of time a resource is considered fresh. Unlike the`Expires` header, this directive is relative to the time of the request.
+    public var maxAge: Int?
+
+    /// Overrides max-age or the Expires header, but only for shared caches (e.g., proxies). Ignored by private caches.
+    public var sMaxAge: Int?
+
+    /// Indicates the client will accept a stale response. An optional value in seconds indicates the upper limit of staleness the client will accept.
+    public var maxStale: Int?
+
+    /// Indicates the client wants a response that will still be fresh for at least the specified number of seconds.
+    public var minFresh: Int?
+
+    /// Indicates the client will accept a stale response, while asynchronously checking in the background for a fresh one. The value indicates how long the client will accept a stale response.
+    public var staleWhileRevalidate: Int?
+
+    /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
+    public var staleIfError: Int?
+
+    /// Initializes the class
+    /// - Parameter rawValue: The initial value.
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    private static let exactMatch: [String: Self] = [
+        "must-revalidate": Self.mustRevalidate,
+        "no-cache": Self.noCache,
+        "no-store": Self.noStore,
+        "no-transform": Self.noTransform,
+        "public": Self.isPublic,
+        "private": Self.isPrivate,
+        "proxy-revalidate": Self.proxyRevalidate,
+        "only-if-cached": Self.onlyIfCached,
+        "max-stale": Self.maxStale
+    ]
+
+    private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
+        "max-age": \.maxAge,
+        "s-maxage": \.sMaxAge,
+        "max-stale": \.maxStale,
+        "min-fresh": \.minFresh,
+        "stale-while-revalidate": \.staleWhileRevalidate,
+        "stale-if-error": \.staleIfError
+    ]
+
+    /// Initializes the class
+    /// - Parameter value: The HTTP header string value.
+    public init(stringLiteral value: String) {
+        var set = CharacterSet.whitespacesAndNewlines
+        set.insert(",")
+
+        value
+            .filter { !($0.isWhitespace || $0.isNewline) }
+            .components(separatedBy: set)
+            .forEach {
+                let str = $0.lowercased()
+
+                if let value = Self.exactMatch[str] {
+                    insert(value)
+                    return
+                }
+
+                let parts = str.components(separatedBy: "=")
+                guard parts.count == 2, let keyPath = Self.prefix[parts[0]], let seconds = Int(parts[1]) else {
+                    return
+                }
+
+                if keyPath == \.maxStale {
+                    insert(Self.maxStale)
+                }
+
+                self[keyPath: keyPath] = seconds
+        }
+    }
+
+    /// Initializes the class
+    /// - Parameter headers: The `HTTPHeaders`
+    public init?(headers: HTTPHeaders) {
+        guard let str = headers.firstValue(name: .cacheControl) else {
+            return nil
+        }
+
+        self.init(stringLiteral: str)
+    }
+
+    /// Generates the header string for this instance.
+    public func toString() -> String {
+        let options = Self.exactMatch
+            .filter { contains($0.value) }
+            .map { $0.key }
+
+        let optionsWithSeconds = Self.prefix
+            .filter { self[keyPath: $0.value] != nil }
+            .map { "\($0.key)=\(self[keyPath: $0.value]!)" }
+
+        return (options + optionsWithSeconds).joined(separator: ", ")
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -1,152 +1,163 @@
 import NIO
 
 // Comments on these properties are copied from the mozilla doc URL shown below.
+extension HTTPHeaders {
+    /// Represents the HTTP `Cache-Control` header.
+    /// - See Also:
+    /// [Cache-Control docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+    public struct CacheControl: OptionSet {
+        // MARK: - Option Values
 
-/// Represents the HTTP `Cache-Control` header.
-/// - See Also:
-/// [Cache-Control docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
-public struct HTTPHeaderCacheControl: OptionSet, ExpressibleByStringLiteral {
-    // MARK: - Option Values
+        /// Indicates that once a resource becomes stale, caches must not use their stale copy without
+        /// successful [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) on the origin server.
+        public static let mustRevalidate = Self(rawValue: 1 << 0)
 
-    /// Indicates that once a resource becomes stale, caches must not use their stale copy without
-    /// successful [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) on the origin server.
-    public static let mustRevalidate = Self(rawValue: 1 << 0)
+        /// Caches must check with the origin server for
+        /// [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) before using the cached copy.
+        public static let noCache = Self(rawValue: 1 << 1)
 
-    /// Caches must check with the origin server for
-    /// [validation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#Cache_validation) before using the cached copy.
-    public static let noCache = Self(rawValue: 1 << 1)
+        /// The cache **should not store anything** about the client request or server response.
+        public static let noStore = Self(rawValue: 1 << 2)
 
-    /// The cache **should not store anything** about the client request or server response.
-    public static let noStore = Self(rawValue: 1 << 2)
+        /// No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified
+        /// by a proxy. A non-transparent proxy or browser feature such as
+        /// [Google's Light Mode](https://support.google.com/webmasters/answer/6211428?hl=en) might, for example, convert between image
+        /// formats in order to save cache space or to reduce the amount of traffic on a slow link. The `no-transform` directive disallows this.
+        public static let noTransform = Self(rawValue: 1 << 3)
 
-    /// No transformations or conversions should be made to the resource. The Content-Encoding, Content-Range, Content-Type headers must not be modified
-    /// by a proxy. A non-transparent proxy or browser feature such as
-    /// [Google's Light Mode](https://support.google.com/webmasters/answer/6211428?hl=en) might, for example, convert between image
-    /// formats in order to save cache space or to reduce the amount of traffic on a slow link. The `no-transform` directive disallows this.
-    public static let noTransform = Self(rawValue: 1 << 3)
+        /// The response may be cached by any cache, even if the response is normally non-cacheable
+        public static let isPublic = Self(rawValue: 1 << 4)
 
-    /// The response may be cached by any cache, even if the response is normally non-cacheable
-    public static let isPublic = Self(rawValue: 1 << 4)
+        /// The response is for a single user and **must not** be stored by a shared cache. A private cache (like the user's browser cache) may store the response.
+        public static let isPrivate = Self(rawValue: 1 << 5)
 
-    /// The response is for a single user and **must not** be stored by a shared cache. A private cache (like the user's browser cache) may store the response.
-    public static let isPrivate = Self(rawValue: 1 << 5)
+        /// Like `must-revalidate`, but only for shared caches (e.g., proxies). Ignored by private caches.
+        public static let proxyRevalidate = Self(rawValue: 1 << 6)
 
-    /// Like `must-revalidate`, but only for shared caches (e.g., proxies). Ignored by private caches.
-    public static let proxyRevalidate = Self(rawValue: 1 << 6)
+        /// Indicates to not retrieve new data. This being the case, the server wishes the client to obtain a response only once and then cache. From this moment the
+        /// client should keep releasing a cached copy and avoid contacting the origin-server to see if a newer copy exists.
+        public static let onlyIfCached = Self(rawValue: 1 << 7)
 
-    /// Indicates to not retrieve new data. This being the case, the server wishes the client to obtain a response only once and then cache. From this moment the
-    /// client should keep releasing a cached copy and avoid contacting the origin-server to see if a newer copy exists.
-    public static let onlyIfCached = Self(rawValue: 1 << 7)
+        /// Indicates the client will accept a stale response.  If the `maxStale` property is set, indicates the upper limit of staleness the client will accept.
+        public static let maxStale = Self(rawValue: 1 << 8)
 
-    /// Indicates the client will accept a stale response.  If the `maxStale` property is set, indicates the upper limit of staleness the client will accept.
-    public static let maxStale = Self(rawValue: 1 << 8)
+        /// Indicates that the response body **will not change** over time.
+        ///
+        /// The resource, if *unexpired*, is unchanged on the server and therefore the client should
+        /// not send a conditional revalidation for it (e.g. `If-None-Match` or `If-Modified-Since`) to check for updates, even when the user explicitly refreshes
+        /// the page. Clients that aren't aware of this extension must ignore them as per the HTTP specification. In Firefox, immutable is only honored on https:// transactions.
+        /// For more information, see also this [blog post](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html).
+        public static let immutable = Self(rawValue: 1 << 9)
 
-    /// Indicates that the response body **will not change** over time.
-    ///
-    /// The resource, if *unexpired*, is unchanged on the server and therefore the client should
-    /// not send a conditional revalidation for it (e.g. `If-None-Match` or `If-Modified-Since`) to check for updates, even when the user explicitly refreshes
-    /// the page. Clients that aren't aware of this extension must ignore them as per the HTTP specification. In Firefox, immutable is only honored on https:// transactions.
-    /// For more information, see also this [blog post](https://bitsup.blogspot.de/2016/05/cache-control-immutable.html).
-    public static let immutable = Self(rawValue: 1 << 9)
+        // MARK: - Properties
+        public var rawValue = 0
 
-    // MARK: - Properties
-    public var rawValue = 0
+        /// The maximum amount of time a resource is considered fresh. Unlike the`Expires` header, this directive is relative to the time of the request.
+        public var maxAge: Int?
 
-    /// The maximum amount of time a resource is considered fresh. Unlike the`Expires` header, this directive is relative to the time of the request.
-    public var maxAge: Int?
+        /// Overrides max-age or the Expires header, but only for shared caches (e.g., proxies). Ignored by private caches.
+        public var sMaxAge: Int?
 
-    /// Overrides max-age or the Expires header, but only for shared caches (e.g., proxies). Ignored by private caches.
-    public var sMaxAge: Int?
+        /// Indicates the client will accept a stale response. An optional value in seconds indicates the upper limit of staleness the client will accept.
+        public var maxStale: Int?
 
-    /// Indicates the client will accept a stale response. An optional value in seconds indicates the upper limit of staleness the client will accept.
-    public var maxStale: Int?
+        /// Indicates the client wants a response that will still be fresh for at least the specified number of seconds.
+        public var minFresh: Int?
 
-    /// Indicates the client wants a response that will still be fresh for at least the specified number of seconds.
-    public var minFresh: Int?
+        /// Indicates the client will accept a stale response, while asynchronously checking in the background for a fresh one. The value indicates how long the client will accept a stale response.
+        public var staleWhileRevalidate: Int?
 
-    /// Indicates the client will accept a stale response, while asynchronously checking in the background for a fresh one. The value indicates how long the client will accept a stale response.
-    public var staleWhileRevalidate: Int?
+        /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
+        public var staleIfError: Int?
 
-    /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
-    public var staleIfError: Int?
+        /// Initializes the class
+        /// - Parameter rawValue: The initial value.
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
 
-    /// Initializes the class
-    /// - Parameter rawValue: The initial value.
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
+        private static let exactMatch: [String: Self] = [
+            "must-revalidate": Self.mustRevalidate,
+            "no-cache": Self.noCache,
+            "no-store": Self.noStore,
+            "no-transform": Self.noTransform,
+            "public": Self.isPublic,
+            "private": Self.isPrivate,
+            "proxy-revalidate": Self.proxyRevalidate,
+            "only-if-cached": Self.onlyIfCached,
+            "max-stale": Self.maxStale
+        ]
 
-    private static let exactMatch: [String: Self] = [
-        "must-revalidate": Self.mustRevalidate,
-        "no-cache": Self.noCache,
-        "no-store": Self.noStore,
-        "no-transform": Self.noTransform,
-        "public": Self.isPublic,
-        "private": Self.isPrivate,
-        "proxy-revalidate": Self.proxyRevalidate,
-        "only-if-cached": Self.onlyIfCached,
-        "max-stale": Self.maxStale
-    ]
+        private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
+            "max-age": \.maxAge,
+            "s-maxage": \.sMaxAge,
+            "max-stale": \.maxStale,
+            "min-fresh": \.minFresh,
+            "stale-while-revalidate": \.staleWhileRevalidate,
+            "stale-if-error": \.staleIfError
+        ]
 
-    private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
-        "max-age": \.maxAge,
-        "s-maxage": \.sMaxAge,
-        "max-stale": \.maxStale,
-        "min-fresh": \.minFresh,
-        "stale-while-revalidate": \.staleWhileRevalidate,
-        "stale-if-error": \.staleIfError
-    ]
+        internal static func parse(_ value: String) -> CacheControl? {
+            var set = CharacterSet.whitespacesAndNewlines
+            set.insert(",")
 
-    /// Initializes the class
-    /// - Parameter value: The HTTP header string value.
-    public init(stringLiteral value: String) {
-        var set = CharacterSet.whitespacesAndNewlines
-        set.insert(",")
+            var foundSomething = false
 
-        value
-            .filter { !($0.isWhitespace || $0.isNewline) }
-            .components(separatedBy: set)
-            .forEach {
-                let str = $0.lowercased()
+            var cache = CacheControl()
 
-                if let value = Self.exactMatch[str] {
-                    insert(value)
-                    return
-                }
+            value
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .split(separator: ",")
+                .forEach {
+                    let str = String($0)
+                    
+                    if let value = Self.exactMatch[str] {
+                        cache.insert(value)
+                        foundSomething = true
+                        return
+                    }
 
-                let parts = str.components(separatedBy: "=")
-                guard parts.count == 2, let keyPath = Self.prefix[parts[0]], let seconds = Int(parts[1]) else {
-                    return
-                }
+                    let parts = str.components(separatedBy: "=")
+                    guard parts.count == 2, let keyPath = Self.prefix[parts[0]], let seconds = Int(parts[1]) else {
+                        return
+                    }
 
-                if keyPath == \.maxStale {
-                    insert(Self.maxStale)
-                }
+                    if keyPath == \.maxStale {
+                        cache.insert(Self.maxStale)
+                        foundSomething = true
+                    }
 
-                self[keyPath: keyPath] = seconds
+                    cache[keyPath: keyPath] = seconds
+                    foundSomething = true
+            }
+
+            return foundSomething ? cache : nil
+        }
+
+        /// Generates the header string for this instance.
+        public func serialize() -> String {
+            let options = Self.exactMatch
+                .filter { contains($0.value) }
+                .map { $0.key }
+
+            let optionsWithSeconds = Self.prefix
+                .filter { self[keyPath: $0.value] != nil }
+                .map { "\($0.key)=\(self[keyPath: $0.value]!)" }
+
+            return (options + optionsWithSeconds).joined(separator: ", ")
         }
     }
 
-    /// Initializes the class
-    /// - Parameter headers: The `HTTPHeaders`
-    public init?(headers: HTTPHeaders) {
-        guard let str = headers.firstValue(name: .cacheControl) else {
-            return nil
+    /// Gets the value of the `Cache-Control` header, if present.
+    public var cacheControl: CacheControl? {
+        get { firstValue(name: .cacheControl).flatMap(CacheControl.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                replaceOrAdd(name: .cacheControl, value: new)
+            } else {
+                remove(name: .expires)
+            }
         }
-
-        self.init(stringLiteral: str)
-    }
-
-    /// Generates the header string for this instance.
-    public func toString() -> String {
-        let options = Self.exactMatch
-            .filter { contains($0.value) }
-            .map { $0.key }
-
-        let optionsWithSeconds = Self.prefix
-            .filter { self[keyPath: $0.value] != nil }
-            .map { "\($0.key)=\(self[keyPath: $0.value]!)" }
-
-        return (options + optionsWithSeconds).joined(separator: ", ")
     }
 }

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -141,14 +141,22 @@ extension HTTPHeaders {
 
         /// Generates the header string for this instance.
         public func serialize() -> String {
-            let options = Self.exactMatch
+            var options = Self.exactMatch
                 .filter { self[keyPath: $0.value] == true }
                 .map { $0.key }
 
-            let optionsWithSeconds = Self.prefix
+            var optionsWithSeconds = Self.prefix
                 .filter { self[keyPath: $0.value] != nil }
                 .map { "\($0.key)=\(self[keyPath: $0.value]!)" }
 
+            if let maxStale = self.maxStale {
+                if let seconds = maxStale.seconds {
+                    optionsWithSeconds.append("max-stale=\(seconds)")
+                } else {
+                    options.append("max-stale")
+                }
+            }
+            
             return (options + optionsWithSeconds).joined(separator: ", ")
         }
     }

--- a/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
@@ -1,0 +1,57 @@
+import NIO
+
+public struct HTTPHeaderExpires {
+    /// The date represented by the header.
+    public let expires: Date
+
+    init?(dateString: String) {
+        // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        
+        if let date = fmt.date(from: dateString) {
+            expires = date
+            return
+        }
+
+        // Obsolete RFC 850 format
+        fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        if let date = fmt.date(from: dateString) {
+            expires = date
+            return
+        }
+
+        // Obsolete ANSI C asctime() format
+        fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
+        if let date = fmt.date(from: dateString) {
+            expires = date
+            return
+        }
+
+        return nil
+    }
+
+    init?(headers: HTTPHeaders) {
+        guard let str = headers.firstValue(name: .expires) else {
+            return nil
+        }
+
+        self.init(dateString: str)
+    }
+
+    init(expires: Date) {
+        self.expires = expires
+    }
+
+    /// Generates the header string for this instance.
+    public func toString() -> String {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+        return fmt.string(from: expires)
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderExpires.swift
@@ -1,57 +1,62 @@
 import NIO
 
-public struct HTTPHeaderExpires {
-    /// The date represented by the header.
-    public let expires: Date
+extension HTTPHeaders {
+    public struct Expires {
+        /// The date represented by the header.
+        public let expires: Date
 
-    init?(dateString: String) {
-        // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
-        let fmt = DateFormatter()
-        fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone(secondsFromGMT: 0)
-        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
-        
-        if let date = fmt.date(from: dateString) {
-            expires = date
-            return
-        }
+        internal static func parse(_ dateString: String) -> Expires? {
+            // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
 
-        // Obsolete RFC 850 format
-        fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
-        if let date = fmt.date(from: dateString) {
-            expires = date
-            return
-        }
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
 
-        // Obsolete ANSI C asctime() format
-        fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
-        if let date = fmt.date(from: dateString) {
-            expires = date
-            return
-        }
+            // Obsolete RFC 850 format
+            fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
 
-        return nil
-    }
+            // Obsolete ANSI C asctime() format
+            fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
+            if let date = fmt.date(from: dateString) {
+                return .init(expires: date)
+            }
 
-    init?(headers: HTTPHeaders) {
-        guard let str = headers.firstValue(name: .expires) else {
             return nil
         }
 
-        self.init(dateString: str)
+        init(expires: Date) {
+            self.expires = expires
+        }
+
+        /// Generates the header string for this instance.
+        public func serialize() -> String {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+
+            return fmt.string(from: expires)
+        }
     }
 
-    init(expires: Date) {
-        self.expires = expires
-    }
-
-    /// Generates the header string for this instance.
-    public func toString() -> String {
-        let fmt = DateFormatter()
-        fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone(secondsFromGMT: 0)
-        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
-
-        return fmt.string(from: expires)
+    /// Gets the value of the `Expires` header, if present.
+    /// ### Note ###
+    /// `Expires` is legacy and you should switch to using `CacheControl` if possible.
+    public var expires: Expires? {
+        get { firstValue(name: .expires).flatMap(Expires.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                self.replaceOrAdd(name: .expires, value: new)
+            } else {
+                self.remove(name: .expires)
+            }
+        }
     }
 }

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -14,7 +14,7 @@ extension HTTPHeaders {
     public func getExpirationDate(requestSentAt: Date) -> Date? {
         // Cache-Control header takes priority over the Expires header
         if let cacheControl = cacheControl {
-            guard !cacheControl.contains(.noStore) else {
+            guard cacheControl.noStore == false else {
                 return nil
             }
 

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -1,20 +1,4 @@
 extension HTTPHeaders {
-    /// Gets the value of the `Cache-Control` header, if present.
-    public func getCacheControl() -> HTTPHeaderCacheControl? {
-        guard let cacheControl = firstValue(name: .cacheControl) else {
-            return nil
-        }
-
-        return HTTPHeaderCacheControl(stringLiteral: cacheControl)
-    }
-
-    /// Gets the value of the `Expires` header, if present.
-    /// ### Note ###
-    /// `Expires` is legacy and you should switch to using `Cache-Control` if possible.
-    public func getExpires() -> HTTPHeaderExpires? {
-        HTTPHeaderExpires(headers: self)
-    }
-
     /// Determines when the cached data should be expired.
     ///
     /// This first checks to see if the `Cache-Control` header is present.  If it is, and `no-store`
@@ -23,10 +7,13 @@ extension HTTPHeaders {
     ///
     /// If no `Cache-Control` header is present then it will examine the `Expires` header.
     ///
+    /// If you need finer grained details about what type of caching, validation, etc... you should instead
+    /// grab the `cacheControl` and `expires` headers yourself.
+    ///
     /// - Parameter requestSentAt: Should be passed the `Date` when the request was sent.
     public func getExpirationDate(requestSentAt: Date) -> Date? {
         // Cache-Control header takes priority over the Expires header
-        if let cacheControl = getCacheControl() {
+        if let cacheControl = cacheControl {
             guard !cacheControl.contains(.noStore) else {
                 return nil
             }
@@ -36,7 +23,7 @@ extension HTTPHeaders {
             }
         }
 
-        if let expires = getExpires() {
+        if let expires = expires {
             return expires.expires
         }
 

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -1,93 +1,43 @@
 extension HTTPHeaders {
-    private enum CacheDateResponse {
-        case set(Date?)
-        case ignore
+    /// Gets the value of the `Cache-Control` header, if present.
+    public func getCacheControl() -> HTTPHeaderCacheControl? {
+        guard let cacheControl = firstValue(name: .cacheControl) else {
+            return nil
+        }
+
+        return HTTPHeaderCacheControl(stringLiteral: cacheControl)
+    }
+
+    /// Gets the value of the `Expires` header, if present.
+    /// ### Note ###
+    /// `Expires` is legacy and you should switch to using `Cache-Control` if possible.
+    public func getExpires() -> HTTPHeaderExpires? {
+        HTTPHeaderExpires(headers: self)
     }
 
     /// Determines when the cached data should be expired.
+    ///
+    /// This first checks to see if the `Cache-Control` header is present.  If it is, and `no-store`
+    /// is set, then `nil` is returned.  If `no-store` is not present, and there is a `max-age` then
+    /// the expiration will add that many seconds to `requestSentAt`.
+    ///
+    /// If no `Cache-Control` header is present then it will examine the `Expires` header.
+    ///
     /// - Parameter requestSentAt: Should be passed the `Date` when the request was sent.
-    public func getCacheExpiration(requestSentAt: Date) -> Date? {
+    public func getExpirationDate(requestSentAt: Date) -> Date? {
         // Cache-Control header takes priority over the Expires header
-        if case let .set(date) = cacheControlDate(requestSentAt: requestSentAt) {
-            return date
-        }
-
-        if let expires = expiresDate() {
-            return expires
-        }
-
-        return nil
-    }
-
-    private func cacheControlDate(requestSentAt: Date) -> CacheDateResponse {
-        guard let cacheControl = firstValue(name: .cacheControl) else {
-            return .ignore
-        }
-
-        let pattern = #"^max-age=(\d+)$"#
-        let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-
-        var set = CharacterSet.whitespacesAndNewlines
-        set.insert(",")
-
-        var newDate: Date?
-
-        let components = cacheControl
-            .filter { !($0.isWhitespace || $0.isNewline) }
-            .components(separatedBy: set)
-
-        for value in components {
-            if value == "no-store" {
-                return .set(nil)
+        if let cacheControl = getCacheControl() {
+            guard !cacheControl.contains(.noStore) else {
+                return nil
             }
 
-            let nsRange = NSRange(value.startIndex ..< value.endIndex, in: value)
-
-            guard let match = regex.firstMatch(in: value, options: [], range: nsRange),
-                let range = Range(match.range(at: 1), in: value),
-                let maxAge = TimeInterval(value[range]) else {
-                    continue
+            if let age = cacheControl.maxAge {
+                return requestSentAt.addingTimeInterval(TimeInterval(age))
             }
-
-            guard maxAge != 0 else {
-                return .set(nil)
-            }
-
-            // Don't immediately return as we may still find a no-store option.
-            newDate = requestSentAt.addingTimeInterval(maxAge)
         }
 
-        guard let desired = newDate else {
-            return .ignore
-        }
-
-        return .set(desired)
-    }
-
-    private func expiresDate() -> Date? {
-        guard let expires = firstValue(name: .expires) else { return nil }
-
-        // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
-        let fmt = DateFormatter()
-        fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone(secondsFromGMT: 0)
-
-        // Preferred format
-        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
-        if let date = fmt.date(from: expires) {
-            return date
-        }
-
-        // Obsolete RFC 850 format
-        fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
-        if let date = fmt.date(from: expires) {
-            return date
-        }
-
-        // Obsolete ANSI C asctime() format
-        fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
-        if let date = fmt.date(from: expires) {
-            return date
+        if let expires = getExpires() {
+            return expires.expires
         }
 
         return nil

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -1,0 +1,83 @@
+extension HTTPHeaders {
+    private enum CacheDateResponse {
+        case set(Date?)
+        case ignore
+    }
+
+    /// Determines when the cached data should be expired.
+    /// - Parameter requestSentAt: Should be passed the `Date` when the request was sent.
+    public func getCacheExpiration(requestSentAt: Date) -> Date? {
+        // Cache-Control header takes priority over the Expires header
+        if case let .set(date) = self.cacheControlDate(requestSentAt: requestSentAt) {
+            return date
+        }
+
+        guard let expires = self.firstValue(name: .expires) else { return nil }
+
+        // https://tools.ietf.org/html/rfc7231#section-7.1.1.1
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+
+        // Preferred format
+        fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        if let date = fmt.date(from: expires) {
+            return date
+        }
+
+        // Obsolete RFC 850 format
+        fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        if let date = fmt.date(from: expires) {
+            return date
+        }
+
+        // Obsolete ANSI C asctime() format
+        fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
+        if let date = fmt.date(from: expires) {
+            return date
+        }
+
+        return nil
+    }
+
+    private func cacheControlDate(requestSentAt: Date) -> CacheDateResponse {
+        guard let cacheControl = self.firstValue(name: .cacheControl) else {
+            return .ignore
+        }
+
+        let pattern = #"^max-age\s*=\s*(\d+)$"#
+        let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+        var set = CharacterSet.whitespacesAndNewlines
+        set.insert(",")
+
+        var newDate: Date?
+
+        for value in cacheControl.components(separatedBy: set) {
+            if value == "no-store" {
+                return .set(nil)
+            }
+
+            let nsRange = NSRange(value.startIndex ..< value.endIndex, in: value)
+
+            guard let match = regex.firstMatch(in: value, options: [], range: nsRange),
+                let range = Range(match.range(at: 1), in: value),
+                let maxAge = TimeInterval(value[range]) else {
+                    continue
+            }
+
+            guard maxAge != 0 else {
+                return .set(nil)
+            }
+
+            // Don't immediately return as we may still find a no-store option.
+            newDate = requestSentAt.addingTimeInterval(maxAge)
+        }
+
+        guard let desired = newDate else {
+            return .ignore
+        }
+
+        return .set(desired)
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Cache.swift
@@ -11,7 +11,7 @@ extension HTTPHeaders {
     /// grab the `cacheControl` and `expires` headers yourself.
     ///
     /// - Parameter requestSentAt: Should be passed the `Date` when the request was sent.
-    public func getExpirationDate(requestSentAt: Date) -> Date? {
+    public func expirationDate(requestSentAt: Date) -> Date? {
         // Cache-Control header takes priority over the Expires header
         if let cacheControl = cacheControl {
             guard cacheControl.noStore == false else {

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -10,7 +10,7 @@ class CacheTests: XCTestCase {
 
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
     }
 
     func testNoStore() {
@@ -18,7 +18,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
     }
 
     func testMaxAge() {
@@ -29,7 +29,7 @@ class CacheTests: XCTestCase {
 
         let required = requested.addingTimeInterval(TimeInterval(seconds))
 
-        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
+        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: requested), required)
     }
 
     func testNoMatching() {
@@ -37,12 +37,12 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
     }
 
     func testMissingHeader() {
         let response = ClientResponse(status: .ok)
-        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: Date()))
+        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: Date()))
     }
 
     private func dateFromFormat(format: String, dateStr: String) -> Date {
@@ -61,7 +61,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
     }
 
     func testObsoleteFormatOne() {
@@ -71,7 +71,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
     }
 
     func testObsoleteFormatTwo() {
@@ -81,7 +81,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
     }
 
     func testMaxAgeOverridesExpires() {
@@ -95,6 +95,6 @@ class CacheTests: XCTestCase {
 
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
+        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: requested), required)
     }
 }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -97,4 +97,34 @@ class CacheTests: XCTestCase {
 
         XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: requested), required)
     }
+
+    func testFlags() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertTrue(response.headers.cacheControl!.noStore)
+        XCTAssertFalse(response.headers.cacheControl!.immutable)
+        XCTAssertEqual(response.headers.cacheControl!.maxAge, 12)
+    }
+
+    func textMaxStaleNoValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNil(cache.maxStale?.seconds)
+    }
+
+    func textMaxStaleNoWithValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNotNil(cache.maxStale?.seconds)
+        XCTAssertEqual(cache.maxStale?.seconds, 12)
+    }
 }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -8,7 +8,7 @@ class CacheTests: XCTestCase {
         headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
         headers.add(name: .cacheControl, value: "no-store, max-age=12")
 
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
     }
@@ -16,7 +16,7 @@ class CacheTests: XCTestCase {
     func testNoStore() {
         let requested = Date()
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
     }
@@ -25,7 +25,7 @@ class CacheTests: XCTestCase {
         let seconds = Int.random(in: 1...3_000_333)
         let requested = Date()
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-age=\(seconds)"))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         let required = requested.addingTimeInterval(TimeInterval(seconds))
 
@@ -35,9 +35,14 @@ class CacheTests: XCTestCase {
     func testNoMatching() {
         let requested = Date()
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+    }
+
+    func testMissingHeader() {
+        let response = ClientResponse(status: .ok)
+        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: Date()))
     }
 
     private func dateFromFormat(format: String, dateStr: String) -> Date {
@@ -54,7 +59,7 @@ class CacheTests: XCTestCase {
         let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
     }
@@ -64,7 +69,7 @@ class CacheTests: XCTestCase {
         let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
     }
@@ -74,7 +79,7 @@ class CacheTests: XCTestCase {
         let format = "EEE MMM d hh:mm:s yyyy"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
     }
@@ -88,7 +93,7 @@ class CacheTests: XCTestCase {
         headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
         headers.add(name: .cacheControl, value: "max-age=\(seconds)")
 
-        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+        let response = ClientResponse(status: .ok, headers: headers)
 
         XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
     }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -10,7 +10,7 @@ class CacheTests: XCTestCase {
 
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
     }
 
     func testNoStore() {
@@ -18,7 +18,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
     }
 
     func testMaxAge() {
@@ -29,7 +29,7 @@ class CacheTests: XCTestCase {
 
         let required = requested.addingTimeInterval(TimeInterval(seconds))
 
-        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: requested), required)
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
     }
 
     func testNoMatching() {
@@ -37,12 +37,12 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: requested))
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
     }
 
     func testMissingHeader() {
         let response = ClientResponse(status: .ok)
-        XCTAssertNil(response.headers.getExpirationDate(requestSentAt: Date()))
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: Date()))
     }
 
     private func dateFromFormat(format: String, dateStr: String) -> Date {
@@ -61,7 +61,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
     }
 
     func testObsoleteFormatOne() {
@@ -71,7 +71,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
     }
 
     func testObsoleteFormatTwo() {
@@ -81,7 +81,7 @@ class CacheTests: XCTestCase {
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: Date()), required)
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
     }
 
     func testMaxAgeOverridesExpires() {
@@ -95,7 +95,7 @@ class CacheTests: XCTestCase {
 
         let response = ClientResponse(status: .ok, headers: headers)
 
-        XCTAssertEqual(response.headers.getExpirationDate(requestSentAt: requested), required)
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
     }
 
     func testFlags() {

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -1,0 +1,87 @@
+import Vapor
+import XCTest
+
+class CacheTests: XCTestCase {
+    func testNoStoreWithExpires() {
+        let requested = Date()
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "no-store, max-age=12")
+
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+    }
+
+    func testNoStore() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+    }
+
+    func testMaxAge() {
+        let seconds = Int.random(in: 1...3_000_333)
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-age=\(seconds)"))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
+    }
+
+    private func dateFromFormat(format: String, dateStr: String) -> Date {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = format
+
+        return fmt.date(from: dateStr)!
+    }
+
+    func testPreferredFormat() {
+        let expires = "Sun, 06 Nov 1994 08:49:37 GMT"
+        let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatOne() {
+        let expires = "Sunday, 06-Nov-94 08:49:37 GMT"
+        let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatTwo() {
+        let expires = "Sun Nov  6 08:49:37 1994"
+        let format = "EEE MMM d hh:mm:s yyyy"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: Date()), required)
+    }
+
+    func testMaxAgeOverridesExpires() {
+        let requested = Date()
+        let seconds = Int.random(in: 1...3_000_333)
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "max-age=\(seconds)")
+
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
+    }
+}

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -32,6 +32,14 @@ class CacheTests: XCTestCase {
         XCTAssertEqual(response.headers.getCacheExpiration(requestSentAt: requested), required)
     }
 
+    func testNoMatching() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
+        let response = ClientResponse(status: .ok, headers: headers, body: nil)
+
+        XCTAssertNil(response.headers.getCacheExpiration(requestSentAt: requested))
+    }
+
     private func dateFromFormat(format: String, dateStr: String) -> Date {
         let fmt = DateFormatter()
         fmt.locale = Locale(identifier: "en_US_POSIX")


### PR DESCRIPTION
Extends `HTTPHeaders` with the following properties:

```swift
response.headers.cacheControl
response.headers.expires
```

and this convenience method:

```swift
response.headers.expirationDate(requestSentAt: Date)
```