### PR TITLE
Expose initializer of Validator

### DIFF
--- a/Sources/Vapor/Validation/Validator.swift
+++ b/Sources/Vapor/Validation/Validator.swift
@@ -1,3 +1,6 @@
 public struct Validator<T: Decodable> {
     public let validate: (_ data: T) -> ValidatorResult
+    public init(validate: @escaping (_ data: T) -> ValidatorResult) {
+        self.validate = validate
+    }
 }


### PR DESCRIPTION
The initializer of `Validator` is now public for creating custom validators (#2232, fixes #2231).