### PR TITLE
Detect package source path from DerivedData directory

### DIFF
--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -46,9 +46,10 @@ public struct DirectoryConfiguration {
             let WorkspacePath: String
             var workspaceURL: URL { URL(fileURLWithPath: WorkspacePath, isDirectory: true) }
         }
-        if (try? workingDirectoryURL.checkSubpathExists(at: "Build", isDirectory: true)) ?? false,
-           (try? workingDirectoryURL.checkSubpathExists(at: "Index", isDirectory: true)) ?? false,
-           let infoPlistData = try? Data.init(contentsOf: workingDirectoryURL.appendingPathComponent("info.plist", isDirectory: false)),
+        let possibleBuildAreaURL = workingDirectoryURL.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        if (try? possibleBuildAreaURL.checkSubpathExists(at: "Build", isDirectory: true)) ?? false,
+           (try? possibleBuildAreaURL.checkSubpathExists(at: "Index", isDirectory: true)) ?? false,
+           let infoPlistData = try? Data.init(contentsOf: possibleBuildAreaURL.appendingPathComponent("info.plist", isDirectory: false)),
            let workspaceInfo = try? PropertyListDecoder().decode(BuildAreaInfo.self, from: infoPlistData),
            (try? workspaceInfo.workspaceURL.checkSubpathExists(at: "Package.swift", isDirectory: false)) ?? false
         {

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -80,65 +80,8 @@ public extension String {
     }
 }
 
-public extension URL {
-    
-    /// Same as `URL.checkResourceIsReachable()`, but explicitly requires that
-    /// the recevier be a file URL, and does _not_ throw if the file simply
-    /// doesn't exist.
-    ///
-    /// - Warning: As with any filesystem API which is not specifically designed
-    /// to handle race conditions, this method **MUST** be considered purely
-    /// advisory; the actual state of the filesystem may change in ways which
-    /// render the result inaccurate at any time and without warning.
-    ///
-    /// - Throws:
-    ///   - Any error potentially thrown by `URL.checkResourceIsReachable()`
-    ///   - `POSIXError.EINVAL` if the receiver is not a file URL.
-    /// - Returns: `true` if, at the time of the call, the receiver refers to a
-    /// filesystem path which appeared to exist when the check was made. `false`
-    /// if the opposite is true and no other filesystem error occurred.
-    func checkFileURLExists() throws -> Bool {
         do {
-            guard self.isFileURL else {
-                throw POSIXError(.EINVAL)
-            }
-            
-            return try self.checkResourceIsReachable()
         } catch CocoaError.fileReadNoSuchFile {
-            return false
         }
     }
-    
-    /// Same as `URL.checkFileURLExists()`, but performs the check operation on
-    /// the result of appending the provided path component to the receiver.
-    ///
-    /// - Warning: As with any filesystem API which is not specifically designed
-    /// to handle race conditions, this method **MUST** be considered purely
-    /// advisory; the actual state of the filesystem may change in ways which
-    /// render the result inaccurate at any time and without warning.
-    ///
-    /// - Parameters:
-    ///   - subpath: A path component to be appended to the receiver, as by
-    ///   `URL.appendingPathComponent(_:)` and checked for existence.
-    ///   - isDirectory: If non-`nil`, indicates whether `subpath` represents a
-    ///   directory. It is always prefrred to provide a value for this parameter
-    ///   whenever possible.
-    /// - Throws: See `URL.checkFileURLExists()`
-    /// - Returns: `treu` if, at the time of the call, the result of appending
-    /// the given `subpath` to the receiver refers to a filesystem path which
-    /// appeared to exist when the check was made. `false` if the opposite was
-    /// true and no other filesystem error occurred.
-    func checkSubpathExists(at subpath: String, isDirectory: Bool? = nil) throws -> Bool {
-        let checkURL: URL
-        
-        if let isDirectory = isDirectory {
-            checkURL = self.appendingPathComponent(subpath, isDirectory: isDirectory)
-        } else {
-            checkURL = self.appendingPathComponent(subpath)
-        }
-        
-        return try checkURL.checkFileURLExists()
-    }
-
 }
-

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -1,8 +1,4 @@
-#if os(Linux)
-import Glibc
-#else
-import Darwin.C
-#endif
+import Foundation
 
 /// `DirectoryConfiguration` represents a configured working directory.
 /// It can also be used to derive a working directory automatically.
@@ -28,25 +24,41 @@ public struct DirectoryConfiguration {
         self.publicDirectory = self.workingDirectory + "Public/"
     }
     
-    /// Creates a `DirectoryConfig` by deriving a working directory using the `#file` variable or `getcwd` method.
+    /// Creates a `DirectoryConfig` by deriving a working directory using the `getcwd` method.
     ///
     /// - returns: The derived `DirectoryConfig` if it could be created, otherwise just "./".
     public static func detect() -> DirectoryConfiguration {
+        let fileManager = FileManager.default
+        
         // get actual working directory
-        let cwd = getcwd(nil, Int(PATH_MAX))
-        defer {
-            free(cwd)
-        }
-
-        let workingDirectory: String
-
-        if let cwd = cwd, let string = String(validatingUTF8: cwd) {
-            workingDirectory = string
-        } else {
-            workingDirectory = "./"
-        }
+        let workingDirectory = fileManager.currentDirectoryPath
+        let workingDirectoryURL = URL(fileURLWithPath: workingDirectory, isDirectory: true)
 
         #if Xcode
+        // Starting with no later than Xcode 11.4b1, and possibly earlier, the DerivedData directory for an
+        // SPM package's workspace contains an `info.plist` which points directly at where `Package.swift`
+        // lives. Very useful! We do some sanity checks that may seem a bit excessive, but are considered
+        // reasonable for ensuring that we neither require the project build directory actually be under the
+        // usual DerivedData location (as this can be changed), nor accidentally treat some other kind of
+        // working directory as a project build area.
+        struct BuildAreaInfo: Codable {
+            let LastAccessedDate: Date
+            let WorkspacePath: String
+            var workspaceURL: URL { URL(fileURLWithPath: WorkspacePath, isDirectory: true) }
+        }
+        if (try? workingDirectoryURL.checkSubpathExists(at: "Build", isDirectory: true)) ?? false,
+           (try? workingDirectoryURL.checkSubpathExists(at: "Index", isDirectory: true)) ?? false,
+           let infoPlistData = try? Data.init(contentsOf: workingDirectoryURL.appendingPathComponent("info.plist", isDirectory: false)),
+           let workspaceInfo = try? PropertyListDecoder().decode(BuildAreaInfo.self, from: infoPlistData),
+           (try? workspaceInfo.workspaceURL.checkSubpathExists(at: "Package.swift", isDirectory: false)) ?? false
+        {
+            // There are `Build` and `Index` directories, the `info.plist` file's structure matches the expected
+            // format, the detected workspace has a `Package.swift` in it, and this is an Xcode build. That's
+            // probably a pretty safe sanity check.
+            return DirectoryConfiguration(workingDirectory: workspaceInfo.WorkspacePath)
+        }
+        
+        // Okay, all that failed. Do our usual sodden `DerivedData` check.
         if workingDirectory.contains("DerivedData") {
             Logger(label: "codes.vapor.directory-config")
                 .warning("No custom working directory set for this scheme, using \(workingDirectory)")
@@ -66,3 +78,66 @@ public extension String {
         }
     }
 }
+
+public extension URL {
+    
+    /// Same as `URL.checkResourceIsReachable()`, but explicitly requires that
+    /// the recevier be a file URL, and does _not_ throw if the file simply
+    /// doesn't exist.
+    ///
+    /// - Warning: As with any filesystem API which is not specifically designed
+    /// to handle race conditions, this method **MUST** be considered purely
+    /// advisory; the actual state of the filesystem may change in ways which
+    /// render the result inaccurate at any time and without warning.
+    ///
+    /// - Throws:
+    ///   - Any error potentially thrown by `URL.checkResourceIsReachable()`
+    ///   - `POSIXError.EINVAL` if the receiver is not a file URL.
+    /// - Returns: `true` if, at the time of the call, the receiver refers to a
+    /// filesystem path which appeared to exist when the check was made. `false`
+    /// if the opposite is true and no other filesystem error occurred.
+    func checkFileURLExists() throws -> Bool {
+        do {
+            guard self.isFileURL else {
+                throw POSIXError(.EINVAL)
+            }
+            
+            return try self.checkResourceIsReachable()
+        } catch CocoaError.fileReadNoSuchFile {
+            return false
+        }
+    }
+    
+    /// Same as `URL.checkFileURLExists()`, but performs the check operation on
+    /// the result of appending the provided path component to the receiver.
+    ///
+    /// - Warning: As with any filesystem API which is not specifically designed
+    /// to handle race conditions, this method **MUST** be considered purely
+    /// advisory; the actual state of the filesystem may change in ways which
+    /// render the result inaccurate at any time and without warning.
+    ///
+    /// - Parameters:
+    ///   - subpath: A path component to be appended to the receiver, as by
+    ///   `URL.appendingPathComponent(_:)` and checked for existence.
+    ///   - isDirectory: If non-`nil`, indicates whether `subpath` represents a
+    ///   directory. It is always prefrred to provide a value for this parameter
+    ///   whenever possible.
+    /// - Throws: See `URL.checkFileURLExists()`
+    /// - Returns: `treu` if, at the time of the call, the result of appending
+    /// the given `subpath` to the receiver refers to a filesystem path which
+    /// appeared to exist when the check was made. `false` if the opposite was
+    /// true and no other filesystem error occurred.
+    func checkSubpathExists(at subpath: String, isDirectory: Bool? = nil) throws -> Bool {
+        let checkURL: URL
+        
+        if let isDirectory = isDirectory {
+            checkURL = self.appendingPathComponent(subpath, isDirectory: isDirectory)
+        } else {
+            checkURL = self.appendingPathComponent(subpath)
+        }
+        
+        return try checkURL.checkFileURLExists()
+    }
+
+}
+

--- a/Sources/Vapor/Utilities/URL+CheckFileExists.swift
+++ b/Sources/Vapor/Utilities/URL+CheckFileExists.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public extension URL {
+    
+    /// Same as `URL.checkResourceIsReachable()`, but explicitly requires that
+    /// the recevier be a file URL, and does _not_ throw if the file simply
+    /// doesn't exist.
+    ///
+    /// - Warning: As with any filesystem API which is not specifically designed
+    /// to handle race conditions, this method **MUST** be considered purely
+    /// advisory; the actual state of the filesystem may change in ways which
+    /// render the result inaccurate at any time and without warning.
+    ///
+    /// - Throws:
+    ///   - Any error potentially thrown by `URL.checkResourceIsReachable()`
+    ///   - `POSIXError.EINVAL` if the receiver is not a file URL.
+    /// - Returns: `true` if, at the time of the call, the receiver refers to a
+    /// filesystem path which appeared to exist when the check was made. `false`
+    /// if the opposite is true and no other filesystem error occurred.
+    func checkFileURLExists() throws -> Bool {
+        do {
+            guard self.isFileURL else {
+                throw POSIXError(.EINVAL)
+            }
+            
+            return try self.checkResourceIsReachable()
+        } catch CocoaError.fileReadNoSuchFile {
+            return false
+        }
+    }
+    
+    /// Same as `URL.checkFileURLExists()`, but performs the check operation on
+    /// the result of appending the provided path component to the receiver.
+    ///
+    /// - Warning: As with any filesystem API which is not specifically designed
+    /// to handle race conditions, this method **MUST** be considered purely
+    /// advisory; the actual state of the filesystem may change in ways which
+    /// render the result inaccurate at any time and without warning.
+    ///
+    /// - Parameters:
+    ///   - subpath: A path component to be appended to the receiver, as by
+    ///   `URL.appendingPathComponent(_:)` and checked for existence.
+    ///   - isDirectory: If non-`nil`, indicates whether `subpath` represents a
+    ///   directory. It is always prefrred to provide a value for this parameter
+    ///   whenever possible.
+    /// - Throws: See `URL.checkFileURLExists()`
+    /// - Returns: `treu` if, at the time of the call, the result of appending
+    /// the given `subpath` to the receiver refers to a filesystem path which
+    /// appeared to exist when the check was made. `false` if the opposite was
+    /// true and no other filesystem error occurred.
+    func checkSubpathExists(at subpath: String, isDirectory: Bool? = nil) throws -> Bool {
+        let checkURL: URL
+        
+        if let isDirectory = isDirectory {
+            checkURL = self.appendingPathComponent(subpath, isDirectory: isDirectory)
+        } else {
+            checkURL = self.appendingPathComponent(subpath)
+        }
+        
+        return try checkURL.checkFileURLExists()
+    }
+
+}

--- a/Tests/VaporTests/DirectoryConfigurationTests.swift
+++ b/Tests/VaporTests/DirectoryConfigurationTests.swift
@@ -13,18 +13,22 @@ class DirectoryConfigurationTests: XCTestCase {
         let tempDirectoryURL = URL(fileURLWithPath: try createTemporaryDirectory(), isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempDirectoryURL) }
         
+        let buildProductsForConfigURL = tempDirectoryURL
+            .appendingPathComponent("Build", isDirectory: true)
+            .appendingPathComponent("Products", isDirectory: true)
+            .appendingPathComponent("Debug", isDirectory: true)
         let fakeWorkspaceURL = tempDirectoryURL.appendingPathComponent("Workspace", isDirectory: true)
         let plistInfo: [String: Any] = ["LastAccessedDate": Date(), "WorkspacePath": fakeWorkspaceURL.path]
         let plistData = try PropertyListSerialization.data(fromPropertyList: plistInfo, format: .xml, options: 0)
         
-        try FileManager.default.createDirectory(at: tempDirectoryURL.appendingPathComponent("Build", isDirectory: true), withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: buildProductsForConfigURL, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: tempDirectoryURL.appendingPathComponent("Index", isDirectory: true), withIntermediateDirectories: false)
         try FileManager.default.createDirectory(at: fakeWorkspaceURL, withIntermediateDirectories: false)
                 
         try plistData.write(to: tempDirectoryURL.appendingPathComponent("info.plist", isDirectory: false))
         try Data().write(to: fakeWorkspaceURL.appendingPathComponent("Package.swift", isDirectory: false))
         
-        guard FileManager.default.changeCurrentDirectoryPath(tempDirectoryURL.path) else {
+        guard FileManager.default.changeCurrentDirectoryPath(buildProductsForConfigURL.path) else {
             throw CocoaError(.fileWriteUnknown)
         }
         

--- a/Tests/VaporTests/DirectoryConfigurationTests.swift
+++ b/Tests/VaporTests/DirectoryConfigurationTests.swift
@@ -1,0 +1,59 @@
+@testable import Vapor
+import XCTest
+import Foundation
+
+class DirectoryConfigurationTests: XCTestCase {
+
+    // The code we test here is only compiled in when `#if Xcode` is true, so we match the condition here too.
+    #if Xcode
+    
+    func testDirectoryConfigurationDetectsValidBuildArea() throws {
+    
+        // Set up a fake build area that satisfies the conditions we check for.
+        let tempDirectoryURL = URL(fileURLWithPath: try createTemporaryDirectory(), isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectoryURL) }
+        
+        let fakeWorkspaceURL = tempDirectoryURL.appendingPathComponent("Workspace", isDirectory: true)
+        let plistInfo: [String: Any] = ["LastAccessedDate": Date(), "WorkspacePath": fakeWorkspaceURL.path]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: plistInfo, format: .xml, options: 0)
+        
+        try FileManager.default.createDirectory(at: tempDirectoryURL.appendingPathComponent("Build", isDirectory: true), withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: tempDirectoryURL.appendingPathComponent("Index", isDirectory: true), withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: fakeWorkspaceURL, withIntermediateDirectories: false)
+                
+        try plistData.write(to: tempDirectoryURL.appendingPathComponent("info.plist", isDirectory: false))
+        try Data().write(to: fakeWorkspaceURL.appendingPathComponent("Package.swift", isDirectory: false))
+        
+        guard FileManager.default.changeCurrentDirectoryPath(tempDirectoryURL.path) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        
+        let detectedConfig = DirectoryConfiguration.detect()
+        
+        XCTAssertEqual(detectedConfig.workingDirectory, fakeWorkspaceURL.path.finished(with: "/"))
+    }
+    
+    #endif
+
+}
+
+// Taken from https://github.com/apple/swift-nio/blob/2.14.0/Tests/NIOTests/TestUtils.swift#L134-L147
+// Modified to:
+//  - Query `FileManager` directly
+//  - Use a different prefix
+//  - Throw a `POSIXError` if `mkdtemp(3)` fails.
+func createTemporaryDirectory() throws -> String {
+    let template = "\(FileManager.default.temporaryDirectory.path)/.VaporTests-temp-dir_XXXXXX"
+
+    var templateBytes = template.utf8 + [0]
+    let templateBytesCount = templateBytes.count
+    try templateBytes.withUnsafeMutableBufferPointer { ptr in
+        try ptr.baseAddress!.withMemoryRebound(to: Int8.self, capacity: templateBytesCount) { (ptr: UnsafeMutablePointer<Int8>) in
+            guard mkdtemp(ptr) != nil else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EINVAL, userInfo: [NSFilePathErrorKey: template])
+            }
+        }
+    }
+    templateBytes.removeLast()
+    return String(decoding: templateBytes, as: Unicode.UTF8.self)
+}


### PR DESCRIPTION
Since at least Xcode 11.4b1 (and probably sooner), there is an `info.plist` in a Swift package's `DerivedData` subdirectory. This plist provides the path to the directory containing `Package.swift`. Updates `DirectoryConfiguration.detect()` to notice and use this when possible. Implemented in a thoroughly paranoid fashion that probably does more checking than it really needs to.

A rather late attempt to re-address https://github.com/vapor/core/issues/207.