### PR TITLE
Support underscore in HTTP header directive key

### DIFF
--- a/Sources/Vapor/HTTP/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/HTTPHeaders+Directive.swift
@@ -5,9 +5,9 @@ extension HTTPHeaders {
 
         var description: String {
             if let parameter = self.parameter {
-                return "\(self.value)=\(parameter)"
+                return "Directive(value: \(self.value.debugDescription), parameter: \(parameter.debugDescription))"
             } else {
-                return "\(self.value)"
+                return "Directive(value: \(self.value.debugDescription))"
             }
         }
         
@@ -221,9 +221,12 @@ private extension Character {
     static var comma: Self {
         .init(",")
     }
+    static var underscore: Self {
+        .init("_")
+    }
 
     var isDirectiveKey: Bool {
-        self.isLetter || self == .dash
+        self.isLetter || self == .dash || self == .underscore
     }
 }
 

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -155,4 +155,13 @@ final class HTTPHeaderValueTests: XCTestCase {
         XCTAssertEqual(headers.contentDisposition?.name, "fieldName")
         XCTAssertEqual(headers.contentDisposition?.filename, "filename.jpg")
     }
+
+    func testCookie_parsing() throws {
+        let headers = HTTPHeaders([
+            ("cookie", "vapor-session=0FuTYcHmGw7Bz1G4HiF+EA==; _ga=GA1.1.500315824.1585154561; _gid=GA1.1.500224287.1585154561")
+        ])
+        XCTAssertEqual(headers.cookie?["vapor-session"]?.string, "0FuTYcHmGw7Bz1G4HiF+EA==")
+        XCTAssertEqual(headers.cookie?["_ga"]?.string, "GA1.1.500315824.1585154561")
+        XCTAssertEqual(headers.cookie?["_gid"]?.string, "GA1.1.500224287.1585154561")
+    }
 }


### PR DESCRIPTION
Adds support for underscores in HTTP header directive keys. This fixes an issue with cookie names like `_ga` and `_gid` not being parsed correctly (#2266, fixes #2264). 