### PR TITLE
Log the request path of a failed request in the ErrorMiddleware.

### DIFF
--- a/Sources/Vapor/Logging/Logger+LogError.swift
+++ b/Sources/Vapor/Logging/Logger+LogError.swift
@@ -9,7 +9,7 @@ extension Logger {
     ///                Defaults to `true`.
     public func report(
         error e: Error,
-        path: String? = nil,
+        request: Request? = nil,
         verbose: Bool = true,
         file: String = #file,
         function: String = #function,
@@ -19,14 +19,14 @@ extension Logger {
         switch e {
         case let debuggable as Debuggable:
             
-            let pathString: String
-            if let path = path {
-                pathString = " \(path)"
+            let requestString: String
+            if let request = request {
+                requestString = " \(request.http.method) \(request.http.urlString)"
             } else {
-                pathString = ""
+                requestString = ""
             }
             
-            let errorString = "\(debuggable.fullIdentifier):\(pathString) \(debuggable.reason)"
+            let errorString = "\(debuggable.fullIdentifier):\(requestString) \(debuggable.reason)"
             if let source = debuggable.sourceLocation {
                 error(errorString, file: source.file.lastPart, function: source.function, line: source.line, column: source.column)
             } else {

--- a/Sources/Vapor/Logging/Logger+LogError.swift
+++ b/Sources/Vapor/Logging/Logger+LogError.swift
@@ -9,6 +9,7 @@ extension Logger {
     ///                Defaults to `true`.
     public func report(
         error e: Error,
+        path: String? = nil,
         verbose: Bool = true,
         file: String = #file,
         function: String = #function,
@@ -17,7 +18,15 @@ extension Logger {
     ) {
         switch e {
         case let debuggable as Debuggable:
-            let errorString = "\(debuggable.fullIdentifier): \(debuggable.reason)"
+            
+            let pathString: String
+            if let path = path {
+                pathString = " \(path)"
+            } else {
+                pathString = ""
+            }
+            
+            let errorString = "\(debuggable.fullIdentifier):\(pathString) \(debuggable.reason)"
             if let source = debuggable.sourceLocation {
                 error(errorString, file: source.file.lastPart, function: source.function, line: source.line, column: source.column)
             } else {

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -23,7 +23,9 @@ public final class ErrorMiddleware: Middleware, ServiceType {
     public static func `default`(environment: Environment, log: Logger) -> ErrorMiddleware {
         return .init { req, error in
             // log the error
-            log.report(error: error, verbose: !environment.isRelease)
+            log.report(error: error,
+                       path: req.http.urlString,
+                       verbose: !environment.isRelease)
 
             // variables to determine
             let status: HTTPResponseStatus

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -23,10 +23,12 @@ public final class ErrorMiddleware: Middleware, ServiceType {
     public static func `default`(environment: Environment, log: Logger) -> ErrorMiddleware {
         return .init { req, error in
             // log the error
-            log.report(error: error,
-                       path: req.http.urlString,
-                       verbose: !environment.isRelease)
-
+            log.report(
+                error: error,
+                request: req,
+                verbose: !environment.isRelease
+            )
+            
             // variables to determine
             let status: HTTPResponseStatus
             let reason: String

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,6 +7,7 @@ XCTMain([
     // Vapor
     testCase(ApplicationTests.allTests),
     testCase(MiddlewareTests.allTests),
+    testCase(LoggingTests.allTests)
 ])
 
 #endif

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -56,4 +56,9 @@ class LoggingTests : XCTestCase {
         
         XCTAssert(loggerProvider.logger.didLog(string: "Abort.500: /fail/me Internal Server Error"))
     }
+    
+    static let allTests = [
+        ("testNotFoundLogging", testNotFoundLogging),
+        ("testInternalServerErrorLogging", testInternalServerErrorLogging)
+    ]
 }

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -1,0 +1,59 @@
+import Vapor
+import XCTest
+
+class LoggingTests : XCTestCase {
+
+    func testNotFoundLogging() throws {
+        
+        var services = Services.default()
+        var config = Config.default()
+        let loggerProvider = TestLoggerProvider()
+                
+        try services.register(loggerProvider)
+        config.prefer(TestLogger.self, for: Logger.self)
+        
+        let app = try Application(config: config, services: services)
+
+        let req = Request(
+            http: HTTPRequest(method: .GET, url: "/hello/vapor"),
+            using: app
+        )
+        
+        do {
+            _ = try app.make(Responder.self).respond(to: req).wait()
+        } catch {}
+        
+        XCTAssert(loggerProvider.logger.didLog(string: "Abort.404: /hello/vapor Not Found"))
+    }
+    
+    func testInternalServerErrorLogging() throws {
+        
+        var services = Services.default()
+        var config = Config.default()
+        let loggerProvider = TestLoggerProvider()
+                
+        try services.register(loggerProvider)
+        config.prefer(TestLogger.self, for: Logger.self)
+        
+        let router = EngineRouter.default()
+    
+        router.get("fail/me") { (_) -> String in
+            throw Abort(.internalServerError)
+        }
+        
+        services.register(router, as: Router.self)
+        
+        let app = try Application(config: config, services: services)
+        
+        let req = Request(
+            http: HTTPRequest(method: .GET, url: "/fail/me"),
+            using: app
+        )
+        
+        do {
+            _ = try app.make(Responder.self).respond(to: req).wait()
+        } catch {}
+        
+        XCTAssert(loggerProvider.logger.didLog(string: "Abort.500: /fail/me Internal Server Error"))
+    }
+}

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -23,7 +23,7 @@ class LoggingTests : XCTestCase {
             _ = try app.make(Responder.self).respond(to: req).wait()
         } catch {}
         
-        XCTAssert(loggerProvider.logger.didLog(string: "Abort.404: /hello/vapor Not Found"))
+        XCTAssert(loggerProvider.logger.didLog(string: "Abort.404: GET /hello/vapor Not Found"))
     }
     
     func testInternalServerErrorLogging() throws {
@@ -37,7 +37,7 @@ class LoggingTests : XCTestCase {
         
         let router = EngineRouter.default()
     
-        router.get("fail/me") { (_) -> String in
+        router.post("fail/me") { (_) -> String in
             throw Abort(.internalServerError)
         }
         
@@ -46,7 +46,7 @@ class LoggingTests : XCTestCase {
         let app = try Application(config: config, services: services)
         
         let req = Request(
-            http: HTTPRequest(method: .GET, url: "/fail/me"),
+            http: HTTPRequest(method: .POST, url: "/fail/me"),
             using: app
         )
         
@@ -54,7 +54,7 @@ class LoggingTests : XCTestCase {
             _ = try app.make(Responder.self).respond(to: req).wait()
         } catch {}
         
-        XCTAssert(loggerProvider.logger.didLog(string: "Abort.500: /fail/me Internal Server Error"))
+        XCTAssert(loggerProvider.logger.didLog(string: "Abort.500: POST /fail/me Internal Server Error"))
     }
     
     static let allTests = [

--- a/Tests/VaporTests/LoggingTestsMocks.swift
+++ b/Tests/VaporTests/LoggingTestsMocks.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Vapor
+
+final class TestLogger: Logger {
+    
+    var logs = [String]()
+        
+    public func log(_ string: String, at level: LogLevel, file: String, function: String, line: UInt, column: UInt) {
+        
+        logs += [string]
+    }
+    
+    func didLog(string: String) -> Bool {
+        return logs.contains(string)
+    }
+}
+
+extension TestLogger: Service {}
+
+final class TestLoggerProvider: Provider {
+
+    let logger = TestLogger()
+    
+    func register(_ services: inout Services) throws {
+        services.register(Logger.self) { container -> TestLogger in
+            return self.logger
+        }
+    }
+
+    func didBoot(_ container: Container) throws -> EventLoopFuture<Void> {
+        return .done(on: container)
+    }
+}


### PR DESCRIPTION
Added the request path to the logging from the `ErrorMiddleware`. For instance when a resource `/hello/vapor` cannot be found currently the log will read `Abort.404: Not Found`. After this change the log will read `Abort.404: /hello/vapor Not Found` which will improve monitoring.

