### PR TITLE
Allow Client to be Changed

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -76,6 +76,7 @@ public final class Application {
         self.lifecycle = .init()
         self.isBooted = false
         self.core.initialize()
+        self.clients.initialize()
         self.views.initialize()
         self.sessions.initialize()
         self.sessions.use(.memory)

--- a/Sources/Vapor/Client/Application+Client.swift
+++ b/Sources/Vapor/Client/Application+Client.swift
@@ -40,14 +40,14 @@ extension Application {
         }
 
         struct ClientKey: StorageKey, LockKey {
-            typealias Value = WrappedHTTPClient
+            typealias Value = AsyncHTTPClient
         }
         
         struct Key: StorageKey {
             typealias Value = Storage
         }
 
-        public var http: WrappedHTTPClient {
+        public var http: AsyncHTTPClient {
             if let existing = self.application.storage[ClientKey.self] {
                 return existing
             } else {
@@ -61,7 +61,7 @@ extension Application {
                     eventLoopGroupProvider: .shared(self.application.eventLoopGroup),
                     configuration: self.configuration
                 )
-                let wrapped = WrappedHTTPClient(http: new, eventLoop: self.application.eventLoopGroup.next())
+                let wrapped = AsyncHTTPClient(http: new, eventLoop: self.application.eventLoopGroup.next())
                 self.application.storage.set(ClientKey.self, to: wrapped) {
                     try $0.http.syncShutdown()
                 }

--- a/Sources/Vapor/Client/Application+Client.swift
+++ b/Sources/Vapor/Client/Application+Client.swift
@@ -2,6 +2,10 @@ extension Application {
     public var clients: Clients {
         .init(application: self)
     }
+    
+    public var client: Client {
+        clients.client
+    }
 
     public struct Clients {
         public struct Provider {
@@ -62,9 +66,9 @@ extension Application {
                     eventLoopGroupProvider: .shared(self.application.eventLoopGroup),
                     configuration: self.configuration
                 )
-                let wrapped = AsyncHTTPClient(http: new, eventLoop: self.application.eventLoopGroup.next())
+                let wrapped = AsyncHTTPClient(driver: new, eventLoop: self.application.eventLoopGroup.next())
                 self.application.storage.set(ClientKey.self, to: wrapped) {
-                    try $0.http.syncShutdown()
+                    try $0.driver.syncShutdown()
                 }
                 return wrapped
             }

--- a/Sources/Vapor/Client/Application+Client.swift
+++ b/Sources/Vapor/Client/Application+Client.swift
@@ -93,7 +93,7 @@ extension Application {
         
         private var storage: Storage {
             guard let storage = self.application.storage[Key.self] else {
-                fatalError("Clients not configured. Configure with app.client.initialize()")
+                fatalError("Clients not configured. Configure with app.clients.initialize()")
             }
             return storage
         }

--- a/Sources/Vapor/Client/Application+Client.swift
+++ b/Sources/Vapor/Client/Application+Client.swift
@@ -99,13 +99,3 @@ extension Application {
         }
     }
 }
-
-//extension HTTPClient: Client {
-//    public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-//        self.send(request, eventLoop: .indifferent)
-//    }
-//    
-//    public func `for`(_ request: Vapor.Request) -> Client {
-//        return HTTPClient(eventLoopGroupProvider: .shared(request.eventLoop))
-//    }
-//}

--- a/Sources/Vapor/Client/Application+Client.swift
+++ b/Sources/Vapor/Client/Application+Client.swift
@@ -29,8 +29,9 @@ extension Application {
             nonmutating set {
                 if self.application.storage.contains(ClientKey.self) {
                     self.application.logger.warning("Cannot modify client configuration after client has been used")
+                } else {
+                    self.application.storage[ConfigurationKey.self] = newValue
                 }
-                self.application.storage[ConfigurationKey.self] = newValue
             }
         }
         

--- a/Sources/Vapor/Client/AsyncHTTPClient.swift
+++ b/Sources/Vapor/Client/AsyncHTTPClient.swift
@@ -1,11 +1,53 @@
 import AsyncHTTPClient
 
 public struct AsyncHTTPClient: Client {
-    public let driver: HTTPClient
     public let eventLoop: EventLoop
+    let application: Application
+    
+    public var driver: HTTPClient {
+        if let existing = self.application.storage[ClientKey.self] {
+            return existing
+        } else {
+            let lock = self.application.locks.lock(for: ClientKey.self)
+            lock.lock()
+            defer { lock.unlock() }
+            if let existing = self.application.storage[ClientKey.self] {
+                return existing
+            }
+            let new = HTTPClient(
+                eventLoopGroupProvider: .shared(self.application.eventLoopGroup),
+                configuration: self.configuration
+            )
+            self.application.storage.set(ClientKey.self, to: new) {
+                try $0.syncShutdown()
+            }
+            return new
+        }
+    }
 
+    public var configuration: HTTPClient.Configuration {
+        get {
+            self.application.storage[ConfigurationKey.self] ?? .init()
+        }
+        nonmutating set {
+            if self.application.storage.contains(ClientKey.self) {
+                self.application.logger.warning("Cannot modify client configuration after client has been used")
+            } else {
+                self.application.storage[ConfigurationKey.self] = newValue
+            }
+        }
+    }
+    
+    struct ClientKey: StorageKey, LockKey {
+        typealias Value = HTTPClient
+    }
+    
+    struct ConfigurationKey: StorageKey {
+        typealias Value = HTTPClient.Configuration
+    }
+    
     public func `for`(_ request: Request) -> Client {
-        AsyncHTTPClient(driver: self.driver, eventLoop: request.eventLoop)
+        AsyncHTTPClient(eventLoop: request.eventLoop, application: self.application)
     }
 
     public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {

--- a/Sources/Vapor/Client/AsyncHTTPClient.swift
+++ b/Sources/Vapor/Client/AsyncHTTPClient.swift
@@ -1,14 +1,14 @@
 import AsyncHTTPClient
 
 public struct AsyncHTTPClient: Client {
-    let http: HTTPClient
+    public let driver: HTTPClient
     public let eventLoop: EventLoop
 
     public func `for`(_ request: Request) -> Client {
-        AsyncHTTPClient(http: self.http, eventLoop: request.eventLoop)
+        AsyncHTTPClient(driver: self.driver, eventLoop: request.eventLoop)
     }
 
     public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-        return self.http.send(request, eventLoop: .delegate(on: self.eventLoop))
+        return self.driver.send(request, eventLoop: .delegate(on: self.eventLoop))
     }
 }

--- a/Sources/Vapor/Client/AsyncHTTPClient.swift
+++ b/Sources/Vapor/Client/AsyncHTTPClient.swift
@@ -1,0 +1,14 @@
+import AsyncHTTPClient
+
+public struct AsyncHTTPClient: Client {
+    let http: HTTPClient
+    public let eventLoop: EventLoop
+
+    public func `for`(_ request: Request) -> Client {
+        AsyncHTTPClient(http: self.http, eventLoop: request.eventLoop)
+    }
+
+    public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
+        return self.http.send(request, eventLoop: .delegate(on: self.eventLoop))
+    }
+}

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,5 +1,5 @@
 public protocol Client {
-    var eventLoopGroup: EventLoopGroup { get }
+    var eventLoop: EventLoop { get }
     func `for`(_ request: Request) -> Client
     func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse>
 }
@@ -35,7 +35,7 @@ extension Client {
         do {
             try beforeSend(&request)
         } catch {
-            return self.eventLoopGroup.next().makeFailedFuture(error)
+            return self.eventLoop.makeFailedFuture(error)
         }
         return self.send(request)
     }

--- a/Sources/Vapor/Client/Request+Client.swift
+++ b/Sources/Vapor/Client/Request+Client.swift
@@ -1,22 +1,22 @@
 extension Request {
     public var client: Client {
-        return self.application.client.for(self)
+        self.application.clients.client.for(self)
     }
 }
 
-struct RequestClient: Client {
-    let http: HTTPClient
-    let req: Request
-
-    var eventLoopGroup: EventLoopGroup {
-        return self.req.eventLoop
-    }
-
-    func `for`(_ request: Request) -> Client {
-        RequestClient(http: self.http, req: request)
-    }
-
-    func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-        return self.http.send(request, eventLoop: .delegate(on: self.req.eventLoop))
-    }
-}
+//struct RequestClient: Client {
+//    let http: HTTPClient
+//    let req: Request
+//
+//    var eventLoopGroup: EventLoopGroup {
+//        return self.req.eventLoop
+//    }
+//
+//    func `for`(_ request: Request) -> Client {
+//        RequestClient(http: self.http, req: request)
+//    }
+//
+//    func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
+//        return self.http.send(request, eventLoop: .delegate(on: self.req.eventLoop))
+//    }
+//}

--- a/Sources/Vapor/Client/Request+Client.swift
+++ b/Sources/Vapor/Client/Request+Client.swift
@@ -3,16 +3,3 @@ extension Request {
         self.application.clients.client.for(self)
     }
 }
-
-public struct WrappedHTTPClient: Client {
-    let http: HTTPClient
-    public let eventLoop: EventLoop
-
-    public func `for`(_ request: Request) -> Client {
-        WrappedHTTPClient(http: self.http, eventLoop: request.eventLoop)
-    }
-
-    public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-        return self.http.send(request, eventLoop: .delegate(on: self.eventLoop))
-    }
-}

--- a/Sources/Vapor/Client/Request+Client.swift
+++ b/Sources/Vapor/Client/Request+Client.swift
@@ -4,19 +4,15 @@ extension Request {
     }
 }
 
-//struct RequestClient: Client {
-//    let http: HTTPClient
-//    let req: Request
-//
-//    var eventLoopGroup: EventLoopGroup {
-//        return self.req.eventLoop
-//    }
-//
-//    func `for`(_ request: Request) -> Client {
-//        RequestClient(http: self.http, req: request)
-//    }
-//
-//    func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-//        return self.http.send(request, eventLoop: .delegate(on: self.req.eventLoop))
-//    }
-//}
+public struct WrappedHTTPClient: Client {
+    let http: HTTPClient
+    public let eventLoop: EventLoop
+
+    public func `for`(_ request: Request) -> Client {
+        WrappedHTTPClient(http: self.http, eventLoop: request.eventLoop)
+    }
+
+    public func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
+        return self.http.send(request, eventLoop: .delegate(on: self.eventLoop))
+    }
+}

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1077,7 +1077,7 @@ final class ApplicationTests: XCTestCase {
         }
         try app.start()
 
-        let res = try app.clients.client.get("http://127.0.0.1:8123/foo").wait()
+        let res = try app.client.get("http://127.0.0.1:8123/foo").wait()
         XCTAssertEqual(res.body?.string, "bar")
     }
 
@@ -1091,7 +1091,7 @@ final class ApplicationTests: XCTestCase {
 
         try app.start()
 
-        let res = try app.clients.client.get("http://localhost:8080/hello").wait()
+        let res = try app.client.get("http://localhost:8080/hello").wait()
         XCTAssertEqual(res.body?.string, "Hello, world!")
     }
 
@@ -1200,7 +1200,7 @@ final class ApplicationTests: XCTestCase {
         let cache = EndpointCache<Test>(uri: "/number")
         do {
             let test = try cache.get(
-                using: app.clients.client,
+                using: app.client,
                 logger: app.logger,
                 on: app.eventLoopGroup.next()
             ).wait()
@@ -1208,7 +1208,7 @@ final class ApplicationTests: XCTestCase {
         }
         do {
             let test = try cache.get(
-                using: app.clients.client,
+                using: app.client,
                 logger: app.logger,
                 on: app.eventLoopGroup.next()
             ).wait()
@@ -1238,7 +1238,7 @@ final class ApplicationTests: XCTestCase {
         let cache = EndpointCache<Test>(uri: "/number")
         do {
             let test = try cache.get(
-                using: app.clients.client,
+                using: app.client,
                 logger: app.logger,
                 on: app.eventLoopGroup.next()
             ).wait()
@@ -1246,7 +1246,7 @@ final class ApplicationTests: XCTestCase {
         }
         do {
             let test = try cache.get(
-                using: app.clients.client,
+                using: app.client,
                 logger: app.logger,
                 on: app.eventLoopGroup.next()
             ).wait()
@@ -1256,7 +1256,7 @@ final class ApplicationTests: XCTestCase {
         sleep(1)
         do {
             let test = try cache.get(
-                using: app.clients.client,
+                using: app.client,
                 logger: app.logger,
                 on: app.eventLoopGroup.next()
             ).wait()
@@ -1297,7 +1297,7 @@ final class ApplicationTests: XCTestCase {
         defer { server.shutdown() }
 
         // Small payload should just barely get through.
-        let res = try app.clients.client.post("http://localhost:8080/gzip") { req in
+        let res = try app.client.post("http://localhost:8080/gzip") { req in
             req.headers.replaceOrAdd(name: .contentEncoding, value: "gzip")
             req.body = smallBody
         }.wait()
@@ -1306,7 +1306,7 @@ final class ApplicationTests: XCTestCase {
         // Big payload should be hard-rejected. We can't test for the raw NIOHTTPDecompression.DecompressionError.limit error here because
         // protocol decoding errors are only ever logged and can't be directly caught.
         do {
-            _ = try app.clients.client.post("http://localhost:8080/gzip") { req in
+            _ = try app.client.post("http://localhost:8080/gzip") { req in
                 req.headers.replaceOrAdd(name: .contentEncoding, value: "gzip")
                 req.body = bigBody
             }.wait()

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1205,7 +1205,7 @@ final class ApplicationTests: XCTestCase {
         Thread.async {
             startingPistol.leave()
             startingPistol.wait()
-            XCTAssert(type(of: app.clients.http) == WrappedHTTPClient.self)
+            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
             finishLine.leave()
         }
 
@@ -1213,7 +1213,7 @@ final class ApplicationTests: XCTestCase {
         Thread.async {
             startingPistol.leave()
             startingPistol.wait()
-            XCTAssert(type(of: app.clients.http) == WrappedHTTPClient.self)
+            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
             finishLine.leave()
         }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1495,13 +1495,6 @@ final class ApplicationTests: XCTestCase {
     }
 }
 
-//extension Application.Responder {
-//    /// Creates a `Client` from an `Application`'s  current`Responder`.
-//    var client: Client {
-//        ResponderClient(responder: self.current, application: self.application)
-//    }
-//}
-
 struct ResponderClient: Client {
     let responder: Responder
     let application: Application

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -1016,24 +1016,6 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testClientBeforeSend() throws {
-        let app = Application()
-        defer { app.shutdown() }
-        try app.boot()
-        
-        let res = try app.clients.client.post("http://httpbin.org/anything") { req in
-            try req.content.encode(["hello": "world"])
-        }.wait()
-
-        struct HTTPBinAnything: Codable {
-            var headers: [String: String]
-            var json: [String: String]
-        }
-        let data = try res.content.decode(HTTPBinAnything.self)
-        XCTAssertEqual(data.json, ["hello": "world"])
-        XCTAssertEqual(data.headers["Content-Type"], "application/json; charset=utf-8")
-    }
-
 //    func testSingletonServiceShutdown() throws {
 //        final class Foo {
 //            var didShutdown = false
@@ -1097,34 +1079,6 @@ final class ApplicationTests: XCTestCase {
 
         let res = try app.clients.client.get("http://127.0.0.1:8123/foo").wait()
         XCTAssertEqual(res.body?.string, "bar")
-    }
-
-    func testBoilerplateClient() throws {
-        let app = Application(.init(
-            name: "xctest",
-            arguments: ["vapor", "serve", "-b", "localhost:8080", "--log", "trace"]
-        ))
-        try LoggingSystem.bootstrap(from: &app.environment)
-        defer { app.shutdown() }
-
-        app.get("foo") { req -> EventLoopFuture<String> in
-            return req.client.get("https://httpbin.org/status/201").map { res in
-                XCTAssertEqual(res.status.code, 201)
-                req.application.running?.stop()
-                return "bar"
-            }.flatMapErrorThrowing {
-                req.application.running?.stop()
-                throw $0
-            }
-        }
-
-        try app.boot()
-        try app.start()
-
-        let res = try app.clients.client.get("http://localhost:8080/foo").wait()
-        XCTAssertEqual(res.body?.string, "bar")
-
-        try app.running?.onStop.wait()
     }
 
     func testBoilerplate() throws {
@@ -1192,34 +1146,6 @@ final class ApplicationTests: XCTestCase {
         }
     }
 
-    func testApplicationClientThreadSafety() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        let startingPistol = DispatchGroup()
-        startingPistol.enter()
-        startingPistol.enter()
-
-        let finishLine = DispatchGroup()
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.wait()
-    }
-
     func testRequestRemoteAddress() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
@@ -1231,56 +1157,6 @@ final class ApplicationTests: XCTestCase {
         try app.testable(method: .running).test(.GET, "remote") { res in
             XCTAssertContains(res.body.string, "IP")
         }
-    }
-
-    func testClientConfigurationChange() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        app.clients.configuration.redirectConfiguration = .disallow
-
-        app.get("redirect") {
-            $0.redirect(to: "foo")
-        }
-
-        let server = try app.server.start(hostname: "localhost", port: 8080)
-        defer { server.shutdown() }
-
-        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
-
-        XCTAssertEqual(res.status, .seeOther)
-    }
-    
-    func testClientConfigurationCantBeChangedAfterClientHasBeenUsed() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        app.clients.configuration.redirectConfiguration = .disallow
-
-        app.get("redirect") {
-            $0.redirect(to: "foo")
-        }
-
-        let server = try app.server.start(hostname: "localhost", port: 8080)
-        defer { server.shutdown() }
-
-        _ = try app.clients.client.get("http://localhost:8080/redirect").wait()
-        
-        app.clients.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
-        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
-        XCTAssertEqual(res.status, .seeOther)
-    }
-
-    func testClientResponseCodable() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        let res = try app.clients.client.get("https://httpbin.org/json").wait()
-
-        let encoded = try JSONEncoder().encode(res)
-        let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
-        
-        XCTAssertEqual(res, decoded)
     }
     
     func testMultipleChunkBody() throws {

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -6,7 +6,7 @@ final class ClientTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.clients.configuration.redirectConfiguration = .disallow
+        app.clients.http.configuration.redirectConfiguration = .disallow
 
         app.get("redirect") {
             $0.redirect(to: "foo")
@@ -24,7 +24,7 @@ final class ClientTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.clients.configuration.redirectConfiguration = .disallow
+        app.clients.http.configuration.redirectConfiguration = .disallow
 
         app.get("redirect") {
             $0.redirect(to: "foo")
@@ -35,7 +35,7 @@ final class ClientTests: XCTestCase {
 
         _ = try app.client.get("http://localhost:8080/redirect").wait()
         
-        app.clients.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
+        app.clients.http.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
         let res = try app.client.get("http://localhost:8080/redirect").wait()
         XCTAssertEqual(res.status, .seeOther)
     }

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -1,0 +1,128 @@
+import Vapor
+import XCTest
+
+final class ClientTests: XCTestCase {
+    func testClientConfigurationChange() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.clients.configuration.redirectConfiguration = .disallow
+
+        app.get("redirect") {
+            $0.redirect(to: "foo")
+        }
+
+        let server = try app.server.start(hostname: "localhost", port: 8080)
+        defer { server.shutdown() }
+
+        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
+
+        XCTAssertEqual(res.status, .seeOther)
+    }
+    
+    func testClientConfigurationCantBeChangedAfterClientHasBeenUsed() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.clients.configuration.redirectConfiguration = .disallow
+
+        app.get("redirect") {
+            $0.redirect(to: "foo")
+        }
+
+        let server = try app.server.start(hostname: "localhost", port: 8080)
+        defer { server.shutdown() }
+
+        _ = try app.clients.client.get("http://localhost:8080/redirect").wait()
+        
+        app.clients.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
+        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
+        XCTAssertEqual(res.status, .seeOther)
+    }
+
+    func testClientResponseCodable() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let res = try app.clients.client.get("https://httpbin.org/json").wait()
+
+        let encoded = try JSONEncoder().encode(res)
+        let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
+        
+        XCTAssertEqual(res, decoded)
+    }
+    
+    func testClientBeforeSend() throws {
+        let app = Application()
+        defer { app.shutdown() }
+        try app.boot()
+        
+        let res = try app.clients.client.post("http://httpbin.org/anything") { req in
+            try req.content.encode(["hello": "world"])
+        }.wait()
+
+        struct HTTPBinAnything: Codable {
+            var headers: [String: String]
+            var json: [String: String]
+        }
+        let data = try res.content.decode(HTTPBinAnything.self)
+        XCTAssertEqual(data.json, ["hello": "world"])
+        XCTAssertEqual(data.headers["Content-Type"], "application/json; charset=utf-8")
+    }
+    
+    func testBoilerplateClient() throws {
+        let app = Application(.init(
+            name: "xctest",
+            arguments: ["vapor", "serve", "-b", "localhost:8080", "--log", "trace"]
+        ))
+        try LoggingSystem.bootstrap(from: &app.environment)
+        defer { app.shutdown() }
+
+        app.get("foo") { req -> EventLoopFuture<String> in
+            return req.client.get("https://httpbin.org/status/201").map { res in
+                XCTAssertEqual(res.status.code, 201)
+                req.application.running?.stop()
+                return "bar"
+            }.flatMapErrorThrowing {
+                req.application.running?.stop()
+                throw $0
+            }
+        }
+
+        try app.boot()
+        try app.start()
+
+        let res = try app.clients.client.get("http://localhost:8080/foo").wait()
+        XCTAssertEqual(res.body?.string, "bar")
+
+        try app.running?.onStop.wait()
+    }
+    
+    func testApplicationClientThreadSafety() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let startingPistol = DispatchGroup()
+        startingPistol.enter()
+        startingPistol.enter()
+
+        let finishLine = DispatchGroup()
+        finishLine.enter()
+        Thread.async {
+            startingPistol.leave()
+            startingPistol.wait()
+            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
+            finishLine.leave()
+        }
+
+        finishLine.enter()
+        Thread.async {
+            startingPistol.leave()
+            startingPistol.wait()
+            XCTAssert(type(of: app.clients.http) == AsyncHTTPClient.self)
+            finishLine.leave()
+        }
+
+        finishLine.wait()
+    }
+}

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -15,7 +15,7 @@ final class ClientTests: XCTestCase {
         let server = try app.server.start(hostname: "localhost", port: 8080)
         defer { server.shutdown() }
 
-        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
+        let res = try app.client.get("http://localhost:8080/redirect").wait()
 
         XCTAssertEqual(res.status, .seeOther)
     }
@@ -33,10 +33,10 @@ final class ClientTests: XCTestCase {
         let server = try app.server.start(hostname: "localhost", port: 8080)
         defer { server.shutdown() }
 
-        _ = try app.clients.client.get("http://localhost:8080/redirect").wait()
+        _ = try app.client.get("http://localhost:8080/redirect").wait()
         
         app.clients.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
-        let res = try app.clients.client.get("http://localhost:8080/redirect").wait()
+        let res = try app.client.get("http://localhost:8080/redirect").wait()
         XCTAssertEqual(res.status, .seeOther)
     }
 
@@ -44,7 +44,7 @@ final class ClientTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let res = try app.clients.client.get("https://httpbin.org/json").wait()
+        let res = try app.client.get("https://httpbin.org/json").wait()
 
         let encoded = try JSONEncoder().encode(res)
         let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
@@ -57,7 +57,7 @@ final class ClientTests: XCTestCase {
         defer { app.shutdown() }
         try app.boot()
         
-        let res = try app.clients.client.post("http://httpbin.org/anything") { req in
+        let res = try app.client.post("http://httpbin.org/anything") { req in
             try req.content.encode(["hello": "world"])
         }.wait()
 
@@ -92,7 +92,7 @@ final class ClientTests: XCTestCase {
         try app.boot()
         try app.start()
 
-        let res = try app.clients.client.get("http://localhost:8080/foo").wait()
+        let res = try app.client.get("http://localhost:8080/foo").wait()
         XCTAssertEqual(res.body?.string, "bar")
 
         try app.running?.onStop.wait()


### PR DESCRIPTION
This PR makes Vapor's client configurable. This would allow you to switch between Async HTTP Client and URLSession in your apps, and also a real client and a fake client in tests, using something like:

```swift
app.clients.use(.fake)
```

And also demonstrated [in the tests](https://github.com/vapor/vapor/pull/2277/files#diff-c991ce1ca70f01333e0d2a1315004cb2R1332).

This is a wide ranging PR with one breaking changes that can be likely justified as for most people, `req.client` still does what they expect. Anyone using `app.client.configuration` should migrate to `app.clients.configuration`.

Resolves #2269 