### PR TITLE
Require secure versions of Swift NIO SSL + HTTP/2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
         
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),


### PR DESCRIPTION
Updates SwiftNIO SSL and HTTP/2 dependencies to secure versions. 

See the respective Security advisories pages for more information:
- https://github.com/apple/swift-nio-http2/security/advisories?state=published
- https://github.com/apple/swift-nio-ssl/security/advisories?state=published