### PR TITLE
Remove fatalErrors from URLEncodedFormDecoder

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -101,12 +101,13 @@ private struct _Decoder: Decoder {
         where Key: CodingKey
     {
         guard let data = self.data else {
-            fatalError()
+            throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
         }
         switch data {
         case .dictionary(let dict):
             return KeyedDecodingContainer(KeyedContainer<Key>(data: dict, codingPath: self.codingPath))
-        default: fatalError()
+        default:
+            throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
         }
     }
 
@@ -118,7 +119,8 @@ private struct _Decoder: Decoder {
         switch data {
         case .array(let arr):
             return UnkeyedContainer(data: arr, codingPath: self.codingPath)
-        default: fatalError()
+        default:
+            throw DecodingError.valueNotFound([Any].self, at: codingPath)
         }
     }
 
@@ -201,23 +203,25 @@ private struct _Decoder: Decoder {
             where NestedKey: CodingKey
         {
             guard let data = self.data[key.stringValue] else {
-                fatalError()
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
             }
             switch data {
             case .dictionary(let dict):
                 return KeyedDecodingContainer(KeyedContainer<NestedKey>(data: dict, codingPath: self.codingPath + [key]))
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath)
             }
         }
         
         func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
             guard let data = self.data[key.stringValue] else {
-                fatalError()
+                throw DecodingError.valueNotFound([Any].self, at: codingPath)
             }
             switch data {
             case .array(let arr):
                 return UnkeyedContainer(data: arr, codingPath: self.codingPath + [key])
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([Any].self, at: codingPath)
             }
         }
         
@@ -283,7 +287,8 @@ private struct _Decoder: Decoder {
             switch self.data[self.currentIndex] {
             case .dictionary(let dict):
                 return KeyedDecodingContainer(KeyedContainer<NestedKey>(data: dict, codingPath: self.codingPath))
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([String: Any].self, at: codingPath + [BasicCodingKey.index(currentIndex)])
             }
         }
         
@@ -292,7 +297,8 @@ private struct _Decoder: Decoder {
             switch self.data[self.currentIndex] {
             case .array(let arr):
                 return UnkeyedContainer(data: arr, codingPath: self.codingPath)
-            default: fatalError()
+            default:
+                throw DecodingError.valueNotFound([Any].self, at: codingPath + [BasicCodingKey.index(currentIndex)])
             }
         }
         

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -104,6 +104,18 @@ final class ApplicationTests: XCTestCase {
         
         XCTAssertThrowsError(try request.query.get(StringWrapper.self, at: "hello"))
     }
+    
+    func testCrashingArrayWithPercentEncoding() throws {
+        let app = Application()
+        defer { app.shutdown() }
+
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        request.headers.contentType = .json
+        request.url.path = "/"
+        request.url.query = "emailsToSearch%5B%5D=xyz"
+        
+        XCTAssertThrowsError(try request.query.get([String].self, at: "emailsToSearch[]"))
+    }
 
     func testQueryGet() throws {
         let app = Application()


### PR DESCRIPTION
Removes some `fatalError`s that could be triggered by malformed Request URL query strings during decoding (fixes #2176, related to #2163, #2177).