### PR TITLE
Async password verifier

### DIFF
--- a/Sources/Vapor/Passwords/AsyncPasswordVerifier.swift
+++ b/Sources/Vapor/Passwords/AsyncPasswordVerifier.swift
@@ -3,7 +3,7 @@ public struct AsyncPasswordVerifier {
     private let threadPool: NIOThreadPool
     private let eventLoop: EventLoop
     
-    public init (verifier: PasswordVerifier, threadPool: NIOThreadPool, eventLoop: EventLoop) {
+    public init(verifier: PasswordVerifier, threadPool: NIOThreadPool, eventLoop: EventLoop) {
         self.verifier = verifier
         self.threadPool = threadPool
         self.eventLoop = eventLoop
@@ -33,7 +33,7 @@ public struct AsyncPasswordVerifier {
         self.threadPool.submit { _ in
             do {
                 return promise.succeed(try self.verifier.verify(password, created: digest))
-            } catch  {
+            } catch {
                 return promise.fail(error)
             }
         }

--- a/Sources/Vapor/Passwords/AsyncPasswordVerifier.swift
+++ b/Sources/Vapor/Passwords/AsyncPasswordVerifier.swift
@@ -1,0 +1,55 @@
+public struct AsyncPasswordVerifier {
+    private let verifier: PasswordVerifier
+    private let threadPool: NIOThreadPool
+    private let eventLoop: EventLoop
+    
+    public init (verifier: PasswordVerifier, threadPool: NIOThreadPool, eventLoop: EventLoop) {
+        self.verifier = verifier
+        self.threadPool = threadPool
+        self.eventLoop = eventLoop
+    }
+    
+    public func digest<Password>(_ password: Password) throws -> EventLoopFuture<[UInt8]>
+        where Password: DataProtocol
+    {
+        let promise = eventLoop.makePromise(of: [UInt8].self)
+        self.threadPool.submit { _ in
+            do {
+                return promise.succeed(try self.verifier.digest(password))
+            } catch  {
+                return promise.fail(error)
+            }
+        }
+        return promise.futureResult
+    }
+    
+    public func verify<Password, Digest>(
+        _ password: Password,
+        created digest: Digest
+    ) throws -> EventLoopFuture<Bool>
+        where Password: DataProtocol, Digest: DataProtocol
+    {
+        let promise = eventLoop.makePromise(of: Bool.self)
+        self.threadPool.submit { _ in
+            do {
+                return promise.succeed(try self.verifier.verify(password, created: digest))
+            } catch  {
+                return promise.fail(error)
+            }
+        }
+        return promise.futureResult
+    }
+    
+    public func digest(_ password: String) throws -> EventLoopFuture<String> {
+        try self.digest([UInt8](password.utf8)).map {
+            String(decoding: $0, as: UTF8.self)
+        }
+    }
+
+    public func verify(_ password: String, created digest: String) throws -> EventLoopFuture<Bool> {
+        try self.verify(
+            [UInt8](password.utf8),
+            created: [UInt8](digest.utf8)
+        )
+    }
+}

--- a/Sources/Vapor/Passwords/PasswordVerifier.swift
+++ b/Sources/Vapor/Passwords/PasswordVerifier.swift
@@ -21,64 +21,8 @@ extension PasswordVerifier {
         )
     }
     
-    public func async(on threadPool: NIOThreadPool, hopTo eventLoop: EventLoop) -> AsyncPasswordVerifier
+    public func asynchronized(on threadPool: NIOThreadPool, hopTo eventLoop: EventLoop) -> AsyncPasswordVerifier
      {
         AsyncPasswordVerifier(verifier: self, threadPool: threadPool, eventLoop: eventLoop)
-    }
-}
-
-public struct AsyncPasswordVerifier {
-    private let verifier: PasswordVerifier
-    private let threadPool: NIOThreadPool
-    private let eventLoop: EventLoop
-    
-    public init (verifier: PasswordVerifier, threadPool: NIOThreadPool, eventLoop: EventLoop) {
-        self.verifier = verifier
-        self.threadPool = threadPool
-        self.eventLoop = eventLoop
-    }
-    
-    public func digest<Password>(_ password: Password) throws -> EventLoopFuture<[UInt8]>
-        where Password: DataProtocol
-    {
-        let promise = eventLoop.makePromise(of: [UInt8].self)
-        self.threadPool.submit { _ in
-            do {
-                return promise.succeed(try self.verifier.digest(password))
-            } catch  {
-                return promise.fail(error)
-            }
-        }
-        return promise.futureResult
-    }
-    
-    public func verify<Password, Digest>(
-        _ password: Password,
-        created digest: Digest
-    ) throws -> EventLoopFuture<Bool>
-        where Password: DataProtocol, Digest: DataProtocol
-    {
-        let promise = eventLoop.makePromise(of: Bool.self)
-        self.threadPool.submit { _ in
-            do {
-                return promise.succeed(try self.verifier.verify(password, created: digest))
-            } catch  {
-                return promise.fail(error)
-            }
-        }
-        return promise.futureResult
-    }
-    
-    public func digest(_ password: String) throws -> EventLoopFuture<String> {
-        try self.digest([UInt8](password.utf8)).map {
-            String(decoding: $0, as: UTF8.self)
-        }
-    }
-
-    public func verify(_ password: String, created digest: String) throws -> EventLoopFuture<Bool> {
-        try self.verify(
-            [UInt8](password.utf8),
-            created: [UInt8](digest.utf8)
-        )
     }
 }

--- a/Sources/Vapor/Passwords/PasswordVerifier.swift
+++ b/Sources/Vapor/Passwords/PasswordVerifier.swift
@@ -20,4 +20,65 @@ extension PasswordVerifier {
             created: [UInt8](digest.utf8)
         )
     }
+    
+    public func async(on threadPool: NIOThreadPool, hopTo eventLoop: EventLoop) -> AsyncPasswordVerifier
+     {
+        AsyncPasswordVerifier(verifier: self, threadPool: threadPool, eventLoop: eventLoop)
+    }
+}
+
+public struct AsyncPasswordVerifier {
+    private let verifier: PasswordVerifier
+    private let threadPool: NIOThreadPool
+    private let eventLoop: EventLoop
+    
+    public init (verifier: PasswordVerifier, threadPool: NIOThreadPool, eventLoop: EventLoop) {
+        self.verifier = verifier
+        self.threadPool = threadPool
+        self.eventLoop = eventLoop
+    }
+    
+    public func digest<Password>(_ password: Password) throws -> EventLoopFuture<[UInt8]>
+        where Password: DataProtocol
+    {
+        let promise = eventLoop.makePromise(of: [UInt8].self)
+        self.threadPool.submit { _ in
+            do {
+                return promise.succeed(try self.verifier.digest(password))
+            } catch  {
+                return promise.fail(error)
+            }
+        }
+        return promise.futureResult
+    }
+    
+    public func verify<Password, Digest>(
+        _ password: Password,
+        created digest: Digest
+    ) throws -> EventLoopFuture<Bool>
+        where Password: DataProtocol, Digest: DataProtocol
+    {
+        let promise = eventLoop.makePromise(of: Bool.self)
+        self.threadPool.submit { _ in
+            do {
+                return promise.succeed(try self.verifier.verify(password, created: digest))
+            } catch  {
+                return promise.fail(error)
+            }
+        }
+        return promise.futureResult
+    }
+    
+    public func digest(_ password: String) throws -> EventLoopFuture<String> {
+        try self.digest([UInt8](password.utf8)).map {
+            String(decoding: $0, as: UTF8.self)
+        }
+    }
+
+    public func verify(_ password: String, created digest: String) throws -> EventLoopFuture<Bool> {
+        try self.verify(
+            [UInt8](password.utf8),
+            created: [UInt8](digest.utf8)
+        )
+    }
 }

--- a/Sources/Vapor/Passwords/PasswordVerifier.swift
+++ b/Sources/Vapor/Passwords/PasswordVerifier.swift
@@ -21,7 +21,7 @@ extension PasswordVerifier {
         )
     }
     
-    public func asynchronized(on threadPool: NIOThreadPool, hopTo eventLoop: EventLoop) -> AsyncPasswordVerifier
+    public func async(on threadPool: NIOThreadPool, hopTo eventLoop: EventLoop) -> AsyncPasswordVerifier
      {
         AsyncPasswordVerifier(verifier: self, threadPool: threadPool, eventLoop: eventLoop)
     }

--- a/Sources/Vapor/Passwords/Request+Password.swift
+++ b/Sources/Vapor/Passwords/Request+Password.swift
@@ -13,19 +13,26 @@ extension Request {
         }
         
         public var async: AsyncPasswordVerifier {
-            self.application.password.asynchronized(on: application.threadPool, hopTo: eventLoop)
+            self.application.password.async(on: application.threadPool, hopTo: eventLoop)
         }
         
-        public var verifier: PasswordVerifier {
+        public var sync: PasswordVerifier {
             self.application.password
         }
         
-        public func verify<Password, Digest>(_ password: Password, created digest: Digest) throws -> Bool where Password : DataProtocol, Digest : DataProtocol {
-            try verifier.verify(password, created: digest)
+        public func verify<Password, Digest>(
+            _ password: Password,
+            created digest: Digest
+        ) throws -> Bool
+            where Password : DataProtocol, Digest : DataProtocol
+        {
+            try sync.verify(password, created: digest)
         }
         
-        public func digest<Password>(_ password: Password) throws -> [UInt8] where Password : DataProtocol {
-            try verifier.digest(password)
+        public func digest<Password>(_ password: Password) throws -> [UInt8]
+            where Password : DataProtocol
+        {
+            try sync.digest(password)
         }
     }
 }

--- a/Sources/Vapor/Passwords/Request+Password.swift
+++ b/Sources/Vapor/Passwords/Request+Password.swift
@@ -1,5 +1,5 @@
 extension Request {
-    public var password: PasswordVerifier {
-        self.application.password
+    public var password: AsyncPasswordVerifier {
+        self.application.password.async(on: application.threadPool, hopTo: eventLoop)
     }
 }

--- a/Sources/Vapor/Passwords/Request+Password.swift
+++ b/Sources/Vapor/Passwords/Request+Password.swift
@@ -1,5 +1,31 @@
 extension Request {
-    public var password: AsyncPasswordVerifier {
-        self.application.password.async(on: application.threadPool, hopTo: eventLoop)
+    public var password: Password {
+        Password(for: self)
+    }
+    
+    public struct Password: PasswordVerifier {
+        private let application: Application
+        private let eventLoop: EventLoop
+        
+        init(for req: Request) {
+            self.application = req.application
+            self.eventLoop = req.eventLoop
+        }
+        
+        public var async: AsyncPasswordVerifier {
+            self.application.password.asynchronized(on: application.threadPool, hopTo: eventLoop)
+        }
+        
+        public var verifier: PasswordVerifier {
+            self.application.password
+        }
+        
+        public func verify<Password, Digest>(_ password: Password, created digest: Digest) throws -> Bool where Password : DataProtocol, Digest : DataProtocol {
+            try verifier.verify(password, created: digest)
+        }
+        
+        public func digest<Password>(_ password: Password) throws -> [UInt8] where Password : DataProtocol {
+            try verifier.digest(password)
+        }
     }
 }

--- a/Tests/VaporTests/BcryptTests.swift
+++ b/Tests/VaporTests/BcryptTests.swift
@@ -51,6 +51,13 @@ final class BcryptTests: XCTestCase {
         
         let result = try app.password.verify("vapor", created: hash)
         XCTAssertTrue(result)
+        
+        let asyncHash = try app.password.async(on: app.threadPool
+            , hopTo: app.eventLoopGroup.next()).digest("vapor").wait()
+        XCTAssertTrue(try BCryptDigest().verify("vapor", created: asyncHash))
+        
+        let asyncResult = try app.password.async(on: app.threadPool, hopTo: app.eventLoopGroup.next()).verify("vapor", created: asyncHash).wait()
+        XCTAssertTrue(asyncResult)
     }
     
     func testPlaintextService() throws {

--- a/Tests/VaporTests/BcryptTests.swift
+++ b/Tests/VaporTests/BcryptTests.swift
@@ -42,7 +42,7 @@ final class BcryptTests: XCTestCase {
         XCTAssert(result, "verification failed")
     }
     
-    func testBCryptService() throws {
+    func testSyncBCryptService() throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
         let app = Application(test)
         defer { app.shutdown() }
@@ -51,9 +51,15 @@ final class BcryptTests: XCTestCase {
         
         let result = try app.password.verify("vapor", created: hash)
         XCTAssertTrue(result)
+    }
+    
+    func testAsyncBcryptService() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
         
         let asyncHash = try app.password
-            .asynchronized(on: app.threadPool, hopTo: app.eventLoopGroup.next())
+            .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
             .digest("vapor")
             .wait()
         XCTAssertTrue(try BCryptDigest().verify("vapor", created: asyncHash))

--- a/Tests/VaporTests/BcryptTests.swift
+++ b/Tests/VaporTests/BcryptTests.swift
@@ -52,7 +52,10 @@ final class BcryptTests: XCTestCase {
         let result = try app.password.verify("vapor", created: hash)
         XCTAssertTrue(result)
         
-        let asyncHash = try app.password.asynchronized(on: app.threadPool, hopTo: app.eventLoopGroup.next()).digest("vapor").wait()
+        let asyncHash = try app.password
+            .asynchronized(on: app.threadPool, hopTo: app.eventLoopGroup.next())
+            .digest("vapor")
+            .wait()
         XCTAssertTrue(try BCryptDigest().verify("vapor", created: asyncHash))
         
         struct Verify: Content {
@@ -61,7 +64,10 @@ final class BcryptTests: XCTestCase {
         
         app.post("test") { req -> EventLoopFuture<String> in
             let verify = try req.content.decode(Verify.self)
-            return try req.password.async.verify("vapor", created: verify.digest).map { $0 ? "true" : "false" }
+            return try req.password
+                .async
+                .verify("vapor", created: verify.digest)
+                .map { $0 ? "true" : "false" }
         }
         
         try app.test(.POST, "test", beforeRequest: { req in

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -1,0 +1,111 @@
+import XCTVapor
+
+final class PasswordTests: XCTestCase {
+    func testSyncBCryptService() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        
+        let hash = try app.password.digest("vapor")
+        XCTAssertTrue(try BCryptDigest().verify("vapor", created: hash))
+        
+        let result = try app.password.verify("vapor", created: hash)
+        XCTAssertTrue(result)
+    }
+    
+    func testSyncPlaintextService() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        app.passwords.use(.plaintext)
+        
+        let hash = try app.password.digest("vapor")
+        XCTAssertEqual(hash, "vapor")
+        
+        let result = try app.password.verify("vapor", created: hash)
+        XCTAssertTrue(result)
+    }
+    
+    func testAsyncBCryptRequestPassword() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        
+        try assertAsyncRequestPasswordVerifies(.bcrypt, on: app)
+    }
+    
+    func testAsyncPlaintextRequestPassword() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        
+        try assertAsyncRequestPasswordVerifies(.plaintext, on: app)
+    }
+    
+    func testAsyncBCryptApplicationPassword() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        
+        try assertAsyncApplicationPasswordVerifies(.bcrypt, on: app)
+    }
+    
+    func testAsyncPlaintextApplicationPassword() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        
+        try assertAsyncApplicationPasswordVerifies(.plaintext, on: app)
+    }
+    
+    private func assertAsyncApplicationPasswordVerifies(
+        _ provider: Application.Passwords.Provider,
+        on app: Application,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        app.passwords.use(provider)
+        
+        let asyncHash = try app.password
+            .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
+            .digest("vapor")
+            .wait()
+        
+        let asyncVerifiy = try app.password
+            .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
+            .verify("vapor", created: asyncHash)
+            .wait()
+        
+        XCTAssertTrue(asyncVerifiy, file: file, line: line)
+    }
+    
+    private func assertAsyncRequestPasswordVerifies(
+        _ provider: Application.Passwords.Provider,
+        on app: Application,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        app.passwords.use(provider)
+        
+        app.get("test") { req -> EventLoopFuture<String> in
+            return try req.password
+                .async
+                .digest("vapor")
+                .flatMap { digest -> EventLoopFuture<Bool> in
+                    do {
+                        return try req.password
+                            .async
+                            .verify("vapor", created: digest)
+                    } catch {
+                        XCTFail("failed to verify digest", file: file, line: line)
+                        return req.eventLoop.makeFailedFuture(error)
+                    }
+            }
+            .map { $0 ? "true" : "false" }
+        }
+        
+        try app.test(.GET, "test", afterResponse: { res in
+            XCTAssertEqual(res.body.string, "true", file: file, line: line)
+        })
+    }
+}

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -58,6 +58,15 @@ final class PasswordTests: XCTestCase {
         try assertAsyncApplicationPasswordVerifies(.plaintext, on: app)
     }
     
+    func testAsyncUsesProvider() throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        let app = Application(test)
+        defer { app.shutdown() }
+        app.passwords.use(.plaintext)
+        let hash = try app.password.async(on: app.threadPool, hopTo: app.eventLoopGroup.next()).digest("vapor").wait()
+        XCTAssertEqual(hash, "vapor")
+    }
+    
     private func assertAsyncApplicationPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,


### PR DESCRIPTION
This PR adds `AsyncPasswordVerifier` to allow slow methods like `BCrypt` to run on the threadpool in order to prevent blocking of the event loop. 

This fixes #2218 

The syntax is as follows:
```swift
req.password.async.verify()
```