### PR TITLE
Fixed HTTPCookies init using directives

### DIFF
--- a/Sources/Vapor/HTTP/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/HTTPCookies.swift
@@ -226,16 +226,17 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral {
         self.cookies = [:]
     }
 
-    init?(directives: [HTTPHeaders.Directive]) {
-        self.cookies = [:]
+    init(directives: [HTTPHeaders.Directive]) {
+        var cookies: [String: Value] = [:]
         for directive in directives {
             guard let value = directive.parameter else {
-                return nil
+                continue
             }
-            self.cookies[.init(directive.value)] = .init(string: .init(value))
+            cookies[.init(directive.value)] = .init(string: .init(value))
         }
+        self.cookies = cookies
     }
-    
+
     /// See `ExpressibleByDictionaryLiteral`.
     public init(dictionaryLiteral elements: (String, Value)...) {
         var cookies: [String: Value] = [:]

--- a/Tests/VaporTests/HTTPHeaderValueTests.swift
+++ b/Tests/VaporTests/HTTPHeaderValueTests.swift
@@ -155,4 +155,13 @@ final class HTTPHeaderValueTests: XCTestCase {
         XCTAssertEqual(headers.contentDisposition?.name, "fieldName")
         XCTAssertEqual(headers.contentDisposition?.filename, "filename.jpg")
     }
+
+    func testCookieDirectives() throws {
+        let cookies = HTTPCookies(directives: [
+            HTTPHeaders.Directive(value: "baz"),
+            HTTPHeaders.Directive(value: "bar", parameter: "foo"),
+        ])
+        XCTAssertEqual(cookies["bar"]?.string, "foo")
+        XCTAssertNil(cookies["baz"])
+    }
 }


### PR DESCRIPTION
The HTTPCookies struct is now loading cookies from the directives properly.