### PR TITLE
Add didRegister callback to LifecycleHandler

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -11,7 +11,7 @@ public final class Application {
 
     public struct Lifecycle {
         var handlers: [LifecycleHandler]
-        weak var application: Application?
+        var application: Application?
         
         init() {
             self.handlers = []
@@ -146,6 +146,7 @@ public final class Application {
         self.logger.trace("Shutting down providers")
         self.lifecycle.handlers.forEach { $0.shutdown(self) }
         self.lifecycle.handlers = []
+        self.lifecycle.application = nil
         
         self.logger.trace("Clearing Application storage")
         self.storage.shutdown()

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -11,12 +11,17 @@ public final class Application {
 
     public struct Lifecycle {
         var handlers: [LifecycleHandler]
+        weak var application: Application?
+        
         init() {
             self.handlers = []
         }
 
         public mutating func use(_ handler: LifecycleHandler) {
             self.handlers.append(handler)
+            if let application = self.application {
+                handler.didRegister(application)
+            }
         }
     }
 
@@ -92,6 +97,7 @@ public final class Application {
         // Load specific .env first since values are not overridden.
         self.loadDotEnv(named: ".env.\(self.environment.name)")
         self.loadDotEnv(named: ".env")
+        self.lifecycle.application = self
     }
     
     public func run() throws {

--- a/Sources/Vapor/Utilities/LifecycleHandler.swift
+++ b/Sources/Vapor/Utilities/LifecycleHandler.swift
@@ -1,12 +1,14 @@
 import NIO
 
 public protocol LifecycleHandler {
+    func didRegister(_ application: Application)
     func willBoot(_ application: Application) throws
     func didBoot(_ application: Application) throws
     func shutdown(_ application: Application)
 }
 
 extension LifecycleHandler {
+    public func didRegister(_ application: Application) { }
     public func willBoot(_ application: Application) throws { }
     public func didBoot(_ application: Application) throws { }
     public func shutdown(_ application: Application) { }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -19,14 +19,20 @@ final class ApplicationTests: XCTestCase {
 
     func testLifecycleHandler() throws {
         final class Foo: LifecycleHandler {
+            var didRegisterFlag: Bool
             var willBootFlag: Bool
             var didBootFlag: Bool
             var shutdownFlag: Bool
 
             init() {
+                self.didRegisterFlag = false
                 self.willBootFlag = false
                 self.didBootFlag = false
                 self.shutdownFlag = false
+            }
+            
+            func didRegister(_ application: Application) {
+                self.didRegisterFlag = true
             }
 
             func willBoot(_ application: Application) throws {
@@ -45,20 +51,29 @@ final class ApplicationTests: XCTestCase {
         let app = Application(.testing)
 
         let foo = Foo()
+        
+        XCTAssertEqual(foo.didRegisterFlag, false)
+        XCTAssertEqual(foo.willBootFlag, false)
+        XCTAssertEqual(foo.didBootFlag, false)
+        XCTAssertEqual(foo.shutdownFlag, false)
+        
         app.lifecycle.use(foo)
 
+        XCTAssertEqual(foo.didRegisterFlag, true)
         XCTAssertEqual(foo.willBootFlag, false)
         XCTAssertEqual(foo.didBootFlag, false)
         XCTAssertEqual(foo.shutdownFlag, false)
 
         try app.boot()
 
+        XCTAssertEqual(foo.didRegisterFlag, true)
         XCTAssertEqual(foo.willBootFlag, true)
         XCTAssertEqual(foo.didBootFlag, true)
         XCTAssertEqual(foo.shutdownFlag, false)
 
         app.shutdown()
 
+        XCTAssertEqual(foo.didRegisterFlag, true)
         XCTAssertEqual(foo.willBootFlag, true)
         XCTAssertEqual(foo.didBootFlag, true)
         XCTAssertEqual(foo.shutdownFlag, true)


### PR DESCRIPTION
This PR adds a `didRegister` callback to `LifecycleHandler`. This is useful if you lifecycle type needs to initialise things before configuration, for example, initialise `Storage` with various keys for services it provides.

This avoids either having to have a separate setup function in the lifecycle handler, which is necessary to stop crashes. These occur if a user of a lifecycle tries to configure something before `boot` is called. For instance a repository type necessary for that lifecycle handler.
