### PR TITLE
Adds eTag related methods for Response creation and verification.

### DIFF
--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -73,8 +73,13 @@ extension Content {
     public func eTag() throws -> String? {
         // Hardcode the JSON media type here. Regardless of what type the client
         // asks for, the ETag always needs to be the same, which means we always
-        // have to encode with a single known type that doesn't change.
-        let data = try JSONEncoder().encode(self)
+        // have to encode with a single known type that doesn't change.  Must also
+        // sort the keys or output form is random which would lead to different
+        // eTag for the same object
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        let data = try encoder.encode(self)
 
         let eTag = Array(SHA256.hash(data: data)).hexEncodedString()
 

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -1,3 +1,5 @@
+import Crypto
+
 /// Convertible to / from content in an HTTP message.
 ///
 /// Conformance to this protocol consists of:
@@ -74,9 +76,7 @@ extension Content {
         // have to encode with a single known type that doesn't change.
         let data = try JSONEncoder().encode(self)
 
-        let eTag = Insecure.MD5.hash(data: data).reduce("") {
-          $0 + String(format: "%02hhx", $1)
-        }
+        let eTag = Array(SHA256.hash(data: data)).hexEncodedString()
 
         return #""\#(eTag)""#
     }

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -67,6 +67,19 @@ extension Content {
         }
         return request.eventLoop.makeSucceededFuture(response)
     }
+
+    public func eTag() throws -> String? {
+        // Hardcode the JSON media type here. Regardless of what type the client
+        // asks for, the ETag always needs to be the same, which means we always
+        // have to encode with a single known type that doesn't change.
+        let data = try JSONEncoder().encode(self)
+
+        let eTag = Insecure.MD5.hash(data: data).reduce("") {
+          $0 + String(format: "%02hhx", $1)
+        }
+
+        return #""\#(eTag)""#
+    }
 }
 
 // MARK: Default Conformances

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -142,21 +142,21 @@ public final class Response: CustomStringConvertible {
     ///  whether or not to include the response body when performing a `PATCH` call, for example.
     ///  You want the `ETag` header to be included, but you may or may not want the body.
     ///
-    ///  If you want to support returning a status code of 304 (Not Modified) you can pass the value
-    ///  of the `.ifNoneMatch` header from the request in the `ifNotModifiedHeaders` parameter.
+    ///  If you want to support returning a status code of 304 (Not Modified) based on a matching
+    ///  HTTP `If-None-Match` header, you can pass in the `req` parameter to be examined.
     ///
     /// - Parameters:
     ///   - obj: The object which is (possibly) being encoded and used to calculate the ETag
     ///   - includeBody: Whether or not the `obj` should be included in the body.
     ///   - justCreated: Whether this is a newly created object or not. Determines 201 vs. 200 status
-    ///   - ifNotModifiedHeaders: The value of the HTTP `If-None-Match` header.
+    ///   - req: The `Request` to examine for an `If-None-Match` header.
     /// - Throws: If the encoding fails, or the ETag can't be generated.
     /// - Returns: A `Response`
     public static func withETag<T>(
         _ obj: T,
         includeBody: Bool = true,
         justCreated: Bool = false,
-        ifNoneMatchHeaders: String? = nil
+        req: Request? = nil
     ) throws -> Response where T: Content {
         let status: HTTPStatus
         if justCreated {
@@ -170,7 +170,7 @@ public final class Response: CustomStringConvertible {
         let response = Response(status: status)
 
         if let eTag = try obj.eTag(), !eTag.isEmpty {
-            if let ifNoneMatchHeaders = ifNoneMatchHeaders {
+            if let req = req, let ifNoneMatchHeaders = req.headers.firstValue(name: .ifNoneMatch) {
                 var cs = CharacterSet.whitespacesAndNewlines
                 cs.insert(",")
 

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -135,6 +135,45 @@ public final class Response: CustomStringConvertible {
         self.body = body
         self.storage = .init()
     }
+
+    /// Creates a `Response` which includes an `ETag` HTTP header.
+    ///
+    ///  The `withBody` parameter is here so that you can determine, based on client preference,
+    ///  whether or not to include the response body when performing a `PATCH` call, for example.
+    ///  You want the `ETag` header to be included, but you may or may not want the body.
+    ///
+    /// - Parameters:
+    ///   - obj: The object which is (possibly) being encoded and used to calculate the ETag
+    ///   - includeBody: Whether or not the `obj` should be included in the body.
+    ///   - justCreated: Whether this is a newly created object or not. Determines 201 vs. 200 status
+    /// - Throws: If the encoding fails, or the ETag can't be generated.
+    /// - Returns: A `Response`
+    public static func withETag<T>(
+        _ obj: T,
+        includeBody: Bool = true,
+        justCreated: Bool = false
+    ) throws -> Response where T: Content {
+        let status: HTTPStatus
+        if justCreated {
+            status = .created
+        } else if includeBody {
+            status = .ok
+        } else {
+            status = .noContent
+        }
+
+        let response = Response(status: status)
+
+        if includeBody {
+            try response.content.encode(obj)
+        }
+
+        if let eTag = try obj.eTag(), !eTag.isEmpty {
+            response.headers.add(name: .eTag, value: eTag)
+        }
+
+        return response
+    }
 }
 
 

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -170,7 +170,7 @@ public final class Response: CustomStringConvertible {
         let response = Response(status: status)
 
         if let eTag = try obj.eTag(), !eTag.isEmpty {
-            if let req = req, let ifNoneMatchHeaders = req.headers.firstValue(name: .ifNoneMatch) {
+            if let req = req, let ifNoneMatchHeaders = req.headers.first(name: .ifNoneMatch) {
                 var cs = CharacterSet.whitespacesAndNewlines
                 cs.insert(",")
 

--- a/Tests/VaporTests/ETagTests.swift
+++ b/Tests/VaporTests/ETagTests.swift
@@ -1,0 +1,44 @@
+import Vapor
+import XCTest
+
+final class ETagTests: XCTestCase {
+    static let regex = "^\"[a-fA-F0-9]+\"$"
+
+    private func validate(_ response: Response, status: HTTPStatus, nilBody: Bool = false, line: UInt = #line) throws {
+        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression), line: line)
+
+        XCTAssertEqual(response.status, status, line: line)
+
+        if nilBody {
+            XCTAssertNil(response.body.string, "Found a body", line: line)
+        } else {
+            XCTAssertNotNil(response.body.string, "Didn't find a body", line: line)
+        }
+    }
+
+    func testNewlyCreated() throws {
+        let response = try Response.withETag(DTO(), justCreated: true)
+        try validate(response, status: .created)
+    }
+
+    func testExisting() throws {
+        let response = try Response.withETag(DTO())
+        try validate(response, status: .ok)
+    }
+
+    func testNoBody() throws {
+        let response = try Response.withETag(DTO(), includeBody: false)
+        try validate(response, status: .noContent, nilBody: true)
+    }
+
+    func testEtagFromContent() throws {
+        let eTag = try XCTUnwrap(DTO().eTag())
+        XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression))
+    }
+}
+
+
+private struct DTO: Content {
+    let data = "something"
+}

--- a/Tests/VaporTests/ETagTests.swift
+++ b/Tests/VaporTests/ETagTests.swift
@@ -5,7 +5,7 @@ final class ETagTests: XCTestCase {
     static let regex = "^\"[a-fA-F0-9]+\"$"
 
     private func validate(_ response: Response, status: HTTPStatus, nilBody: Bool = false, line: UInt = #line) throws {
-        let eTag = try XCTUnwrap(response.headers.firstValue(name: .eTag))
+        let eTag = try XCTUnwrap(response.headers.first(name: .eTag))
         XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression), line: line)
 
         XCTAssertEqual(response.status, status, line: line)
@@ -79,9 +79,25 @@ final class ETagTests: XCTestCase {
         let response = try Response.withETag(dto, req: request)
         XCTAssertEqual(response.status, .notModified)
     }
+
+    func testOrderingUnchanged() throws {
+        let dto = DTO()
+
+        var prev = try XCTUnwrap(dto.eTag())
+        for _ in 1 ... 100 {
+            let cur = try XCTUnwrap(dto.eTag())
+            XCTAssertEqual(prev, cur)
+            prev = cur
+        }
+    }
 }
 
 
 private struct DTO: Content {
     let data = UUID().uuidString
+    let dict = [
+        UUID().uuidString: UUID().uuidString,
+        UUID().uuidString: UUID().uuidString,
+        UUID().uuidString: UUID().uuidString
+    ]
 }

--- a/Tests/VaporTests/ETagTests.swift
+++ b/Tests/VaporTests/ETagTests.swift
@@ -36,9 +36,30 @@ final class ETagTests: XCTestCase {
         let eTag = try XCTUnwrap(DTO().eTag())
         XCTAssertNotNil(eTag.range(of: Self.regex, options: .regularExpression))
     }
+
+    func testIfNoneMatchHeaderMatches() throws {
+        let dto = DTO()
+        let eTag = try XCTUnwrap(dto.eTag())
+        let response = try Response.withETag(dto, ifNoneMatchHeaders: eTag)
+        XCTAssertEqual(response.status, .notModified)
+    }
+
+    func testIfNoneMatchDoesNotMatch() throws {
+        let response = try Response.withETag(DTO(), ifNoneMatchHeaders: UUID().uuidString)
+        XCTAssertEqual(response.status, .ok)
+    }
+
+    func testIfNonMatchWithList() throws {
+        let dto = DTO()
+        let eTag = try XCTUnwrap(dto.eTag())
+
+        let headers = "abc, \(eTag), def"
+        let response = try Response.withETag(dto, ifNoneMatchHeaders: headers)
+        XCTAssertEqual(response.status, .notModified)
+    }
 }
 
 
 private struct DTO: Content {
-    let data = "something"
+    let data = UUID().uuidString
 }


### PR DESCRIPTION
@tanner0101 This has to be deployed at the same time as https://github.com/vapor/fluent/pull/667

In order to prevent lost updates, REST APIs should send back an ETag header when querying an object, and subsequent `DELETE`/`PATCH` calls should include that ETag in an `If-Match` HTTP header.   

If you are returning your `Model` directly (i.e. it also conforms to `Content`) you should now write your controller methods as follows.  Note that they all return a `Response` now.

```swift
func get(req: Request) throws -> EventLoopFuture<Response> {
    Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try .withETag($0) }
}

func patch(req: Request) throws -> EventLoopFuture<Response> {
    return Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try $0.verifyETag(on: req) }
        .flatMap { todo in
            // Update all your properties here

            return todo.update(on: req.db).flatMapThrowing {
                // If your model update will modify related tables, you'll
                // want to req-query the object here, before you create
                // the response DTO.
                return try .withETag(todo, includeBody: false)
            }
    }
}

func create(req: Request) throws -> EventLoopFuture<Response> {
    let todo = try Todo(from: req.content.decode(TodoCreateDTO.self))

    return todo.create(on: req.db)
        .flatMapThrowing { try .created(todo, for: req) }
}

func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
    return Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try $0.verifyETag(on: req) }
        .flatMap { $0.delete(on: req.db).transform(to: .noContent) }
}
```

If, however, you are using a DTO instead of directly returning the model, then conform your response object to `ModelContent` (instead of `Content`) and then write them like so.

```swift
func getDTO(req: Request) throws -> EventLoopFuture<Response> {
    Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { return try .withETag(TodoDTO(model: $0)) }
}

func patchDTO(req: Request) throws -> EventLoopFuture<Response> {
    return Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try $0.verifyETag(TodoDTO.self, on: req)}
        .flatMap { todo in
            // Update all your properties here

            return todo.update(on: req.db).flatMapThrowing {
                // If your model update will modify related tables, you'll
                // want to req-query the object here, before you create
                // the response DTO.
                return try .withETag(TodoDTO(model: todo), includeBody: false)
            }
    }
}

func createDTO(req: Request) throws -> EventLoopFuture<Response> {
    let todo = try Todo(from: req.content.decode(TodoCreateDTO.self))

    return todo.create(on: req.db)
        .flatMapThrowing {
            let dto = try TodoDTO(model: todo)
            return try .created(dto, for: req, id: todo.requireID())
    }
}

func deleteTDO(req: Request) throws -> EventLoopFuture<HTTPStatus> {
    return Todo.find(req.parameters.get("id"), on: req.db)
        .unwrap(or: Abort(.notFound))
        .flatMapThrowing { try $0.verifyETag(TodoDTO.self, on: req) }
        .flatMap { $0.delete(on: req.db).transform(to: .noContent) }
}
```