### PR TITLE
Add Metadata type to AbortError & return validationErrors as metadata

### DIFF
--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -18,6 +18,9 @@ public protocol AbortError: LocalizedError, CustomStringConvertible {
     /// The human-readable (and hopefully understandable) reason for this error.
     var reason: String { get }
     
+    /// Some metadata for the error
+    var metadata: Metadata { get }
+    
     var source: ErrorSource? { get }
 }
 
@@ -49,6 +52,10 @@ extension AbortError {
     
     public var source: ErrorSource? {
         return nil
+    }
+
+    public var metadata: Metadata {
+        return [:]
     }
 }
 

--- a/Sources/Vapor/Utilities/Metadata.swift
+++ b/Sources/Vapor/Utilities/Metadata.swift
@@ -75,16 +75,17 @@ extension MetadataValue: Encodable {
     }
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.singleValueContainer()
+
         switch self {
         case .string(let value):
-            try container.encode(value, forKey: .string)
+            try container.encode(value)
         case .stringConvertible(let value):
-            try container.encode(value.description, forKey: .stringConvertible)
+            try container.encode(value.description)
         case .dictionary(let value):
-            try container.encode(value, forKey: .dictionary)
+            try container.encode(value)
         case .array(let value):
-            try container.encode(value, forKey: .array)
+            try container.encode(value)
         }
     }
 }

--- a/Sources/Vapor/Utilities/Metadata.swift
+++ b/Sources/Vapor/Utilities/Metadata.swift
@@ -13,6 +13,8 @@ extension MetadataValue: Encodable {
         var container = encoder.singleValueContainer()
         
         switch value {
+        case let metadata as MetadataValue:
+            try container.encode(metadata)
         case is Void:
             try container.encodeNil()
         case let bool as Bool:

--- a/Sources/Vapor/Utilities/Metadata.swift
+++ b/Sources/Vapor/Utilities/Metadata.swift
@@ -1,0 +1,90 @@
+public typealias Metadata = [String: MetadataValue]
+
+public enum MetadataValue {
+    case string(String)
+    case stringConvertible(CustomStringConvertible)
+    case dictionary(Metadata)
+    case array([Metadata.Value])
+}
+
+extension MetadataValue: Equatable {
+    public static func == (lhs: Metadata.Value, rhs: Metadata.Value) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhs), .string(let rhs)):
+            return lhs == rhs
+        case (.stringConvertible(let lhs), .stringConvertible(let rhs)):
+            return lhs.description == rhs.description
+        case (.array(let lhs), .array(let rhs)):
+            return lhs == rhs
+        case (.dictionary(let lhs), .dictionary(let rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension MetadataValue: ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension MetadataValue: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .dictionary(let dict):
+            return dict.mapValues { $0.description }.description
+        case .array(let list):
+            return list.map { $0.description }.description
+        case .string(let str):
+            return str
+        case .stringConvertible(let repr):
+            return repr.description
+        }
+    }
+}
+
+extension MetadataValue: ExpressibleByStringInterpolation {}
+
+extension MetadataValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    public typealias Value = Metadata.Value
+
+    public init(dictionaryLiteral elements: (String, Metadata.Value)...) {
+        self = .dictionary(.init(uniqueKeysWithValues: elements))
+    }
+}
+
+extension MetadataValue: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = Metadata.Value
+
+    public init(arrayLiteral elements: Metadata.Value...) {
+        self = .array(elements)
+    }
+}
+
+extension MetadataValue: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case string
+        case stringConvertible
+        case dictionary
+        case array
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .string(let value):
+            try container.encode(value, forKey: .string)
+        case .stringConvertible(let value):
+            try container.encode(value.description, forKey: .stringConvertible)
+        case .dictionary(let value):
+            try container.encode(value, forKey: .dictionary)
+        case .array(let value):
+            try container.encode(value, forKey: .array)
+        }
+    }
+}

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -44,7 +44,7 @@ extension ValidationsError: AbortError {
             let validationError = [failure.key.description: [failure.failureDescription ?? ""]]
             validationErrors.merge(validationError) { $0 + $1 }
         }
-        
-        return ["validationErrors" : "\(validationErrors)"]
+   
+        return ["validationErrors" : .init(validationErrors)]
     }
 }

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -36,4 +36,15 @@ extension ValidationsError: AbortError {
     public var reason: String {
         self.description
     }
+    
+    public var metadata: Metadata {
+        var validationErrors: [String: [String]] = [:]
+        
+        self.failures.forEach { failure in
+            let validationError = [failure.key.description: [failure.failureDescription ?? ""]]
+            validationErrors.merge(validationError) { $0 + $1 }
+        }
+        
+        return ["validationErrors" : "\(validationErrors)"]
+    }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -650,9 +650,8 @@ final class ApplicationTests: XCTestCase {
             ], as: .json)
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
-            XCTAssertContains(res.body.string, "email is not a valid email address")
-            XCTAssertContains(res.body.string, #"{"validationErrors":{"email":["email is not a valid email address"]}}"#)
-            XCTAssertEqual(res.body.string, #"{"error":true,"metadata":{"validationErrors":{"email":["email is not a valid email address"]}},"reason":"email is not a valid email address"}"#)
+            XCTAssertContains(res.body.string, #""reason":"email is not a valid email address""#)
+            XCTAssertContains(res.body.string, #""metadata":{"validationErrors":{"email":["email is not a valid email address"]}}"#)
         }
     }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -651,7 +651,8 @@ final class ApplicationTests: XCTestCase {
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "email is not a valid email address")
-            XCTAssertContains(res.body.string, "{\"validationErrors\":\"[\"email\": [\"email is not a valid email address\"]]\"}")
+            XCTAssertContains(res.body.string, #"{"validationErrors":{"email":["email is not a valid email address"]}}"#)
+            XCTAssertEqual(res.body.string, #"{"error":true,"metadata":{"validationErrors":{"email":["email is not a valid email address"]}},"reason":"email is not a valid email address"}"#)
         }
     }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -651,6 +651,7 @@ final class ApplicationTests: XCTestCase {
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "email is not a valid email address")
+            XCTAssertContains(res.body.string, "{\"validationErrors\":\"[\"email\": [\"email is not a valid email address\"]]\"}")
         }
     }
 


### PR DESCRIPTION
### Metadata type
Adds encodable `Metadata` type, which can be used to encode any value. 

```swift
typealias Metadata = [String: MetadataValue]

struct MetadataValue: Encodable {
    var value: Any
}
```

**Please notice!** If any value will be stored which cannot be encoded, this will throw an error.

### Metadata property in AbortError
Adds a metadata property to `AbortError`, defaulting to `[:]`. This can be used to add any metadata for a special error.

```swift
extension FooError: AbortError  {
    var metadata: Metadata {
        return ["foo", .init("bar")]
    }
}
```

### Metadata for ValidationsErrors 
Returns individual validation errors via metadata property. The response for a `ValidationsError` looks like this:

```json
{
  "error": true,
  "metadata": {
    "validationErrors": {
      "email": "email is not a valid email address"
    }
  },
  "reason": "email is not a valid email address"
}
```

#### Special cases
Multiple validations for one key will be combined using ' and ' if they are declared at once.
```swift
validations.add("foo", as: String.self, is: .count(3...) && .alphanumeric)
```
will result in
```json
{
  "foo": "foo is less than minimum of 3 character(s) and should contain only alphanumeric characters"
}
```

Multiple validations declared individually will be returned as array.
```swift
validations.add("foo", as: String.self, is: .count(3...))
validations.add("foo", as: String.self, is: .alphanumeric)
```
will result in
```json
{
  "foo": [
    "foo is less than minimum of 3 character(s)",
    "foo should contain only alphanumeric characters"
  ]
}
```

Nested validations will be returned as object.
```swift
validations.add("foo") { foo in
    foo.add("bar", as: String.self, is: .count(3...))
}
```
will result in 
```json
{
  "foo": {
    "bar": "bar is less than minimum of 3 character(s)"
  }
}
```