### PR TITLE
Return custom response for ValidationsError from default ErrorMiddleware

### DIFF
--- a/Sources/Vapor/Error/CustomErrorResponseConvertible.swift
+++ b/Sources/Vapor/Error/CustomErrorResponseConvertible.swift
@@ -1,0 +1,3 @@
+public protocol CustomErrorResponseConvertible {
+    func customResponse() -> Response
+}

--- a/Sources/Vapor/Error/HasCustomResponse.swift
+++ b/Sources/Vapor/Error/HasCustomResponse.swift
@@ -1,3 +1,0 @@
-public protocol HasCustomResponse {
-    func customResponse() -> Response
-}

--- a/Sources/Vapor/Error/HasCustomResponse.swift
+++ b/Sources/Vapor/Error/HasCustomResponse.swift
@@ -1,0 +1,3 @@
+public protocol ErrorWithCustomResponse {
+    func customResponse() -> Response
+}

--- a/Sources/Vapor/Error/HasCustomResponse.swift
+++ b/Sources/Vapor/Error/HasCustomResponse.swift
@@ -1,3 +1,3 @@
-public protocol ErrorWithCustomResponse {
+public protocol HasCustomResponse {
     func customResponse() -> Response
 }

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -23,7 +23,7 @@ public final class ErrorMiddleware: Middleware {
             let headers: HTTPHeaders
             
             // directly return response if error conforms to HasCustomResponse
-            if let responseError = error as? HasCustomResponse {
+            if let responseError = error as? CustomErrorResponseConvertible {
                 return responseError.customResponse()
             }
 

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -21,6 +21,11 @@ public final class ErrorMiddleware: Middleware {
             let status: HTTPResponseStatus
             let reason: String
             let headers: HTTPHeaders
+            
+            // directly return response if error conforms to HasCustomResponse
+            if let responseError = error as? ErrorWithCustomResponse {
+                return responseError.customResponse()
+            }
 
             // inspect the error type
             switch error {

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -23,7 +23,7 @@ public final class ErrorMiddleware: Middleware {
             let headers: HTTPHeaders
             
             // directly return response if error conforms to HasCustomResponse
-            if let responseError = error as? ErrorWithCustomResponse {
+            if let responseError = error as? HasCustomResponse {
                 return responseError.customResponse()
             }
 

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -38,7 +38,7 @@ extension ValidationsError: AbortError {
     }
 }
 
-extension ValidationsError: ErrorWithCustomResponse {
+extension ValidationsError: HasCustomResponse {
     internal struct ErrorResponse: Codable {
         var error: Bool
         var reason: String

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -38,7 +38,7 @@ extension ValidationsError: AbortError {
     }
 }
 
-extension ValidationsError: HasCustomResponse {
+extension ValidationsError: CustomErrorResponseConvertible {
     internal struct ErrorResponse: Codable {
         var error: Bool
         var reason: String

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -47,8 +47,12 @@ extension ValidationsError: HasCustomResponse {
     
     public func customResponse() -> Response {
         // collect validationErrors
-        let validationErrors = self.failures.reduce(into: [String: String]()) {
-            $0[$1.key.description] = $1.failureDescription ?? ""
+        var validationErrors: [String: String] = [:]
+        
+        self.failures.forEach { failure in
+            validationErrors = validationErrors.merging([failure.key.description: failure.failureDescription ?? ""]) {
+                return $0 + ", " + $1
+            }
         }
         
         // create a Response with appropriate status

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -635,6 +635,12 @@ final class ApplicationTests: XCTestCase {
             var email: String
         }
         
+        struct ValidationErrorResponse: Codable {
+            var error: Bool
+            var reason: String
+            var validationErrors: [String: String]
+        }
+        
         let app = Application(.testing)
         defer { app.shutdown() }
         
@@ -651,6 +657,11 @@ final class ApplicationTests: XCTestCase {
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "email is not a valid email address")
+            XCTAssertContent(ValidationErrorResponse.self, res, { error in
+                XCTAssertTrue(error.error)
+                XCTAssertContains(error.reason, "email is not a valid email address")
+                XCTAssertEqual(error.validationErrors["email"], "email is not a valid email address")
+            })
         }
     }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -629,6 +629,7 @@ final class ApplicationTests: XCTestCase {
         struct User: Content, Validatable {
             static func validations(_ v: inout Validations) {
                 v.add("email", is: .email)
+                v.add("email", is: .ascii)
             }
 
             var name: String
@@ -652,7 +653,7 @@ final class ApplicationTests: XCTestCase {
         try app.testable().test(.POST, "/users", beforeRequest: { req in
             try req.content.encode([
                 "name": "vapor",
-                "email": "foo"
+                "email": "foo®"
             ], as: .json)
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
@@ -660,7 +661,7 @@ final class ApplicationTests: XCTestCase {
             XCTAssertContent(ValidationErrorResponse.self, res, { error in
                 XCTAssertTrue(error.error)
                 XCTAssertContains(error.reason, "email is not a valid email address")
-                XCTAssertEqual(error.validationErrors["email"], "email is not a valid email address")
+                XCTAssertEqual(error.validationErrors["email"], "email is not a valid email address, email contains \'®\' (allowed: ASCII)")
             })
         }
     }


### PR DESCRIPTION
- Create a new protocol `CustomErrorResponseConvertible` for adding a custom response to an error.
```swift
extension SpecialError: CustomErrorResponseConvertible {
  func customResponse() -> Response {
    let response: Response
    // Create custom response
    return response
  }
}
```
This custom response will be returned from `ErrorMiddleware.default` if the error confirms to the protocol.
```swift
// Inside of ErrorMiddleware.default closure
if let responseError = error as? CustomErrorResponseConvertible {
  return responseError.customResponse()
}
```

- Conform `ValidationsError` to `CustomErrorResponseConvertible` to return a dictionary of validationErrors within the response body:
```json
{
  "error": true,
  "reason": "email is not a valid email address",
  "validationErrors": {
    "email": "email is not a valid email address"
  }
}
```