### PR TITLE
improve HTTP server compression configuration

### DIFF
--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -1,1 +1,71 @@
-// nothing here yet...
+extension HTTPServer.Configuration {
+    /// When `true`, HTTP server will support gzip and deflate compression.
+    @available(*, deprecated, message: "Use requestDecompression and responseCompression")
+    public var supportCompression: Bool {
+        get {
+            switch (self.requestDecompression.storage, self.responseCompression.storage) {
+            case (.enabled, .enabled):
+                return true
+            default:
+                return false
+            }
+        }
+        set {
+            self.requestDecompression = .enabled
+            self.responseCompression = .enabled
+        }
+    }
+
+    /// Limit of data to decompress when HTTP compression is supported.
+    @available(*, deprecated, message: "Use requestDecompression")
+    public var decompressionLimit: NIOHTTPDecompression.DecompressionLimit {
+        get {
+            switch self.requestDecompression.storage {
+            case .disabled:
+                return .ratio(10)
+            case .enabled(let limit):
+                return limit
+            }
+        }
+        set {
+            self.requestDecompression = .enabled(limit: newValue)
+        }
+    }
+
+    @available(*, deprecated, message: "Use requestDecompression and responseCompression")
+    public init(
+        hostname: String = "127.0.0.1",
+        port: Int = 8080,
+        backlog: Int = 256,
+        maxBodySize: Int = 1 << 14,
+        reuseAddress: Bool = true,
+        tcpNoDelay: Bool = true,
+        webSocketMaxFrameSize: Int = 1 << 14,
+        supportCompression: Bool = false,
+        decompressionLimit: NIOHTTPDecompression.DecompressionLimit = .ratio(10),
+        supportPipelining: Bool = false,
+        supportVersions: Set<HTTPVersionMajor>? = nil,
+        tlsConfiguration: TLSConfiguration? = nil,
+        serverName: String? = nil,
+        logger: Logger? = nil
+    ) {
+        self.init(
+            hostname: hostname,
+            port: port,
+            backlog: backlog,
+            maxBodySize: maxBodySize,
+            reuseAddress: reuseAddress,
+            tcpNoDelay: tcpNoDelay,
+            webSocketMaxFrameSize: webSocketMaxFrameSize,
+            responseCompression: supportCompression
+                ? .enabled : .disabled,
+            requestDecompression: supportCompression
+                ? .enabled(limit: decompressionLimit) : .disabled,
+            supportPipelining: supportPipelining,
+            supportVersions: supportVersions,
+            tlsConfiguration: tlsConfiguration,
+            serverName: serverName,
+            logger: logger
+        )
+    }
+}

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -31,6 +31,8 @@
 @_exported import struct NIOHTTP1.HTTPVersion
 @_exported import enum NIOHTTP1.HTTPResponseStatus
 
+@_exported import enum NIOHTTPCompression.NIOHTTPDecompression
+
 @_exported import struct NIOSSL.TLSConfiguration
 
 @_exported import WebSocketKit

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1405,8 +1405,10 @@ final class ApplicationTests: XCTestCase {
         let smallBody = ByteBuffer(base64String: "H4sIAAAAAAAAE/NIzcnJ11Eozy/KSVEEAObG5usNAAA=")! // "Hello, world!"
         let bigBody = ByteBuffer(base64String: "H4sIAAAAAAAAE/NIzcnJ11HILU3OgBBJmenpqUUK5flFOSkKJRmJeQpJqWn5RamKAICcGhUqAAAA")! // "Hello, much much bigger world than before!"
 
-        app.server.configuration.supportCompression = true
-        app.server.configuration.decompressionLimit = .size(smallBody.readableBytes) // Max out at the smaller payload (.size is of compressed data)
+        // Max out at the smaller payload (.size is of compressed data)
+        app.server.configuration.requestDecompression = .enabled(
+            limit: .size(smallBody.readableBytes)
+        )
         app.post("gzip") { $0.body.string ?? "" }
 
         let server = try app.server.start()


### PR DESCRIPTION
Improves HTTP server compression configuration APIs.

```swift
app.server.configuration.responseCompression = .disabled
app.server.configuration.requestDecompression = .enabled(
    limit: .ratio(15)
)
```