### PR TITLE
Use non-deprecated configureHTTP2SecureUpgrade.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.11.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),

--- a/Sources/Vapor/Server/HTTPServer.swift
+++ b/Sources/Vapor/Server/HTTPServer.swift
@@ -259,7 +259,7 @@ private final class HTTPServerConnection {
                         return channel.close(mode: .all)
                     }
                     return channel.pipeline.addHandler(tlsHandler).flatMap { _ in
-                        return channel.pipeline.configureHTTP2SecureUpgrade(h2PipelineConfigurator: { pipeline in
+                        return channel.configureHTTP2SecureUpgrade(h2ChannelConfigurator: { channel in
                             return channel.configureHTTP2Pipeline(
                                 mode: .server,
                                 inboundStreamStateInitializer: { (channel, streamID) in
@@ -271,8 +271,8 @@ private final class HTTPServerConnection {
                                     )
                                 }
                             ).map { _ in }
-                        }, http1PipelineConfigurator: { pipeline in
-                            return pipeline.addVaporHTTP1Handlers(
+                        }, http1ChannelConfigurator: { channel in
+                            return channel.pipeline.addVaporHTTP1Handlers(
                                 application: application!,
                                 responder: responder,
                                 configuration: configuration


### PR DESCRIPTION
Fixes a deprecation warning from `swift-nio-http2` requiring version 1.11.0 (#2261). 
