### PR TITLE
Improve error handling and timeouts for WebSockets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", from: "1.2.0"),
 
         // WebSocket client library built on SwiftNIO
-        .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0-beta.2.5"),
     ],
     targets: [
         // C helpers

--- a/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
@@ -52,7 +52,7 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
             if res.status == .switchingProtocols, let upgrader = res.upgrader {
                 switch upgrader {
                 case .webSocket(let onUpgrade):
-                    let webSocketUpgrader = NIOWebSocketServerUpgrader(shouldUpgrade: { channel, _ in
+                    let webSocketUpgrader = NIOWebSocketServerUpgrader(automaticErrorHandling: false, shouldUpgrade: { channel, _ in
                         return channel.eventLoop.makeSucceededFuture([:])
                     }, upgradePipelineHandler: { channel, req in
                         return WebSocket.server(on: channel, onUpgrade: onUpgrade)


### PR DESCRIPTION
Improves error handling on WebSocket connections. Improvements to WebSocket-Kit intercept errors or timeouts at the ChannelHandler level and expose them to the WebSocket class.

Now, when an error occurs (such as a malformed WebSocket frame) the error is available via the closeCode on WebSocket. Example:

```swift
func connected(request: Request, connection: WebSocket) {
  _ = connection.onClose.always { (result) in
      let closeReason = connectionInfo.connection.closeCode ?? .unknown(0)
      // Application-specific cleanup code here
  }

}
```
