### PR TITLE
Provide the hex encoding utilities on Sequences

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1367,6 +1367,14 @@ final class ApplicationTests: XCTestCase {
         XCTAssertEqual(bytes.hexEncodedString(uppercase: true), "012A80F0")
     }
     
+    func testHexEncodingSequence() throws {
+        let bytes: AnySequence<UInt8> = AnySequence([1, 42, 128, 240])
+
+        XCTAssertEqual(bytes.hex, "012a80f0")
+        XCTAssertEqual(bytes.hexEncodedString(), "012a80f0")
+        XCTAssertEqual(bytes.hexEncodedString(uppercase: true), "012A80F0")
+    }
+    
     func testConfigureHTTPDecompressionLimit() throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
- Might as well let Sequences have them as well as Collections
- Make `hexEncodedBytes()` public, why wouldn't it be?
- Specialize `hexEncodedBytes()` on `Collection` to use a (theoretically) more efficient method. It's probably a completely unmeasurable difference in practice.
- Add unit test to make sure it works on `Sequence`s properly. (Sure, it crashes if you try something like `sequence(0) { $0 + 1 }.hex`, but that's to be expected. Maybe at some point a length limit check can be added.)