### PR TITLE
Add support for Codable types with URL properties to URLEncodedFormData.

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormData.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormData.swift
@@ -26,6 +26,14 @@ enum URLEncodedFormData: ExpressibleByArrayLiteral, ExpressibleByStringLiteral, 
         }
     }
 
+    /// Converts self to an `URL` or returns `nil` if not convertible.
+    var url: URL? {
+        switch self {
+        case .string(let s): return URL(string: s)
+        default: return nil
+        }
+    }
+
     /// Converts self to an `[URLEncodedFormData]` or returns `nil` if not convertible.
     var array: [URLEncodedFormData]? {
         switch self {

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDataConvertible.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDataConvertible.swift
@@ -25,6 +25,22 @@ extension String: URLEncodedFormDataConvertible {
     }
 }
 
+extension URL: URLEncodedFormDataConvertible {
+    /// `URLEncodedFormDataConvertible` conformance.
+    init?(urlEncodedFormData: URLEncodedFormData) {
+        guard let url = urlEncodedFormData.url else {
+            return nil
+        }
+
+        self = url
+    }
+
+    /// `URLEncodedFormDataConvertible` conformance.
+    var urlEncodedFormData: URLEncodedFormData? {
+        return .string(self.absoluteString)
+    }
+}
+
 extension FixedWidthInteger {
     /// `URLEncodedFormDataConvertible` conformance.
     init?(urlEncodedFormData: URLEncodedFormData) {

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -6,7 +6,7 @@ final class URLEncodedFormTests: XCTestCase {
     
     func testDecode() throws {
         let data = """
-        name=Tanner&age=23&pets[]=Zizek&pets[]=Foo&dict[a]=1&dict[b]=2&foos[]=baz&nums[]=3.14
+        name=Tanner&age=23&pets[]=Zizek&pets[]=Foo&dict[a]=1&dict[b]=2&foos[]=baz&nums[]=3.14&url=https%3A%2F%2Fvapor.codes
         """
         
         let user = try URLEncodedFormDecoder().decode(User.self, from: data)
@@ -19,10 +19,11 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(user.dict["b"], 2)
         XCTAssertEqual(user.foos[0], .baz)
         XCTAssertEqual(user.nums[0], 3.14)
+        XCTAssertEqual(user.url, URL(string: "https://vapor.codes"))
     }
     
     func testEncode() throws {
-        let user = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [.baz], nums: [3.14])
+        let user = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [.baz], nums: [3.14], url: URL(string: "https://vapor.codes")!)
         let result = try URLEncodedFormEncoder().encode(user)
         XCTAssert(result.contains("pets[]=Zizek"))
         XCTAssert(result.contains("pets[]=Foo"))
@@ -32,10 +33,11 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("dict[b]=2"))
         XCTAssert(result.contains("foos[]=baz"))
         XCTAssert(result.contains("nums[]=3.14"))
+        XCTAssert(result.contains("url=https://vapor.codes"))
     }
     
     func testCodable() throws {
-        let a = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [], nums: [])
+        let a = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [], nums: [], url: URL(string: "https://vapor.codes")!)
         let body = try URLEncodedFormEncoder().encode(a)
         print(body)
         let b = try! URLEncodedFormDecoder().decode(User.self, from: body)
@@ -162,6 +164,7 @@ private struct User: Codable, Equatable {
     var dict: [String: Int]
     var foos: [Foo]
     var nums: [Decimal]
+    var url: URL
 }
 
 private enum Foo: String, Codable {


### PR DESCRIPTION
Add support for encoding and decode URLs. Fixes https://github.com/vapor/url-encoded-form/issues/24 now that its been moved here for Vapor 4.