### PR TITLE
Make Request.route publicly settable

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -29,7 +29,7 @@ public final class Request: CustomStringConvertible {
     ///
     ///     req.route?.description // "GET /hello/:name"
     ///
-    public internal(set) var route: Route?
+    public var route: Route?
 
     // MARK: Content
 


### PR DESCRIPTION
Makes `Request.route` publicly settable (#2315). This makes it easier to build and use custom `Responder` types.