### PR TITLE
Load Environment variables from files

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -162,4 +162,10 @@ public func routes(_ app: Application) throws {
     app.get("view") { req in
         req.view.render("hello.txt", ["name": "world"])
     }
+
+    app.get("secret") { (req) -> EventLoopFuture<String> in
+        return Environment
+            .secret(key: "PASSWORD_SECRET", fileIO: req.application.fileio, on: req.eventLoop)
+            .unwrap(or: Abort(.badRequest))
+    }
 }

--- a/Sources/Vapor/Services/Environment+Secret.swift
+++ b/Sources/Vapor/Services/Environment+Secret.swift
@@ -1,0 +1,44 @@
+extension Environment {
+
+    /// Reads a file content for a secret. The secret key represents the name of the environment variable that holds the path for the file containing the secret
+    /// - Parameters:
+    ///     - key: Environment name for the path to the file containing the secret
+    ///     - fileIO: FileIO handler provided by NIO
+    ///     - on: EventLoop to operate on while opening the file
+    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    public static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
+        guard let filePath = self.get(key) else { return eventLoop.future(nil) }
+        return self.secret(path: filePath, fileIO: fileIO, on: eventLoop)
+    }
+
+
+    /// Reads a file content for a secret. The path is a file path to the file that contains the secret in plain text
+    /// - Parameters:
+    ///     - path: Path to the file that contains the secret
+    ///     - fileIO: FileIO handler provided by NIO
+    ///     - on: EventLoop to operate on while opening the file
+    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    public static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
+        return fileIO
+            .openFile(path: path, eventLoop: eventLoop)
+            .flatMap({ (arg) -> EventLoopFuture<ByteBuffer> in
+                return fileIO
+                    .read(fileRegion: arg.1, allocator: .init(), eventLoop: eventLoop)
+                    .flatMapThrowing({ (buffer) -> ByteBuffer in
+                        try arg.0.close()
+                        return buffer
+                    })
+            })
+            .map({ (buffer) -> (String) in
+                var buffer = buffer
+                return buffer.readString(length: buffer.writerIndex) ?? ""
+            })
+            .map({ (secret) -> (String) in
+                secret.trimmingCharacters(in: .whitespacesAndNewlines)
+            })
+            .recover ({ (_) -> String? in
+                nil
+            })
+    }
+}
+

--- a/Tests/VaporTests/EnvironmentSecretTests.swift
+++ b/Tests/VaporTests/EnvironmentSecretTests.swift
@@ -1,0 +1,56 @@
+@testable import Vapor
+import XCTVapor
+import COperatingSystem
+
+final class EnvironmentSecretTests: XCTestCase {
+    func testNonExistingSecretFile() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/non-existing-secret"
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(path: path, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertNil(secretContent)
+    }
+
+    func testExistingSecretFile() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(path: path, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testExistingSecretFileFromEnvironmentKey() throws {
+        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let key = "MY_ENVIRONMENT_SECRET"
+        setenv(key, path, 1)
+        let app = Application(.testing)
+        defer {
+            app.shutdown()
+            unsetenv(key)
+        }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(key: key, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testLoadingSecretFromEnvKeyWhichDoesNotExist() throws {
+        let key = "MY_NON_EXISTING_ENVIRONMENT_SECRET"
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let eventLoop = app.eventLoopGroup.next()
+        let secretContent = try! Environment.secret(key: key, fileIO: app.fileio, on: eventLoop).wait()
+        XCTAssertNil(secretContent)
+    }
+}

--- a/Tests/VaporTests/Utilities/my-secret-env-content
+++ b/Tests/VaporTests/Utilities/my-secret-env-content
@@ -1,0 +1,1 @@
+password


### PR DESCRIPTION
Adds support to load Environment variables content's from files (#2190, fixes #2006). 

This functionality can be useful when dealing with Docker and Docker secrets or Kubernetes Secrets.

For example, if you have a file which includes the password for your database you can load this much easier from disk than previously.

```swift
let databasePasswordOnAppBoot = Environment
    .secret(path: "<Path to your file>", fileIO: app.fileio, on: app.eventLoopGroup.next())
    .unwrap(or: Abort(.badRequest))
```

Example from inside a request:

```swift
let secretPasswordUsedInARequest = Environment
    .secret(path: "<Path to your file>", fileIO: req.application.fileio, on: req.eventLoop)
    .unwrap(or: Abort(.badRequest))
```

It also supports loading the path from an existing Environment variable:
```swift
let passwordSecret = Environment
    .secret(key: "PASSWORD_SECRET_FILE = ", fileIO: app.fileio, on: app.eventLoopGroup.next())
    .unwrap(or: Abort(.badRequest))
```