### PR TITLE
Adds EndpointCache for handling GET resource caching

### DIFF
--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -1,4 +1,4 @@
-public enum CachingDataError: Swift.Error {
+public enum EndpointCacheError: Swift.Error {
     case unexpctedResponseStatus(HTTPStatus, uri: URI)
     case badJSON(Error)
 }
@@ -88,7 +88,7 @@ public final class EndpointCache<T> where T: Decodable {
             self.uri, headers: headers
         ).flatMapThrowing { response -> ClientResponse in
             if !(response.status == .notModified || response.status == .ok) {
-                throw CachingDataError.unexpctedResponseStatus(response.status, uri: self.uri)
+                throw EndpointCacheError.unexpctedResponseStatus(response.status, uri: self.uri)
             }
 
             return response
@@ -125,7 +125,7 @@ public final class EndpointCache<T> where T: Decodable {
                 do {
                     data = try response.content.decode(T.self)
                 } catch {
-                    return eventLoop.makeFailedFuture(CachingDataError.badJSON(error))
+                    return eventLoop.makeFailedFuture(EndpointCacheError.badJSON(error))
                 }
 
                 if self.cacheUntil != nil {

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -1,0 +1,174 @@
+
+/// Handles the complexities of HTTP caching.
+open class EndpointCache<T: Decodable> {
+    public enum CachingDataError: Swift.Error {
+        case unexpctedResponseStatus(HTTPStatus, uri: URI)
+        case badJSON(Error)
+    }
+
+    internal var cached: T?
+    internal var request: EventLoopFuture<T>?
+    internal var headers: HTTPHeaders?
+    internal var cacheUntil: Date?
+
+    private let sync: Lock
+    private let uri: URI
+
+    /// The designated initializer.
+    /// - Parameters:
+    ///   - uri: The `URI` of the resource to be downloaded.
+    public init(uri: URI) {
+        self.uri = uri
+        self.sync = .init()
+    }
+
+    /// Downloads the resource.
+    /// - Parameters:
+    ///   - request: The `Request` which is initiating the download.
+    ///   - logger: An optional logger
+    public func get(on request: Request, logger: Logger? = nil) -> EventLoopFuture<T> {
+        return self.download(on: request.eventLoop, using: request.client, logger: logger)
+    }
+
+    /// Downloads the resource.
+    /// - Parameters:
+    ///   - eventLoop: The `EventLoop` to use for the download.
+    ///   - client: The `Client` which will perform the download.
+    ///   - logger: An optional logger
+    public func get(on eventLoop: EventLoop, using client: Client, logger: Logger?) -> EventLoopFuture<T> {
+        self.sync.lock()
+        defer { self.sync.unlock() }
+
+        if let cached = self.cached, let cacheUntil = self.cacheUntil, Date() < cacheUntil {
+            // If no-cache was set on the header, you *always* have to validate with the server.
+            // must-revalidate does not require checking with the server until after it expires.
+            if self.headers == nil || self.headers?.cacheControl == nil || self.headers?.cacheControl?.noCache == false {
+                return eventLoop.makeSucceededFuture(cached)
+            }
+        }
+
+        // Don't make a new request if one is already running.
+        if let request = self.request {
+            // The current request may be happening on a different event loop.
+            return request.hop(to: eventLoop)
+        }
+
+        logger?.debug("Requesting data from \(self.uri)")
+
+        self.request = self.download(on: eventLoop, using: client, logger: logger)
+
+        // Once the request finishes, clear the current request and return the data.
+        return self.request!.map { data in
+            // Synchronize access to shared state
+            self.sync.lock()
+            defer { self.sync.unlock() }
+            self.request = nil
+
+            return data
+        }
+    }
+
+    internal func download(on eventLoop: EventLoop, using client: Client, logger: Logger?) -> EventLoopFuture<T> {
+        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.3.4
+        var headers: HTTPHeaders = [:]
+        if let eTag = self.headers?.firstValue(name: .eTag) {
+            headers.add(name: .ifNoneMatch, value: eTag)
+        }
+
+        if let lastModified = self.headers?.lastModified {
+            // TODO: If using HTTP/1.0 then this should be .ifUnmodifiedSince instead. Don't know
+            // how to determine that right now.
+            headers.add(name: .ifModifiedSince, value: lastModified.serialize())
+        }
+
+        // Cache-Control max-age is calculated against the request date.
+        let requestSentAt = Date()
+
+        return client.get(
+            self.uri, headers: headers
+        ).flatMapThrowing { response -> ClientResponse in
+            if !(response.status == .notModified || response.status == .ok) {
+                throw CachingDataError.unexpctedResponseStatus(response.status, uri: self.uri)
+            }
+
+            return response
+        }.flatMap { response -> EventLoopFuture<T> in
+            // Synchronize access to shared state.
+            self.sync.lock()
+            defer { self.sync.unlock() }
+
+            if let cacheControl = response.headers.cacheControl, cacheControl.noStore == true {
+                // The server *shouldn't* give an expiration with no-store, but...
+                self.removeCaching()
+            } else {
+                self.headers = response.headers
+                self.cacheUntil = self.headers?.expirationDate(requestSentAt: requestSentAt)
+            }
+
+            switch response.status {
+            case .notModified:
+                logger?.debug("Cached data is still valid.")
+
+                guard let cached = self.cached else {
+                    // This shouldn't actually be possible, but just in case.
+                    self.removeCaching()
+                    return self.download(on: eventLoop, using: client, logger: logger)
+                }
+
+                return eventLoop.makeSucceededFuture(cached)
+
+            case .ok:
+                logger?.debug("New data should be (possibly) cached")
+
+                let data: T
+
+                do {
+                    data = try response.content.decode(T.self)
+                } catch {
+                    return eventLoop.makeFailedFuture(CachingDataError.badJSON(error))
+                }
+
+                if self.cacheUntil != nil {
+                    self.cached = data
+                }
+
+                return eventLoop.makeSucceededFuture(data)
+
+            default:
+                // This shouldn't ever happen due to the previous flatMapThrowing
+                return eventLoop.makeFailedFuture(Abort(.internalServerError))
+            }
+        }.flatMapError { error -> EventLoopFuture<T> in
+            // Synchronize access to shared state.
+            self.sync.lock()
+            defer { self.sync.unlock() }
+
+            guard let headers = self.headers, let cached = self.cached else {
+                return eventLoop.makeFailedFuture(error)
+            }
+
+            if let cacheControl = headers.cacheControl, let cacheUntil = self.cacheUntil {
+                if let staleIfError = cacheControl.staleIfError,
+                    cacheUntil.addingTimeInterval(Double(staleIfError)) > Date() {
+                    // Can use the data for staleIfError seconds past expiration when the server is non-responsive
+                    return eventLoop.makeSucceededFuture(cached)
+                } else if cacheControl.noCache == true && cacheUntil > Date() {
+                    // The spec isn't very clear here.  If no-cache is present you're supposed to validate with the
+                    // server. However, if the server doesn't respond, but I'm still within the expiration time, I'm
+                    // opting to say that the cache should be considered usable.
+                    return eventLoop.makeSucceededFuture(cached)
+                }
+            }
+
+            self.removeCaching()
+
+            return eventLoop.makeFailedFuture(error)
+        }
+    }
+
+    private func removeCaching() {
+        self.cached = nil
+        self.headers = nil
+        self.cacheUntil = nil
+    }
+}

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -1,6 +1,6 @@
 public enum EndpointCacheError: Swift.Error {
     case unexpctedResponseStatus(HTTPStatus, uri: URI)
-    case badJSON(Error)
+    case contentDecodeFailure(Error)
 }
 
 /// Handles the complexities of HTTP caching.
@@ -125,7 +125,7 @@ public final class EndpointCache<T> where T: Decodable {
                 do {
                     data = try response.content.decode(T.self)
                 } catch {
-                    return eventLoop.makeFailedFuture(EndpointCacheError.badJSON(error))
+                    return eventLoop.makeFailedFuture(EndpointCacheError.contentDecodeFailure(error))
                 }
 
                 if self.cacheUntil != nil {

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -5,10 +5,10 @@ public enum CachingDataError: Swift.Error {
 
 /// Handles the complexities of HTTP caching.
 public final class EndpointCache<T> where T: Decodable {
-    internal var cached: T?
-    internal var request: EventLoopFuture<T>?
-    internal var headers: HTTPHeaders?
-    internal var cacheUntil: Date?
+    private var cached: T?
+    private var request: EventLoopFuture<T>?
+    private var headers: HTTPHeaders?
+    private var cacheUntil: Date?
 
     private let sync: Lock
     private let uri: URI

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -68,7 +68,7 @@ public final class EndpointCache<T> where T: Decodable {
         }
     }
 
-    internal func download(on eventLoop: EventLoop, using client: Client, logger: Logger?) -> EventLoopFuture<T> {
+    private func download(on eventLoop: EventLoop, using client: Client, logger: Logger?) -> EventLoopFuture<T> {
         // https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.3.4
         var headers: HTTPHeaders = [:]
         if let eTag = self.headers?.firstValue(name: .eTag) {

--- a/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaderCacheControl.swift
@@ -70,38 +70,42 @@ extension HTTPHeaders {
         /// Indicates the client will accept a stale response if the check for a fresh one fails. The value indicates how many *seconds* long the client will accept the stale response after the initial expiration.
         public var staleIfError: Int?
 
-        public init() {
-            self.mustRevalidate = false
-            self.noCache = false
-            self.noStore = false
-            self.noTransform = false
-            self.isPublic = false
-            self.isPrivate = false
-            self.proxyRevalidate = false
-            self.onlyIfCached = false
-            self.immutable = false
+        /// Creates a new `CacheControl`.
+        public init(
+            mustRevalidated: Bool = false,
+            noCache: Bool = false,
+            noStore: Bool = false,
+            noTransform: Bool = false,
+            isPublic: Bool = false,
+            isPrivate: Bool = false,
+            proxyRevalidate: Bool = false,
+            onlyIfCached: Bool = false,
+            immutable: Bool = false,
+            maxAge: Int? = nil,
+            sMaxAge: Int? = nil,
+            maxStale: MaxStale? = nil,
+            minFresh: Int? = nil,
+            staleWhileRevalidate: Int? = nil,
+            staleIfError: Int? = nil
+        ) {
+            self.mustRevalidate = mustRevalidated
+            self.noCache = noCache
+            self.noStore = noStore
+            self.noTransform = noTransform
+            self.isPublic = isPublic
+            self.isPrivate = isPrivate
+            self.proxyRevalidate = proxyRevalidate
+            self.onlyIfCached = onlyIfCached
+            self.immutable = immutable
+            self.maxAge = maxAge
+            self.sMaxAge = sMaxAge
+            self.maxStale = maxStale
+            self.minFresh = minFresh
+            self.staleWhileRevalidate = staleWhileRevalidate
+            self.staleIfError = staleIfError
         }
 
-        private static let exactMatch: [String: WritableKeyPath<Self, Bool>] = [
-            "must-revalidate": \.mustRevalidate,
-            "no-cache": \.noCache,
-            "no-store": \.noStore,
-            "no-transform": \.noTransform,
-            "public": \.isPublic,
-            "private": \.isPrivate,
-            "proxy-revalidate": \.proxyRevalidate,
-            "only-if-cached": \.onlyIfCached
-        ]
-
-        private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
-            "max-age": \.maxAge,
-            "s-maxage": \.sMaxAge,
-            "min-fresh": \.minFresh,
-            "stale-while-revalidate": \.staleWhileRevalidate,
-            "stale-if-error": \.staleIfError
-        ]
-
-        internal static func parse(_ value: String) -> CacheControl? {
+        public static func parse(_ value: String) -> CacheControl? {
             var set = CharacterSet.whitespacesAndNewlines
             set.insert(",")
 
@@ -171,6 +175,25 @@ extension HTTPHeaders {
             
             return (options + optionsWithSeconds).joined(separator: ", ")
         }
+
+        private static let exactMatch: [String: WritableKeyPath<Self, Bool>] = [
+            "must-revalidate": \.mustRevalidate,
+            "no-cache": \.noCache,
+            "no-store": \.noStore,
+            "no-transform": \.noTransform,
+            "public": \.isPublic,
+            "private": \.isPrivate,
+            "proxy-revalidate": \.proxyRevalidate,
+            "only-if-cached": \.onlyIfCached
+        ]
+
+        private static let prefix: [String: WritableKeyPath<Self, Int?>] = [
+            "max-age": \.maxAge,
+            "s-maxage": \.sMaxAge,
+            "min-fresh": \.minFresh,
+            "stale-while-revalidate": \.staleWhileRevalidate,
+            "stale-if-error": \.staleIfError
+        ]
     }
 
     /// Gets the value of the `Cache-Control` header, if present.

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -27,7 +27,7 @@ extension Application {
             typealias Value = Storage
         }
 
-        let application: Application
+        public let application: Application
 
         public var current: Vapor.Responder {
             guard let factory = self.storage.factory else {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1326,9 +1326,7 @@ final class ApplicationTests: XCTestCase {
             defer { current += 1 }
             let res = Response()
             try res.content.encode(Test(number: current))
-            var cacheControl = HTTPHeaders.CacheControl()
-            cacheControl.maxAge = 1
-            res.headers.cacheControl = cacheControl
+            res.headers.cacheControl = .init(maxAge: 1)
             return res
         }
 


### PR DESCRIPTION
Adds `EndpointCache` which can be used to handle GET requests which are cache aware.

```swift
let endpoint = EndpointCache<MyDataType>(uri: "https://foo.dev/path/to/resource")

endpoint.get(on: req) { data in 
    // Access cached data.
}
```

This class is thread-safe and will only cache one copy of the resource per event loop. 