### PR TITLE
Add Base32 APIs from Vapor 3's Crypto

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
     ],
     targets: [
         // C helpers
+        .target(name: "CBase32"),
         .target(name: "CBcrypt"),
         .target(name: "CMultipartParser"),
         .target(name: "COperatingSystem"),
@@ -62,6 +63,7 @@ let package = Package(
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
             .product(name: "AsyncKit", package: "async-kit"),
             .product(name: "Backtrace", package: "swift-backtrace"),
+            .target(name: "CBase32"),
             .target(name: "CBcrypt"),
             .target(name: "CMultipartParser"),
             .target(name: "COperatingSystem"),

--- a/Sources/CBase32/cbase32.c
+++ b/Sources/CBase32/cbase32.c
@@ -1,0 +1,95 @@
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#include "cbase32.h"
+
+int cbase32_decode(const uint8_t *encoded, uint8_t *result, int bufSize) {
+  int buffer = 0;
+  int bitsLeft = 0;
+  int count = 0;
+  for (const uint8_t *ptr = encoded; count < bufSize && *ptr; ++ptr) {
+    uint8_t ch = *ptr;
+    if (ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n' || ch == '-') {
+      continue;
+    }
+    buffer <<= 5;
+
+    // Deal with commonly mistyped characters
+    if (ch == '0') {
+      ch = 'O';
+    } else if (ch == '1') {
+      ch = 'L';
+    } else if (ch == '8') {
+      ch = 'B';
+    }
+
+    // Look up one base32 digit
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+      ch = (ch & 0x1F) - 1;
+    } else if (ch >= '2' && ch <= '7') {
+      ch -= '2' - 26;
+    } else {
+      return -1;
+    }
+
+    buffer |= ch;
+    bitsLeft += 5;
+    if (bitsLeft >= 8) {
+      result[count++] = buffer >> (bitsLeft - 8);
+      bitsLeft -= 8;
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}
+
+int cbase32_encode(const uint8_t *data, int length, uint8_t *result,
+                  int bufSize) {
+  if (length < 0 || length > (1 << 28)) {
+    return -1;
+  }
+  int count = 0;
+  if (length > 0) {
+    int buffer = data[0];
+    int next = 1;
+    int bitsLeft = 8;
+    while (count < bufSize && (bitsLeft > 0 || next < length)) {
+      if (bitsLeft < 5) {
+        if (next < length) {
+          buffer <<= 8;
+          buffer |= data[next++] & 0xFF;
+          bitsLeft += 8;
+        } else {
+          int pad = 5 - bitsLeft;
+          buffer <<= pad;
+          bitsLeft += pad;
+        }
+      }
+      int index = 0x1F & (buffer >> (bitsLeft - 5));
+      bitsLeft -= 5;
+      result[count++] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"[index];
+    }
+  }
+  if (count < bufSize) {
+    result[count] = '\000';
+  }
+  return count;
+}

--- a/Sources/CBase32/cbase32.h
+++ b/Sources/CBase32/cbase32.h
@@ -1,0 +1,37 @@
+// Base32 implementation
+//
+// Copyright 2010 Google Inc.
+// Author: Markus Gutschke
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Encode and decode from base32 encoding using the following alphabet:
+//   ABCDEFGHIJKLMNOPQRSTUVWXYZ234567
+// This alphabet is documented in RFC 4648/3548
+//
+// We allow white-space and hyphens, but all other characters are considered
+// invalid.
+//
+// All functions return the number of output bytes or -1 on error. If the
+// output buffer is too small, the result will silently be truncated.
+
+#ifndef _CBASE32_H_
+#define _CBASE32_H_
+
+#include <stdint.h>
+
+int cbase32_decode(const uint8_t *encoded, uint8_t *result, int bufSize);
+int cbase32_encode(const uint8_t *data, int length, uint8_t *result,
+                  int bufSize);
+
+#endif /* _BASE32_H_ */

--- a/Sources/CBase32/include/module.modulemap
+++ b/Sources/CBase32/include/module.modulemap
@@ -1,0 +1,4 @@
+module CBase32 [system][extern_c] {
+ header "../cbase32.h"
+ export *
+}

--- a/Sources/Vapor/Utilities/Base32.swift
+++ b/Sources/Vapor/Utilities/Base32.swift
@@ -1,0 +1,50 @@
+import CBase32
+
+extension Data {
+    // MARK: Base32
+
+    /// Decodes a base32 encoded `String`.
+    public init?(base32Encoded: String) {
+        guard let data = base32Encoded.data(using: .utf8) else {
+            return nil
+        }
+        self.init(base32Encoded: data)
+    }
+
+    /// Decodes base32 encoded `Data`.
+    public init?(base32Encoded: Data) {
+        let maxSize = (base32Encoded.count * 5 + 4) / 8
+        var result = UnsafeMutablePointer<UInt8>.allocate(capacity: maxSize)
+        defer {
+            result.deinitialize(count: maxSize)
+            result.deallocate()
+        }
+        let size = base32Encoded.withUnsafeBytes { ptr in
+            cbase32_decode(ptr.baseAddress?.assumingMemoryBound(to: UInt8.self), result, numericCast(maxSize))
+        }
+        self = .init(buffer: UnsafeBufferPointer(start: result, count: numericCast(size)))
+    }
+
+    /// Encodes data to a base32 encoded `String`.
+    ///
+    /// - returns: The base32 encoded string.
+    public func base32EncodedString() -> String {
+        return String(data: base32EncodedData(), encoding: .utf8)!
+    }
+
+    /// Encodes data to base32 encoded `Data`.
+    ///
+    /// - returns: The base32 encoded data.
+    public func base32EncodedData() -> Data {
+        let maxSize = (count * 8 + 4) / 5
+        var result = UnsafeMutablePointer<UInt8>.allocate(capacity: maxSize)
+        defer {
+            result.deinitialize(count: maxSize)
+            result.deallocate()
+        }
+        let size = self.withUnsafeBytes { ptr in
+            return cbase32_encode(ptr.baseAddress?.assumingMemoryBound(to: UInt8.self), numericCast(count), result, numericCast(maxSize))
+        }
+        return .init(buffer: UnsafeBufferPointer(start: result, count: numericCast(size)))
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1432,6 +1432,13 @@ final class ApplicationTests: XCTestCase {
             XCTFail("\(error)")
         }
     }
+
+    func testBase32() throws {
+        let data = Data([1, 2, 3, 4])
+        XCTAssertEqual(data.base32EncodedString(), "AEBAGBA")
+        XCTAssertEqual(Data(base32Encoded: "AEBAGBA"), data)
+
+    }
 }
 
 extension Application.Responder {


### PR DESCRIPTION
Ports Base32 APIs from Vapor 3's Crypto library to Vapor 4 now that we rely on SwiftCrypto. 

```swift
let data = Data([1, 2, 3, 4])
XCTAssertEqual(data.base32EncodedString(), "AEBAGBA")
XCTAssertEqual(Data(base32Encoded: "AEBAGBA"), data)
```