### PR TITLE
Close Request.BodyStream on malformed request

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -172,6 +172,11 @@ public func routes(_ app: Application) throws {
             .secret(key: "PASSWORD_SECRET", fileIO: req.application.fileio, on: req.eventLoop)
             .unwrap(or: Abort(.badRequest))
     }
+
+    app.on(.POST, "max-256", body: .collect(maxSize: 256)) { req -> HTTPStatus in
+        print("in route")
+        return .ok
+    }
 }
 
 struct TestError: AbortError {

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -22,9 +22,12 @@ extension Request {
         }
 
         func write(_ chunk: BodyStreamResult, promise: EventLoopPromise<Void>?) {
-            if case .end = chunk {
+            switch chunk {
+            case .end, .error:
                 self.isClosed = true
+            case .buffer: break
             }
+            
             if let handler = handler {
                 handler(chunk, promise)
             } else {
@@ -49,6 +52,10 @@ extension Request {
                 next?.succeed(())
             }
             return promise.futureResult
+        }
+
+        deinit {
+            assert(self.isClosed, "Request.BodyStream deinitialized before closing.")
         }
     }
 }

--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -335,7 +335,7 @@ final class HTTPServerErrorHandler: ChannelInboundHandler {
     
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         self.logger.error("Unhandled HTTP server error: \(error)")
-        context.close(promise: nil)
+        context.close(mode: .output, promise: nil)
     }
 }
 

--- a/Sources/Vapor/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/Server/HTTPServerRequestDecoder.swift
@@ -102,6 +102,16 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
         }
     }
 
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        switch self.requestState {
+        case .streamingBody(let stream):
+            stream.write(.error(error), promise: nil)
+        default:
+            break
+        }
+        context.fireErrorCaught(error)
+    }
+
     func write(_ part: BodyStreamResult, to stream: Request.BodyStream, context: ChannelHandlerContext) {
         self.pendingWriteCount += 1
         stream.write(part).whenComplete { result in


### PR DESCRIPTION
`Request.BodyStream` is now closed correctly when an error is caught while decoding streaming requests (#2258, fixes #2253). 