### PR TITLE
Add Content hooks

### DIFF
--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -63,6 +63,23 @@ extension ClientRequest {
             }
             return try decoder.decode(D.self, from: body, headers: self.headers)
         }
+
+        mutating func encode<C>(_ content: C, using encoder: ContentEncoder) throws where C : Content {
+            var content = content
+            try content.beforeEncode()
+            var body = ByteBufferAllocator().buffer(capacity: 0)
+            try encoder.encode(content, to: &body, headers: &self.headers)
+            self.body = body
+        }
+
+        func decode<C>(_ content: C.Type, using decoder: ContentDecoder) throws -> C where C : Content {
+            guard let body = self.body else {
+                throw Abort(.lengthRequired)
+            }
+            var decoded = try decoder.decode(C.self, from: body, headers: self.headers)
+            try decoded.afterDecode()
+            return decoded
+        }
     }
 
     public var content: ContentContainer {

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -38,7 +38,21 @@ public protocol Content: Codable, RequestDecodable, ResponseEncodable {
     ///
     static var defaultContentType: HTTPMediaType { get }
 
+    /// Called before this `Content` is encoded, generally for a `Response` object.
+    ///
+    /// You should use this method to perform any "sanitizing" which you need on the data.
+    /// For example, you may wish to replace empty strings with a `nil`, `trim()` your
+    /// strings or replace empty arrays with `nil`. You can also use this method to abort
+    /// the encoding if something isn't valid. An empty array may indicate an error, for example.
     mutating func beforeEncode() throws
+
+
+    /// Called after this `Content` is decoded, generally from a `Request` object.
+    ///
+    /// You should use this method to perform any "sanitizing" which you need on the data.
+    /// For example, you may wish to replace empty strings with a `nil`, `trim()` your
+    /// strings or replace empty arrays with `nil`. You can also use this method to abort
+    /// the decoding if something isn't valid. An empty string may indicate an error, for example.
     mutating func afterDecode() throws
 }
 

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -37,6 +37,9 @@ public protocol Content: Codable, RequestDecodable, ResponseEncodable {
     ///     }
     ///
     static var defaultContentType: HTTPMediaType { get }
+
+    mutating func beforeEncode() throws
+    mutating func afterDecode() throws
 }
 
 /// MARK: Default Implementations
@@ -64,6 +67,9 @@ extension Content {
         }
         return request.eventLoop.makeSucceededFuture(response)
     }
+
+    public mutating func beforeEncode() throws { }
+    public mutating func afterDecode() throws { }
 }
 
 // MARK: Default Conformances

--- a/Sources/Vapor/Content/ContentContainer.swift
+++ b/Sources/Vapor/Content/ContentContainer.swift
@@ -15,6 +15,13 @@ extension ContentContainer {
         return try self.decode(D.self, using: self.configuredDecoder())
     }
 
+    public func decode<C>(_ decodable: C.Type) throws -> C where C: Content {
+        var content = try self.decode(C.self, using: self.configuredDecoder())
+        try content.afterDecode()
+
+        return content
+    }
+
     // MARK: Encode
 
     /// Serializes an `Encodable` object to this message using specific `HTTPMessageEncoder`.
@@ -27,6 +34,8 @@ extension ContentContainer {
     public mutating func encode<C>(_ encodable: C) throws
         where C: Content
     {
+        var encodable = encodable
+        try encodable.beforeEncode()
         try self.encode(encodable, as: C.defaultContentType)
     }
 
@@ -44,7 +53,23 @@ extension ContentContainer {
     {
         try self.encode(encodable, using: self.configuredEncoder(for: contentType))
     }
-    
+
+    /// Serializes a `Content` object to this message using specific `HTTPMessageEncoder`.
+    ///
+    ///     try req.content.encode(user, using: JSONEncoder())
+    ///
+    /// - parameters:
+    ///     - content: Instance of generic `Content` to serialize to this HTTP message.
+    ///     - encoder: Specific `HTTPMessageEncoder` to use.
+    /// - throws: Errors during serialization.
+    public mutating func encode<C>(_ content: C, as contentType: HTTPMediaType) throws
+        where C: Content
+    {
+        var content = content
+        try content.beforeEncode()
+        try self.encode(content, using: self.configuredEncoder(for: contentType))
+    }
+
     // MARK: Single Value
     
     /// Fetches a single `Decodable` value at the supplied key-path from this HTTP request's query string.

--- a/Sources/XCTVapor/XCTHTTPRequest.swift
+++ b/Sources/XCTVapor/XCTHTTPRequest.swift
@@ -19,6 +19,12 @@ public struct XCTHTTPRequest {
         func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D where D : Decodable {
             fatalError("Decoding from test request is not supported.")
         }
+
+        mutating func encode<C>(_ content: C, using encoder: ContentEncoder) throws where C : Content {
+            var content = content
+            try content.beforeEncode()
+            try encoder.encode(content, to: &self.body, headers: &self.headers)
+        }
     }
 
     public var content: ContentContainer {

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -20,6 +20,12 @@ extension XCTHTTPResponse {
         func decode<D>(_ decodable: D.Type, using decoder: ContentDecoder) throws -> D where D : Decodable {
             try decoder.decode(D.self, from: self.body, headers: self.headers)
         }
+
+        func decode<C>(_ content: C.Type, using decoder: ContentDecoder) throws -> C where C : Content {
+            var decoded = try decoder.decode(C.self, from: self.body, headers: self.headers)
+            try decoded.afterDecode()
+            return decoded
+        }
     }
 
     public var content: ContentContainer {


### PR DESCRIPTION
Adds optional `beforeEncode` and `afterDecode` methods to `Content` protocol (#2267). 

Docs: https://docs.vapor.codes/4.0/content/#hooks
