### PR TITLE
Collected request body drain .end

### DIFF
--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -29,6 +29,7 @@ extension Request {
                 }
             case .collected(let buffer):
                 _ = handler(.buffer(buffer))
+                _ = handler(.end)
             case .none: break
             }
         }


### PR DESCRIPTION
Correctly sends `.end` when draining a body with collected buffer (#2222, fixes #2210). 