### PR TITLE
Change async password verifier to non-throwing

### DIFF
--- a/Sources/Vapor/Passwords/AsyncPasswordHasher.swift
+++ b/Sources/Vapor/Passwords/AsyncPasswordHasher.swift
@@ -22,7 +22,7 @@ public struct AsyncPasswordHasher {
         self.eventLoop = eventLoop
     }
     
-    public func hash<Password>(_ password: Password) throws -> EventLoopFuture<[UInt8]>
+    public func hash<Password>(_ password: Password) -> EventLoopFuture<[UInt8]>
         where Password: DataProtocol
     {
         let promise = self.eventLoop.makePromise(of: [UInt8].self)
@@ -39,7 +39,7 @@ public struct AsyncPasswordHasher {
     public func verify<Password, Digest>(
         _ password: Password,
         created digest: Digest
-    ) throws -> EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Bool>
         where Password: DataProtocol, Digest: DataProtocol
     {
         let promise = eventLoop.makePromise(of: Bool.self)
@@ -53,14 +53,14 @@ public struct AsyncPasswordHasher {
         return promise.futureResult
     }
     
-    public func hash(_ password: String) throws -> EventLoopFuture<String> {
-        try self.hash([UInt8](password.utf8)).map {
+    public func hash(_ password: String) -> EventLoopFuture<String> {
+        self.hash([UInt8](password.utf8)).map {
             String(decoding: $0, as: UTF8.self)
         }
     }
 
-    public func verify(_ password: String, created digest: String) throws -> EventLoopFuture<Bool> {
-        try self.verify(
+    public func verify(_ password: String, created digest: String) -> EventLoopFuture<Bool> {
+        self.verify(
             [UInt8](password.utf8),
             created: [UInt8](digest.utf8)
         )

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -109,18 +109,14 @@ final class PasswordTests: XCTestCase {
         app.passwords.use(provider)
         
         app.get("test") { req -> EventLoopFuture<String> in
-            return try req.password
+            return req.password
                 .async
                 .hash("vapor")
                 .flatMap { digest -> EventLoopFuture<Bool> in
-                    do {
-                        return try req.password
-                            .async
-                            .verify("vapor", created: digest)
-                    } catch {
-                        XCTFail("failed to verify digest", file: file, line: line)
-                        return req.eventLoop.makeFailedFuture(error)
-                    }
+                    return req.password
+                        .async
+                        .verify("vapor", created: digest)
+                   
             }
             .map { $0 ? "true" : "false" }
         }


### PR DESCRIPTION
Changed `AsyncPasswordVerifier` methods to be non-throwing, since it is async.
