### PR TITLE
Use .output close mode for non-keepalive requests

### DIFF
--- a/Sources/Vapor/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/Server/HTTPServerHandler.swift
@@ -38,7 +38,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
             let done = context.write(self.wrapOutboundOut(response))
             if !request.isKeepAlive {
                 done.whenComplete { _ in
-                    context.close(promise: nil)
+                    context.close(mode: .output, promise: nil)
                 }
             }
         }


### PR DESCRIPTION
Changes the close mode to `.output` when closing a non-keepalive connection after the response is sent (#2257, fixes #2252).