### PR TITLE
Consume entire body stream when payload too large

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -172,6 +172,10 @@ public func routes(_ app: Application) throws {
             .secret(key: "PASSWORD_SECRET", fileIO: req.application.fileio, on: req.eventLoop)
             .unwrap(or: Abort(.badRequest))
     }
+
+    app.on(.POST, "max-256", body: .collect(maxSize: 256)) { req in
+        req.body.data?.readableBytes ?? 0
+    }
 }
 
 struct TestError: AbortError {


### PR DESCRIPTION
Updates `Request.BodyStream.consume` to read the entire incoming body stream before throwing an error if the payload is too large (#2256, fixes #2252). 

This fixes the following error that could be caused if the connection was closed (no keep-alive) before the entire request was read. 

```
Unhandled HTTP server error: stream ended at an unexpected time
```