### PR TITLE
Allow fully custom CORS check

### DIFF
--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -21,12 +21,17 @@ public final class CORSMiddleware: Middleware {
         /// Uses wildcard to allow any origin.
         case all
         
-        // Uses a whitelist of allowable origins.
+        /// Uses a whitelist of allowable origins.
         case whitelist([String])
 
         /// Uses custom string provided as an associated value.
         case custom(String)
 
+        /// Uses fully custom implementation.
+        ///
+        /// - Returns: Header string to be used in response for allowed origin.
+        case closure((Request) -> String)
+        
         /// Creates the header string depending on the case of self.
         ///
         /// - Parameter request: Request for which the allow origin header should be created.
@@ -43,6 +48,8 @@ public final class CORSMiddleware: Middleware {
                 return origins.contains(origin) ? origin : ""
             case .custom(let string):
                 return string
+            case .closure(let closure):
+                    return closure(req)
             }
         }
     }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
I needed a way to customize what I check before allowing a CORS request, beyond what the existing options allow.
I thought that letting the user be fully in control might be a good idea since it covers every single use case.
So I added an option that can run a custom function receiving the `Request` and returning the value to be set for `access-control-allow-origin`

I have no idea if this is the best way of doing it, it Works For Me™

