### PR TITLE
expose methods for hex encoded strings

### DIFF
--- a/Sources/Vapor/Utilities/Bytes+Hex.swift
+++ b/Sources/Vapor/Utilities/Bytes+Hex.swift
@@ -1,6 +1,10 @@
 extension Collection where Element == UInt8 {
-    func hexEncodedString(uppercase: Bool = false) -> String {
-        return String(decoding: hexEncodedBytes(uppercase: uppercase), as: Unicode.UTF8.self)
+    public var hex: String {
+        self.hexEncodedString()
+    }
+
+    public func hexEncodedString(uppercase: Bool = false) -> String {
+        return String(decoding: self.hexEncodedBytes(uppercase: uppercase), as: Unicode.UTF8.self)
     }
 
     func hexEncodedBytes(uppercase: Bool = false) -> [UInt8] {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1358,6 +1358,13 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(test.number, 1)
         }
     }
+
+    func testHexEncoding() throws {
+        let bytes: [UInt8] = [1, 42, 128, 240]
+        XCTAssertEqual(bytes.hex, "012a80f0")
+        XCTAssertEqual(bytes.hexEncodedString(), "012a80f0")
+        XCTAssertEqual(bytes.hexEncodedString(uppercase: true), "012A80F0")
+    }
 }
 
 extension Application.Responder {


### PR DESCRIPTION
Exposes methods for generating hex-encoded strings from a collection of bytes (#2189, fixes #2187). 

```swift
import Vapor

let bytes: [UInt8] = ...
print(bytes.hexEncodedString()) // Hex-encoded w/ lowercase characters
print(bytes.hexEncodedString(uppercase: true)) // Hex-encoded w/ uppercase characters
```

A concise `hex` method has also been added to match the similar `base64` method which already exists.

```swift
print(bytes.hex) // Hex-encoded string (lowercase)
```