### PR TITLE
Adds  missing overloaded get method with [PathComponent] for the path parameter in the RoutesBuilder

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -33,6 +33,16 @@ extension RoutesBuilder {
     {
         return self.on(.GET, path, use: closure)
     }
+
+    @discardableResult
+    public func get<Response>(
+        _ path: [PathComponent],
+        use closure: @escaping (Request) throws -> Response
+    ) -> Route
+        where Response: ResponseEncodable
+    {
+        return self.on(.GET, path, use: closure)
+    }
     
     @discardableResult
     public func post<Response>(


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->
Adds  missing overloaded `get` method with `[PathComponent]` for the `path` parameter in the `RoutesBuilder`. (Fixes #2147)

<!-- Describe your changes clearly and use examples if possible. -->
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
