### PR TITLE
add Storage to Request + Response, deprecate userInfo

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -7,7 +7,6 @@ public final class Application {
     public let eventLoopGroupProvider: EventLoopGroupProvider
     public let eventLoopGroup: EventLoopGroup
     public var storage: Storage
-    public var userInfo: [AnyHashable: Any]
     public private(set) var didShutdown: Bool
     public var logger: Logger
     private var isBooted: Bool
@@ -71,7 +70,6 @@ public final class Application {
             self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         }
         self.locks = .init()
-        self.userInfo = [:]
         self.didShutdown = false
         self.logger = .init(label: "codes.vapor.application")
         self.storage = .init(logger: self.logger)
@@ -140,7 +138,6 @@ public final class Application {
         self.logger.trace("Clearing Application storage")
         self.storage.shutdown()
         self.storage.clear()
-        self.userInfo = [:]
 
         switch self.eventLoopGroupProvider {
         case .shared:

--- a/Sources/Vapor/Authentication/AuthenticationCache.swift
+++ b/Sources/Vapor/Authentication/AuthenticationCache.swift
@@ -84,20 +84,17 @@ extension Request {
         }
     }
 
+    private struct AuthenticationCacheKey: StorageKey {
+        typealias Value = AuthenticationCache
+    }
+
     internal var _authenticationCache: AuthenticationCache {
-        get {
-            if let existing = self.userInfo[_authenticationCacheKey] as? AuthenticationCache {
-                return existing
-            } else {
-                let new = AuthenticationCache()
-                self.userInfo[_authenticationCacheKey] = new
-                return new
-            }
-        }
-        set {
-            self.userInfo[_authenticationCacheKey] = newValue
+        if let existing = self.storage[AuthenticationCacheKey.self] {
+            return existing
+        } else {
+            let new = AuthenticationCache()
+            self.storage[AuthenticationCacheKey.self] = new
+            return new
         }
     }
 }
-
-private let _authenticationCacheKey = "authc"

--- a/Sources/Vapor/Deprecated.swift
+++ b/Sources/Vapor/Deprecated.swift
@@ -1,1 +1,31 @@
-// nothing here yet...
+extension Application {
+    private struct UserInfoKey: StorageKey {
+        typealias Value = [AnyHashable: Any]
+    }
+
+    @available(*, deprecated, message: "Use storage instead.")
+    public var userInfo: [AnyHashable: Any] {
+        get {
+            self.storage[UserInfoKey.self] ?? [:]
+        }
+        set {
+            self.storage[UserInfoKey.self] = newValue
+        }
+    }
+}
+
+extension Request {
+    private struct UserInfoKey: StorageKey {
+        typealias Value = [AnyHashable: Any]
+    }
+
+    @available(*, deprecated, message: "Use storage instead.")
+    public var userInfo: [AnyHashable: Any] {
+        get {
+            self.storage[UserInfoKey.self] ?? [:]
+        }
+        set {
+            self.storage[UserInfoKey.self] = newValue
+        }
+    }
+}

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -128,8 +128,8 @@ public final class Request: CustomStringConvertible {
     public let eventLoop: EventLoop
     
     public var parameters: Parameters
-    
-    public var userInfo: [AnyHashable: Any]
+
+    public var storage: Storage
     
     public convenience init(
         application: Application,
@@ -181,7 +181,7 @@ public final class Request: CustomStringConvertible {
         self.remoteAddress = remoteAddress
         self.eventLoop = eventLoop
         self.parameters = .init()
-        self.userInfo = [:]
+        self.storage = .init()
         self.isKeepAlive = true
         self.logger = logger
         self.logger[metadataKey: "request-id"] = .string(UUID().uuidString)

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -37,6 +37,8 @@ public final class Response: CustomStringConvertible {
     }
     
     internal var upgrader: Upgrader?
+
+    public var storage: Storage
     
     /// Get and set `HTTPCookies` for this `HTTPResponse`
     /// This accesses the `"Set-Cookie"` header.
@@ -131,6 +133,7 @@ public final class Response: CustomStringConvertible {
         self.version = version
         self.headers = headers
         self.body = body
+        self.storage = .init()
     }
 }
 

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -34,21 +34,18 @@ extension Request {
     public func destroySession() {
         self._sessionCache.session = nil
     }
+
+    private struct SessionCacheKey: StorageKey {
+        typealias Value = SessionCache
+    }
     
     internal var _sessionCache: SessionCache {
-        get {
-            if let existing = self.userInfo[_sessionCacheKey] as? SessionCache {
-                return existing
-            } else {
-                let new = SessionCache()
-                self.userInfo[_sessionCacheKey] = new
-                return new
-            }
-        }
-        set {
-            self.userInfo[_sessionCacheKey] = newValue
+        if let existing = self.storage[SessionCacheKey.self] {
+            return existing
+        } else {
+            let new = SessionCache()
+            self.storage[SessionCacheKey.self] = new
+            return new
         }
     }
 }
-
-private let _sessionCacheKey = "session"


### PR DESCRIPTION
Adds `Request.storage` and `Response.storage` for storing user-defined values. `userInfo` has been deprecated since `Storage` is more type-safe and performant (#2216). 