### PR TITLE
HTTPMediaType comparisons should be case insensitive

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -53,20 +53,12 @@ public struct HTTPMediaType: Hashable, CustomStringConvertible, Equatable {
         guard lhs.type != "*" && rhs.type != "*" else {
             return true
         }
-        
-        guard lhs.type != rhs.type else {
-            guard lhs.subType != "*" && rhs.subType != "*" else {
-                return true
-            }
-            
-            guard lhs.subType != rhs.subType else {
-                return true
-            }
-            
+
+        guard lhs.type.caseInsensitiveCompare(rhs.type) == .orderedSame else {
             return false
         }
-        
-        return false
+
+        return lhs.subType == "*" || rhs.subType == "*" || lhs.subType.caseInsensitiveCompare(rhs.subType) == .orderedSame
     }
     
     /// The `MediaType`'s discrete or composite type. Usually one of the following.

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -175,4 +175,16 @@ final class HTTPHeaderValueTests: XCTestCase {
         XCTAssertEqual(headers.cookie?["vapor-session"]?.string, "ZFPQ46p3frNX52i3dM+JFlWbTxQX5rtGuQ5r7Gb6JUs=")
         XCTAssertEqual(headers.cookie?["oauth2_consent_csrf"]?.string, "MTU4NjkzNzgwMnxEdi1CQkFFQ180SUFBUkFCRUFBQVB2LUNBQUVHYzNSeWFXNW5EQVlBQkdOemNtWUdjM1J5YVc1bkRDSUFJR1ExWVRnM09USmhOamRsWXpSbU4yRmhOR1UwTW1KaU5tRXpPRGczTmpjMHweHbVecAf193ev3_1Tcf60iY9jSsq5-IQxGTyoztRTfg==")
     }
+
+    func testMediaTypeMainTypeCaseInsensitive() throws {
+        let lower = HTTPMediaType(type: "foo", subType: "")
+        let upper = HTTPMediaType(type: "FOO", subType: "")
+        XCTAssertEqual(lower, upper)
+    }
+
+    func testMediaTypeSubTypeCaseInsensitive() throws {
+        let lower = HTTPMediaType(type: "foo", subType: "bar")
+        let upper = HTTPMediaType(type: "foo", subType: "BAR")
+        XCTAssertEqual(lower, upper)
+    }
 }


### PR DESCRIPTION
Updates `HTTPMediaType` equality checks so that the values are no longer case sensitive.