### PR TITLE
Improve body handling for HEAD responses

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -19,11 +19,9 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
             case .failure(let error):
                 self.errorCaught(context: context, error: error)
             case .success(let response):
-                let contentLength = response.headers.first(name: .contentLength)
                 if request.method == .HEAD {
-                    response.body = .init()
+                    response.forHeadRequest = true
                 }
-                response.headers.replaceOrAdd(name: .contentLength, value: contentLength ?? "0")
                 self.serialize(response, for: request, context: context)
             }
         }

--- a/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
@@ -31,8 +31,9 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
             headers: response.headers
         ))), promise: nil)
         
-        if response.status == .noContent {
-            // don't send bodies for 204 (no content) requests
+        if response.status == .noContent || response.forHeadRequest {
+            // don't send bodies for 204 (no content) responses
+            // or HEAD requests
             context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: promise)
         } else {
             switch response.body.storage {

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -32,6 +32,9 @@ public final class Response: CustomStringConvertible {
         didSet { self.headers.updateContentLength(self.body.count) }
     }
 
+    // If `true`, don't serialize the body.
+    var forHeadRequest: Bool
+
     internal enum Upgrader {
         case webSocket(maxFrameSize: WebSocketMaxFrameSize, onUpgrade: (WebSocket) -> ())
     }
@@ -134,6 +137,7 @@ public final class Response: CustomStringConvertible {
         self.headers = headers
         self.body = body
         self.storage = .init()
+        self.forHeadRequest = false
     }
 }
 


### PR DESCRIPTION
Improves logic for handling HEAD responses (#2310). 

Previously when HEAD requests were detected, the response body would be replaced with an empty body and the `content-length` header would be re-added. This caused problems with responses that don't use the `content-length` header, even for non-HEAD requests. 

Now, when HEAD requests are detected, the response body is not changed. Instead, a flag is set signaling the serializer to skip serialization of the body. 