### PR TITLE
Allow WebSocket maxFrameSize to be configured

### DIFF
--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -33,7 +33,7 @@ public final class Response: CustomStringConvertible {
     }
 
     internal enum Upgrader {
-        case webSocket(onUpgrade: (WebSocket) -> ())
+        case webSocket(maxFrameSize: Int?, onUpgrade: (WebSocket) -> ())
     }
     
     internal var upgrader: Upgrader?

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -33,7 +33,7 @@ public final class Response: CustomStringConvertible {
     }
 
     internal enum Upgrader {
-        case webSocket(maxFrameSize: Int?, onUpgrade: (WebSocket) -> ())
+        case webSocket(maxFrameSize: WebSocketMaxFrameSize, onUpgrade: (WebSocket) -> ())
     }
     
     internal var upgrader: Upgrader?

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -1,8 +1,13 @@
+public enum WebSocketMaxFrameSize {
+    case `default`
+    case override(Int)
+}
+
 extension RoutesBuilder {
     @discardableResult
     public func webSocket(
         _ path: PathComponent...,
-        maxFrameSize: Int? = nil,
+        maxFrameSize: WebSocketMaxFrameSize = .`default`,
         onUpgrade: @escaping (Request, WebSocket) -> ()
     ) -> Route {
         return self.on(.GET, path) { request -> Response in

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -2,11 +2,12 @@ extension RoutesBuilder {
     @discardableResult
     public func webSocket(
         _ path: PathComponent...,
+        maxFrameSize: Int? = nil,
         onUpgrade: @escaping (Request, WebSocket) -> ()
     ) -> Route {
         return self.on(.GET, path) { request -> Response in
             let res = Response(status: .switchingProtocols)
-            res.upgrader = .webSocket(onUpgrade: { ws in
+            res.upgrader = .webSocket(maxFrameSize: maxFrameSize, onUpgrade: { ws in
                 onUpgrade(request, ws)
             })
             return res

--- a/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
@@ -52,8 +52,14 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
             if res.status == .switchingProtocols, let upgrader = res.upgrader {
                 switch upgrader {
                 case .webSocket(let maxFrameSize, let onUpgrade):
-                    let maxFrameSize = maxFrameSize ?? 1 << 14
-                    let webSocketUpgrader = NIOWebSocketServerUpgrader(maxFrameSize: maxFrameSize, automaticErrorHandling: false, shouldUpgrade: { channel, _ in
+                    let maxFrameSizeBytes: Int
+                    switch maxFrameSize {
+                    case .`default`:
+                        maxFrameSizeBytes = 1 << 14
+                    case .override(let bytes):
+                        maxFrameSizeBytes = bytes
+                    }
+                    let webSocketUpgrader = NIOWebSocketServerUpgrader(maxFrameSize: maxFrameSizeBytes, automaticErrorHandling: false, shouldUpgrade: { channel, _ in
                         return channel.eventLoop.makeSucceededFuture([:])
                     }, upgradePipelineHandler: { channel, req in
                         return WebSocket.server(on: channel, onUpgrade: onUpgrade)

--- a/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerUpgradeHandler.swift
@@ -51,8 +51,9 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
             self.upgradeState = .upgraded
             if res.status == .switchingProtocols, let upgrader = res.upgrader {
                 switch upgrader {
-                case .webSocket(let onUpgrade):
-                    let webSocketUpgrader = NIOWebSocketServerUpgrader(automaticErrorHandling: false, shouldUpgrade: { channel, _ in
+                case .webSocket(let maxFrameSize, let onUpgrade):
+                    let maxFrameSize = maxFrameSize ?? 1 << 14
+                    let webSocketUpgrader = NIOWebSocketServerUpgrader(maxFrameSize: maxFrameSize, automaticErrorHandling: false, shouldUpgrade: { channel, _ in
                         return channel.eventLoop.makeSucceededFuture([:])
                     }, upgradePipelineHandler: { channel, req in
                         return WebSocket.server(on: channel, onUpgrade: onUpgrade)


### PR DESCRIPTION
The maximum frame size of an incoming WebSocket packet can be configured. This fixes issues for apps that were running into the limit (#2195, fixes #2194).

```swift
let maxFrameSize: Int = 1024 * 1024 * 2 // 2mb
app.webSocket("api", "ws", maxFrameSize: .override(maxFrameSize)) { (request, ws) in
    websocketController.connected(request: request, connection: ws)
}
```