### PR TITLE
Auth/z testing

### DIFF
--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -9,6 +9,13 @@ public protocol RequestAuthenticator: Authenticator, Middleware {
     func authenticate(request: Request) -> EventLoopFuture<User?>
 }
 
+extension Authenticator where Self: Middleware {
+    @available(*, deprecated, message: "middleware() call is no longer required.")
+    public func middleware() -> Middleware {
+        self
+    }
+}
+
 extension RequestAuthenticator {
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // if the user has already been authenticated

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -41,7 +41,7 @@ private final class GuardAuthenticationMiddleware<A>: Middleware
 
     /// See `Middleware`.
     public func respond(to req: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        guard req.auth.has(A.self) else {
+        guard req.authc.has(A.self) else {
             return req.eventLoop.makeFailedFuture(self.error)
         }
         return next.respond(to: req)

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -22,7 +22,7 @@ private final class RedirectMiddleware<A>: Middleware where A: Authenticatable {
 
     /// See Middleware.respond
     func respond(to req: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        if req.auth.has(A.self) {
+        if req.authc.has(A.self) {
             return next.respond(to: req)
         }
         let redirect = req.redirect(to: path)

--- a/Sources/Vapor/Authorization/Authorizer.swift
+++ b/Sources/Vapor/Authorization/Authorizer.swift
@@ -1,0 +1,72 @@
+/// Capable of being authorized.
+public protocol Authorizable { }
+
+public protocol Authorizer { }
+
+public protocol RequestAuthorizer: Authorizer, Middleware {
+    func authorize(request: Request) -> EventLoopFuture<Void>
+}
+
+public protocol ParameterAuthorizer: RequestAuthorizer {
+    associatedtype Value: LosslessStringConvertible
+    var name: String { get }
+    func authorize(parameter: Value, for request: Request) -> EventLoopFuture<Void>
+}
+
+extension ParameterAuthorizer {
+    public func authorize(request: Request) -> EventLoopFuture<Void> {
+        guard let parameter = request.parameters.get(self.name, as: Value.self) else {
+            request.logger.error("Authorization: Missing parameter: \(self.name)")
+            return request.eventLoop.makeFailedFuture(Abort(.forbidden))
+        }
+        return self.authorize(parameter: parameter, for: request)
+    }
+}
+
+extension RequestAuthorizer {
+    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        self.authorize(request: request).flatMap { _ in
+            next.respond(to: request)
+        }
+    }
+}
+
+public protocol RoleAuthorizable: Authenticatable {
+    associatedtype Role: Equatable, Authorizable
+    var role: Role { get }
+}
+
+extension RoleAuthorizable {
+    public static func authorizer(roles: Role...) -> RoleAuthorizer<Self> {
+        .init(roles: roles)
+    }
+    public static func authorizer(role: Role) -> RoleAuthorizer<Self> {
+        .init(roles: [role])
+    }
+    public static func authorizer(roles: [Role]) -> RoleAuthorizer<Self> {
+        .init(roles: roles)
+    }
+}
+
+public struct RoleAuthorizer<User>: RequestAuthorizer
+    where User: RoleAuthorizable
+{
+    let roles: [User.Role]
+
+    internal init(roles: [User.Role]) {
+        self.roles = roles
+    }
+
+    public func authorize(request: Request) -> EventLoopFuture<Void> {
+        do {
+            let user = try request.authc.require(User.self)
+            guard self.roles.contains(user.role) else {
+                throw Abort(.forbidden)
+            }
+            request.authz.add(user.role)
+            return request.eventLoop.makeSucceededFuture(())
+        } catch {
+            return request.eventLoop.makeFailedFuture(error)
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/HTTPMediaType.swift
@@ -181,6 +181,12 @@ public extension HTTPMediaType {
     static let css = HTTPMediaType(type: "text", subType: "css", parameters: ["charset": "utf-8"])
     /// URL encoded form media type.
     static let urlEncodedForm = HTTPMediaType(type: "application", subType: "x-www-form-urlencoded", parameters: ["charset": "utf-8"])
+    // Multipart encoded form data with boundary.
+    static func formData(boundary: String) -> HTTPMediaType {
+        .init(type: "multipart", subType: "form-data", parameters: [
+            "boundary": boundary
+        ])
+    }
     /// Multipart encoded form data.
     static let formData = HTTPMediaType(type: "multipart", subType: "form-data")
     /// Mixed multipart encoded data.

--- a/Sources/XCTVapor/XCTHTTPRequest.swift
+++ b/Sources/XCTVapor/XCTHTTPRequest.swift
@@ -1,0 +1,40 @@
+public struct XCTHTTPRequest {
+    public var method: HTTPMethod
+    public var uri: URI
+    public var headers: HTTPHeaders
+    public var body: ByteBuffer
+}
+
+extension XCTHTTPRequest {
+    private struct _ContentContainer: ContentContainer {
+        var body: ByteBuffer
+        var headers: HTTPHeaders
+
+        var contentType: HTTPMediaType? {
+            return self.headers.contentType
+        }
+
+        mutating func encode<E>(_ encodable: E, using encoder: ContentEncoder) throws
+            where E: Encodable
+        {
+            try encoder.encode(encodable, to: &self.body, headers: &self.headers)
+        }
+
+        func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D
+            where D: Decodable
+        {
+            fatalError("Decoding from test request is not supported")
+        }
+    }
+
+    public var content: ContentContainer {
+        get {
+            _ContentContainer(body: self.body, headers: self.headers)
+        }
+        set {
+            let container = (newValue as! _ContentContainer)
+            self.body = container.body
+            self.headers = container.headers
+        }
+    }
+}

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -1,62 +1,47 @@
 public struct XCTHTTPResponse {
     public var status: HTTPStatus
     public var headers: HTTPHeaders
-    public var body: Response.Body
+    public var body: ByteBuffer
 }
 
 extension XCTHTTPResponse {
     private struct _ContentContainer: ContentContainer {
-        var body: String
+        var body: ByteBuffer
         var headers: HTTPHeaders
 
         var contentType: HTTPMediaType? {
             return self.headers.contentType
         }
 
-        mutating func encode<E>(_ encodable: E, using encoder: ContentEncoder) throws where E : Encodable {
+        mutating func encode<E>(_ encodable: E, using encoder: ContentEncoder) throws
+            where E: Encodable
+        {
             fatalError("Encoding to test response is not supported")
         }
 
-        func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D where D : Decodable {
-            var body = ByteBufferAllocator().buffer(capacity: 0)
-            body.writeString(self.body)
-            return try decoder.decode(D.self, from: body, headers: self.headers)
+        func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D
+            where D: Decodable
+        {
+            try decoder.decode(D.self, from: self.body, headers: self.headers)
         }
     }
 
     public var content: ContentContainer {
-        _ContentContainer(body: self.body.string ?? "", headers: self.headers)
+        _ContentContainer(body: self.body, headers: self.headers)
     }
 }
-//    @discardableResult
-//    public func assertStatus(is status: HTTPStatus, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
-//        XCTAssertEqual(self.response.status, status, file: file, line: line)
-//        return self
-//    }
-//
-//    @discardableResult
-//    public func assertBody(equals string: String, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
-//        let bodyString = self.response.body.description
-//        XCTAssertEqual(bodyString, string, file: file, line: line)
-//        return self
-//    }
-//
-//    @discardableResult
-//    public func assertBody(contains string: String, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
-//        let bodyString = self.response.body.description
-//        if !bodyString.contains(string) {
-//            XCTFail("body contains check: (\(string.debugDescription)) does not appear in (\(bodyString.debugDescription))", file: file, line: line)
-//        }
-//        return self
-//    }
-//
-//    @discardableResult
-//    public func assertBody(isEmpty: Bool, file: StaticString = #file, line: UInt = #line) -> XCTHTTPResponse {
-//        if isEmpty != self.response.body.isEmpty {
-//            XCTFail("body empty check: body.isEmpty = \(self.response.body.isEmpty)", file: file, line: line)
-//        }
-//        return self
-//    }
+
+extension ByteBuffer {
+    public var string: String {
+        .init(decoding: self.readableBytesView, as: UTF8.self)
+    }
+
+    public init(string: String) {
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString(string)
+        self = buffer
+    }
+}
 
 extension Response.Body {
     var isEmpty: Bool {
@@ -73,17 +58,13 @@ public func XCTAssertContent<D>(
 )
     where D: Decodable
 {
-    guard let body = res.body.buffer else {
-        XCTFail("response does not contain body", file: file, line: line)
-        return
-    }
     guard let contentType = res.headers.contentType else {
         XCTFail("response does not contain content type", file: file, line: line)
         return
     }
     do {
         let decoder = try ContentConfiguration.global.requireDecoder(for: contentType)
-        let content = try decoder.decode(D.self, from: body, headers: res.headers)
+        let content = try decoder.decode(D.self, from: res.body, headers: res.headers)
         closure(content)
     } catch {
         XCTFail("could not decode body: \(error)", file: file, line: line)

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -22,9 +22,9 @@ final class AuthenticationTests: XCTestCase {
         defer { app.shutdown() }
         
         app.routes.grouped([
-            TestAuthenticator().middleware(), Test.guardMiddleware()
+            TestAuthenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            try req.authc.require(Test.self).name
         }
 
         try app.testable().test(.GET, "/test") { res in
@@ -57,9 +57,9 @@ final class AuthenticationTests: XCTestCase {
         defer { app.shutdown() }
 
         app.routes.grouped([
-            TestAuthenticator().middleware(), Test.guardMiddleware()
+            TestAuthenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            try req.authc.require(Test.self).name
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -105,11 +105,11 @@ final class AuthenticationTests: XCTestCase {
         
         app.routes.grouped([
             SessionsMiddleware(session: app.sessions.driver),
-            TestSessionAuthenticator().middleware(),
-            TestBearerAuthenticator().middleware(),
+            TestSessionAuthenticator(),
+            TestBearerAuthenticator(),
             Test.guardMiddleware(),
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            try req.authc.require(Test.self).name
         }
 
         var sessionCookie: HTTPCookies.Value?
@@ -149,6 +149,6 @@ final class AuthenticationTests: XCTestCase {
         }
 
         var config = Middlewares()
-        config.use(TestAuthenticator().middleware())
+        config.use(TestAuthenticator())
     }
 }

--- a/Tests/VaporTests/AuthorizationTests.swift
+++ b/Tests/VaporTests/AuthorizationTests.swift
@@ -1,0 +1,91 @@
+import XCTVapor
+
+final class AuthorizationTests: XCTestCase {
+    func testRoleAuthorization() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.grouped([
+            TestUser.authenticator,
+            TestUser.authorizer(role: .admin)
+        ]).get("test") { req -> String in
+            try XCTAssertEqual(req.authz.require(TestUser.Role.self), .admin)
+            return try req.authc.require(TestUser.self).name
+        }
+
+        try app.test(.GET, "/test", afterResponse: { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }).test(.GET, "/test", beforeRequest: { req in
+            req.headers.bearerAuthorization = .init(token: "admin")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }).test(.GET, "/test", beforeRequest: { req in
+            req.headers.bearerAuthorization = .init(token: "user")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        })
+    }
+
+    func testParameterAuthorization() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.grouped([
+            EvenParameterAuthorizer(name: "foo")
+        ]).get("test", ":foo") { req -> HTTPStatus in
+            .ok
+        }
+
+        try app.test(.GET, "/test/1", afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        }).test(.GET, "/test/2", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+}
+
+private enum TestRole: Equatable, Authorizable {
+    case user
+    case admin
+}
+
+private struct TestUser: RoleAuthorizable {
+    static var authenticator: TestAuthenticator {
+        .init()
+    }
+
+    var name: String
+    var role: TestRole
+}
+
+private struct TestAuthenticator: BearerAuthenticator {
+    typealias User = TestUser
+
+    func authenticate(
+        bearer: BearerAuthorization,
+        for request: Request
+    ) -> EventLoopFuture<TestUser?> {
+        let role: User.Role
+        switch bearer.token {
+        case "user":
+            role = .user
+        case "admin":
+            role = .admin
+        default:
+            return request.eventLoop.makeSucceededFuture(nil)
+        }
+        let test = TestUser(name: "Vapor", role: role)
+        return request.eventLoop.makeSucceededFuture(test)
+    }
+}
+
+private struct EvenParameterAuthorizer: ParameterAuthorizer {
+    var name: String
+    func authorize(parameter: Int, for request: Request) -> EventLoopFuture<Void> {
+        guard parameter % 2 == 0 else {
+            return request.eventLoop.makeFailedFuture(Abort(.forbidden))
+        }
+        return request.eventLoop.makeSucceededFuture(())
+    }
+}


### PR DESCRIPTION
Proof of concept authorization implementation based heavily on the existing authentication API. 

Introduces two new protocols:

- `Authorizable`: Entities that can be authorized, like a user's posts.
- `Authorizer`: Types capable of authorizing entities, like a `RequestAuthorizer` or `ParameterAuthorizer`. 

Introduces a new helper API for accessing authorized data:

```swift
req.authz.require(Post.self)
```

Authorization functions similarly to Authentication. Authorizers are added to a route group and function as middleware. Authorizers can utilize the authentication API to get the currently authenticated user followed by implementation-specific logic to fetch and cache authorized data. The authorized data is retrieved by the user from `req.authz`. 

### Role Example

This example shows how authorization could be used with user roles.

Assume the following types:

```swift
enum Role: Equatable, Authorizable {
    case user
    case developer
    case admin
}

struct User: Authenticatable {
    var name: String
    var role: Role
}
```

A `RoleAuthorizer` can be created conforming to `RequestAuthorizer`. 

```swift
struct RoleAuthorizer: RequestAuthorizer {
    let roles: [Role]

    public func authorize(request: Request) -> EventLoopFuture<Void> {
        do {
            let user = try request.authc.require(User.self)
            guard self.roles.contains(user.role) else {
                throw Abort(.forbidden)
            }
            request.authz.add(user.role)
            return request.eventLoop.makeSucceededFuture(())
        } catch {
            return request.eventLoop.makeFailedFuture(error)
        }
    }
}
```

This authorizer ensures the authenticated user's roles exist in the role requirements of the authorizer. If it does, the user's specific role is stored in the authorization cache so that it can be accessed by the routes if needed.

```swift
app.grouped([
    // Any valid authenticator for User.
    SomeUserAuthenticator(), 
    // Require either the developer or admin role.
    RoleAuthorizer(roles: [.developer, .admin])
]).get("test") { req in
    let role = try req.authz.require(Role.self)
    print(role) // The authorized role, either .admin or .developer.
    let user = try req.authc.require(User.self)
    print(user) // The authenticated user. 
}
```

Like `Authenticator`s, `Authorizer`s can be used as middleware in route groups. We add a user authenticator first, then the role authorizer we created. This will protect our `GET /test` route with both authentication and authorization.

### Fluent Children Example

This example shows how authorization could be combined with Fluent APIs. 

Assume the following models:

```swift
final class User: Model, Content, Authenticatable {
    @ID var id: UUID?
    @Field var name: String
    @Children var todos: [Todo]
}

final class Todo: Model, Content, Authorizable {
    @ID var id: UUID?
    @Field var title: String
    @Parent var user: User
}
```

Given these models, and an assumed User authenticator, we could write the following code to protect Todo endpoints:

```swift
let todos = app.grouped("todos").grouped([
    User.authenticator // Assume any valid authenticator. 
])
// GET /todos
todos.get { req in
    // Use the existing authentication API to fetch the user
    // and return all of their todos.
    try req.authc.require(User.self)
        .$todos
        .query(on: req.db)
        .all()
}
// POST /todos
todos.post { req in
    // Use the existing authentication API to fetch the user
    // and attach a new Todo.
    let todo = try req.content.decode(Todo.self)
    return try req.authc.require(User.self)
        .$todos
        .create(todo, on: req.db)
        .transform(to: todo)
}

let todo = todos.grouped(":todoID").grouped([
    // This Fluent provided extension creates an authorizer
    // that requires the parameter exists as a child relation.
    User.authorizer(parameter: ":todoID", isChild: \.$todos)
])
// GET /todos/:id
todo.on(.GET) { req in
    // The authorized Todo was already fetched by the authorizer
    // and can be accessed from the authorization cache.
    try req.authz.require(Todo.self)
}
// DELETE /todos/:id
todo.on(.DELETE) { req in
    // Fetch the authorized Todo then delete it. 
    try req.authz.require(Todo.self)
        .delete(on: req.db)
        .transform(to: HTTPStatus.ok)
}
```

In the above example, `GET /todos` will return only the authenticated user's Todos. Likewise, `GET /todos/:id` will return an error if the user attempts to access a Todo that does not belong to them. 

See https://github.com/vapor/fluent/pull/661 for an example of Fluent `@Children` authorization helpers built on top of the base protocols.

See https://github.com/vapor/api-template/pull/90 for the API template (Todo example) updated with authorization. 