### PR TITLE
Adds ETag related methods

### DIFF
--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -80,27 +80,6 @@ extension Content {
 
         return #""\#(eTag)""#
     }
-
-    /// Creates a `Response` which includes an `ETag` HTTP header.
-    ///
-    ///  The `withBody` parameter is here so that you can determine, based on client preference
-    ///  whether or not to include the response body when performing a `PATCH` call, for example.
-    ///  You want the `ETag` header to be included, but you may or may not want the body.
-    /// - Parameter withBody: Whether or not the body should be included.
-    /// - Returns: A `Response`
-    public func eTagResponse(withBody: Bool = true) throws -> Response {
-        let response = Response(status: withBody ? .ok : .noContent)
-
-        if withBody {
-            try response.content.encode(self)
-        }
-
-        if let eTag = try self.eTag(), !eTag.isEmpty {
-            response.headers.add(name: .eTag, value: eTag)
-        }
-
-        return response
-    }
 }
 
 // MARK: Default Conformances

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -149,7 +149,7 @@ public final class Response: CustomStringConvertible {
     /// - Throws: If the encoding fails, or the ETag can't be generated.
     /// - Returns: A `Response`
     public static func withETag<T>(
-        obj: T,
+        _ obj: T,
         includeBody: Bool = true,
         justCreated: Bool = false
     ) throws -> Response where T: Content {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1477,6 +1477,17 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(res.body.string, "<h1>Hello</h1>\n")
         }
     }
+
+    func testContentWithETag() throws {
+        let response = try DTO().eTagResponse()
+
+        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
+    }
+}
+
+private struct DTO: Content {
+    let data = "something"
 }
 
 extension Application.Responder {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1477,33 +1477,6 @@ final class ApplicationTests: XCTestCase {
             XCTAssertEqual(res.body.string, "<h1>Hello</h1>\n")
         }
     }
-
-    func testResponseWithBodyAndETag() throws {
-        let response = try DTO().eTagResponse()
-
-        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
-        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
-        XCTAssertNotNil(response.body.string)
-        XCTAssertEqual(response.status, .ok)
-    }
-
-    func testResponseWithNoBodyIncludingETag() throws {
-        let response = try DTO().eTagResponse(withBody: false)
-        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
-        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
-        XCTAssertNil(response.body.string)
-        XCTAssertEqual(response.status, .noContent)
-    }
-
-    func testEtagFromContent() throws {
-        let content = DTO()
-        let eTag = try XCTUnwrap(content.eTag())
-        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
-    }
-}
-
-private struct DTO: Content {
-    let data = "something"
 }
 
 extension Application.Responder {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1478,10 +1478,26 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testContentWithETag() throws {
+    func testResponseWithBodyAndETag() throws {
         let response = try DTO().eTagResponse()
 
         let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
+        XCTAssertNotNil(response.body.string)
+        XCTAssertEqual(response.status, .ok)
+    }
+
+    func testResponseWithNoBodyIncludingETag() throws {
+        let response = try DTO().eTagResponse(withBody: false)
+        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
+        XCTAssertNil(response.body.string)
+        XCTAssertEqual(response.status, .noContent)
+    }
+
+    func testEtagFromContent() throws {
+        let content = DTO()
+        let eTag = try XCTUnwrap(content.eTag())
         XCTAssertNotNil(eTag.range(of: "^\"[a-fA-F0-9]+\"$", options: .regularExpression))
     }
 }

--- a/Tests/VaporTests/ETagTests.swift
+++ b/Tests/VaporTests/ETagTests.swift
@@ -1,0 +1,45 @@
+import Vapor
+import XCTest
+
+final class ETagTests: XCTestCase {
+    static let regex = "^\"[a-fA-F0-9]+\"$"
+
+    private func validate(_ response: Response, status: HTTPStatus, nilBody: Bool = false, line: UInt = #line) throws {
+        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression), line: line)
+
+        XCTAssertEqual(response.status, status, line: line)
+
+        if nilBody {
+            XCTAssertNil(response.body.string, "Found a body", line: line)
+        } else {
+            XCTAssertNotNil(response.body.string, "Didn't find a body", line: line)
+        }
+    }
+
+    func testNewlyCreated() throws {
+        let response = try Response.withETag(obj: DTO(), justCreated: true)
+        try validate(response, status: .created)
+    }
+
+    func testExisting() throws {
+        let response = try Response.withETag(obj: DTO())
+        try validate(response, status: .ok)
+    }
+
+    func testNoBody() throws {
+        let response = try Response.withETag(obj: DTO(), includeBody: false)
+        try validate(response, status: .noContent, nilBody: true)
+    }
+
+    func testEtagFromContent() throws {
+        let content = DTO()
+        let eTag = try XCTUnwrap(content.eTag())
+        XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression))
+    }
+}
+
+
+private struct DTO: Content {
+    let data = "something"
+}

--- a/Tests/VaporTests/ETagTests.swift
+++ b/Tests/VaporTests/ETagTests.swift
@@ -18,23 +18,22 @@ final class ETagTests: XCTestCase {
     }
 
     func testNewlyCreated() throws {
-        let response = try Response.withETag(obj: DTO(), justCreated: true)
+        let response = try Response.withETag(DTO(), justCreated: true)
         try validate(response, status: .created)
     }
 
     func testExisting() throws {
-        let response = try Response.withETag(obj: DTO())
+        let response = try Response.withETag(DTO())
         try validate(response, status: .ok)
     }
 
     func testNoBody() throws {
-        let response = try Response.withETag(obj: DTO(), includeBody: false)
+        let response = try Response.withETag(DTO(), includeBody: false)
         try validate(response, status: .noContent, nilBody: true)
     }
 
     func testEtagFromContent() throws {
-        let content = DTO()
-        let eTag = try XCTUnwrap(content.eTag())
+        let eTag = try XCTUnwrap(DTO().eTag())
         XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression))
     }
 }


### PR DESCRIPTION
REST API's that return a modifiable object should include an ETag header for data sanity on subsequent PUT/PATCH calls.  This allows clients to easily include that header in their `get` routes, if desired.

```swift
func get(req: Request) throws -> EventLoopFuture<Response> {
    return Todo.find(req.parameters.get("todoID"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try SomeDTO($0).eTagResponse() }
}
```