### PR TITLE
set HTTP request decompression ratio limit

### DIFF
--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -338,7 +338,7 @@ private extension ChannelPipeline {
         
         // add response compressor if configured
         if configuration.supportCompression {
-            let requestDecompressionHandler = NIOHTTPRequestDecompressor(limit: .none)
+            let requestDecompressionHandler = NIOHTTPRequestDecompressor(limit: .ratio(10))
             let responseCompressionHandler = HTTPResponseCompressor()
 
             handlers.append(responseCompressionHandler)


### PR DESCRIPTION
Sets a ratio limit of 10x for decompressed HTTP requests. 