### PR TITLE
AbortError identifier fix

### DIFF
--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -54,7 +54,7 @@ public struct Abort: AbortError {
         function: String = #function,
         line: Int = #line
     ) {
-        self.identifier = status.code.description
+        self.identifier = identifier ?? status.code.description
         self.headers = headers
         self.status = status
         self.reason = reason ?? status.reasonPhrase


### PR DESCRIPTION
AbortError's constructor no longer ignores the supplied identifier (#2205). 