### PR TITLE
Update to Metrics 2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
 
         // Swift metrics API
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
 
         // WebSocket client library built on SwiftNIO
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0-rc.1"),

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -8,7 +8,6 @@
 @_exported import Foundation
 
 @_exported import Logging
-@_exported import Metrics
 
 @_exported import struct NIO.ByteBuffer
 @_exported import struct NIO.ByteBufferAllocator

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -1,3 +1,5 @@
+import Metrics
+
 /// Vapor's main `Responder` type. Combines configured middleware + router to create a responder.
 internal struct DefaultResponder: Responder {
     private let router: TrieRouter<Route>


### PR DESCRIPTION
Updates to SwiftMetrics 2.0 which adds a new case the `TimeUnit` enum (#2224, fixes #2213).

⚠️ `Metrics` is no longer `@_exported` by Vapor. Add `import Metrics` to any files you use SwiftMetrics in.