### PR TITLE
Add method for customizing log handler

### DIFF
--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -1,5 +1,5 @@
 extension LoggingSystem {
-    public static func bootstrap(from environment: inout Environment, factoryfactory: (Logger.Level) -> (String) -> LogHandler) throws {
+    public static func bootstrap(from environment: inout Environment, _ factory: (Logger.Level) -> (String) -> LogHandler) throws {
         struct LogSignature: CommandSignature {
             @Option(name: "log", help: "Change log level")
             var level: Logger.Level?
@@ -17,16 +17,16 @@ extension LoggingSystem {
         }
 
         // Bootstrap logger with a factory created by the factoryfactory.
-        return LoggingSystem.bootstrap(factoryfactory(level))
+        return LoggingSystem.bootstrap(factory(level))
     }
 
     public static func bootstrap(from environment: inout Environment) throws {
-        try bootstrap(from: &environment, factoryfactory: { level in
+        try self.bootstrap(from: &environment) { level in
             let console = Terminal()
             return { (label: String) in
                 return ConsoleLogger(label: label, console: console, level: level)
             }
-        })
+        }
     }
 }
 

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -1,5 +1,5 @@
 extension LoggingSystem {
-    public static func bootstrap(from environment: inout Environment) throws {
+    public static func bootstrap(from environment: inout Environment, factoryfactory: (Logger.Level) -> (String) -> LogHandler) throws {
         struct LogSignature: CommandSignature {
             @Option(name: "log", help: "Change log level")
             var level: Logger.Level?
@@ -16,8 +16,17 @@ extension LoggingSystem {
             StackTrace.isCaptureEnabled = false
         }
 
-        // Bootstrap logger to use Terminal.
-        return LoggingSystem.bootstrap(console: Terminal(), level: level)
+        // Bootstrap logger with a factory created by the factoryfactory.
+        return LoggingSystem.bootstrap(factoryfactory(level))
+    }
+
+    public static func bootstrap(from environment: inout Environment) throws {
+        try bootstrap(from: &environment, factoryfactory: { level in
+            let console = Terminal()
+            return { (label: String) in
+                return ConsoleLogger(label: label, console: console, level: level)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Adds a new method for bootstrapping a custom log handler (#2348). 

The new `LoggingSystem.bootstrap` method accepts a `LogHandler` factory. The detected logging level (configurable with `--log` or `LOG_LEVEL`) is passed to the closure. 

```swift
LoggingSystem.bootstrap(from: &env) { logLevel in 
    MyLogHandler(logLevel: logLevel)
}
```

There is also a new helper for parsing `Logger.Level` from the environment.

```swift
let logLevel = Logger.Level.detect(from: &env)
```
