### PR TITLE
Add ByteBuffer.string helper to XCTVapor

### DIFF
--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,3 +1,2 @@
 @_exported import XCTest
 @_exported import Vapor
-

--- a/Sources/XCTVapor/Utilities.swift
+++ b/Sources/XCTVapor/Utilities.swift
@@ -1,0 +1,5 @@
+extension ByteBuffer {
+    public var string: String {
+        .init(decoding: self.readableBytesView, as: UTF8.self)
+    }
+}


### PR DESCRIPTION
Adds `ByteBuffer.string` helper for converting a ByteBuffer's readable bytes view to a `String` (#2206). 