### PR TITLE
Fix invalid session ID handling

### DIFF
--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -42,7 +42,13 @@ public final class SessionsMiddleware: Middleware {
             // A cookie value exists, get the session for it.
             let id = SessionID(string: cookieValue.string)
             return self.session.readSession(id, for: request).flatMap { data in
-                request._sessionCache.session = .init(id: id, data: data ?? .init())
+                if let data = data {
+                    // Session found, restore data and id.
+                    request._sessionCache.session = .init(id: id, data: data)
+                } else {
+                    // Session id not found, create new session.
+                    request._sessionCache.session = .init()
+                }
                 return next.respond(to: request).flatMap { res in
                     return self.addCookies(to: res, for: request)
                 }


### PR DESCRIPTION
Requests containing unrecognized session IDs will now result in a new session being created (#2347, fixes #2339). 

This fixes a problem where clearing browser cookies would be required after changing Vapor's session driver. 