### PR TITLE
Fix "Server starting on..." log message

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -182,15 +182,15 @@ public final class HTTPServer: Server {
     }
     
     public func start(hostname: String?, port: Int?) throws {
-        // print starting message
-        let scheme = self.configuration.tlsConfiguration == nil ? "http" : "https"
-        let address = "\(scheme)://\(self.configuration.hostname):\(self.configuration.port)"
-        self.configuration.logger.notice("Server starting on \(address)")
-
         // determine which hostname / port to bind to
         var configuration = self.configuration
         configuration.hostname = hostname ?? configuration.hostname
         configuration.port = port ?? configuration.port
+
+        // print starting message
+        let scheme = configuration.tlsConfiguration == nil ? "http" : "https"
+        let address = "\(scheme)://\(configuration.hostname):\(configuration.port)"
+        self.configuration.logger.notice("Server starting on \(address)")
 
         // start the actual HTTPServer
         self.connection = try HTTPServerConnection.start(


### PR DESCRIPTION
The `[ NOTICE ] Server starting on ...` log message reported during startup of a `serve` command was always reporting the serving address and port as `http://127.0.0.1:8080` regardless of any `--hostname` or `--port` options in effect. It now accurately reflects the scheme, bind address, and port on which the server will not only listen, but avoid splitting the infinitive.