### PR TITLE
`Environment` cleanups

### DIFF
--- a/Sources/Vapor/Environment/Environment+Process.swift
+++ b/Sources/Vapor/Environment/Environment+Process.swift
@@ -1,5 +1,4 @@
 extension Environment {    
-
     /// The process information of an environment. Wraps `ProcessInto.processInfo`.
     @dynamicMemberLookup public struct Process {
 

--- a/Sources/Vapor/Environment/Environment+Process.swift
+++ b/Sources/Vapor/Environment/Environment+Process.swift
@@ -1,6 +1,8 @@
 extension Environment {    
+
     /// The process information of an environment. Wraps `ProcessInto.processInfo`.
     @dynamicMemberLookup public struct Process {
+
         /// The process information of the environment.
         private let _info: ProcessInfo
         
@@ -19,6 +21,7 @@ extension Environment {
             get {
                 return self._info.environment[member].flatMap { T($0) }
             }
+
             nonmutating set (value) {
                 if let raw = value?.description {
                     setenv(member, raw, 1)
@@ -36,6 +39,7 @@ extension Environment {
             get {
                 return self._info.environment[member]
             }
+
             nonmutating set (value) {
                 if let raw = value {
                     setenv(member, raw, 1)
@@ -45,4 +49,5 @@ extension Environment {
             }
         }
     }
+
 }

--- a/Sources/Vapor/Environment/Environment+Process.swift
+++ b/Sources/Vapor/Environment/Environment+Process.swift
@@ -17,11 +17,7 @@ extension Environment {
         ///     Environment.process.DATABASE_PORT // 3306
         public subscript<T>(dynamicMember member: String) -> T? where T: LosslessStringConvertible {
             get {
-                guard let raw = self._info.environment[member], let value = T(raw) else {
-                    return nil
-                }
-                
-                return value
+                return self._info.environment[member].flatMap { T($0) }
             }
             nonmutating set (value) {
                 if let raw = value?.description {
@@ -38,11 +34,7 @@ extension Environment {
         ///     Environment.process.DATABASE_USER // "root"
         public subscript(dynamicMember member: String) -> String? {
             get {
-                guard let value = self._info.environment[member] else {
-                    return nil
-                }
-                
-                return value
+                return self._info.environment[member]
             }
             nonmutating set (value) {
                 if let raw = value {

--- a/Sources/Vapor/Environment/Environment+Process.swift
+++ b/Sources/Vapor/Environment/Environment+Process.swift
@@ -1,7 +1,6 @@
 extension Environment {    
     /// The process information of an environment. Wraps `ProcessInto.processInfo`.
     @dynamicMemberLookup public struct Process {
-
         /// The process information of the environment.
         private let _info: ProcessInfo
         
@@ -48,5 +47,4 @@ extension Environment {
             }
         }
     }
-
 }

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -52,7 +52,7 @@ extension Environment {
             }
             .map { buffer -> String in
                 return buffer
-                       .getString(at: buffer.readerIndex, length: buffer.readableBytes)!
+                    .getString(at: buffer.readerIndex, length: buffer.readableBytes)!
                        .trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .recover { _ -> String? in

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -53,7 +53,7 @@ extension Environment {
             .map { buffer -> String in
                 return buffer
                     .getString(at: buffer.readerIndex, length: buffer.readableBytes)!
-                       .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .recover { _ -> String? in
                 nil

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -39,5 +39,5 @@ extension Environment {
                 nil
             })
     }
-}
 
+}

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -1,43 +1,63 @@
 extension Environment {
-    /// Reads a file's content for a secret. The secret key represents the name of the environment variable that holds the path for the file containing the secret
+    
+    /// Reads a file's content for a secret. The secret key is the name of the environment variable that is expected to
+    /// specify the path of the file containing the secret.
+    ///
     /// - Parameters:
-    ///     - key: Environment name for the path to the file containing the secret
-    ///     - fileIO: FileIO handler provided by NIO
-    ///     - on: EventLoop to operate on while opening the file
-    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    ///   - key: The environment variable name
+    ///   - fileIO: `NonBlockingFileIO` handler provided by NIO
+    ///   - eventLoop: `EventLoop` for NIO to use for working with the file
+    ///
+    /// Example usage:
+    ///
+    /// ````
+    /// func configure(_ app: Application) {
+    ///     // ...
+    ///
+    ///     let databasePassword = try Environment.secret(
+    ///         key: "DATABASE_PASSWORD_FILE",
+    ///         fileIO: app.fileio,
+    ///         on: app.eventLoopGroup.next()
+    ///     ).wait()
+    ///
+    /// ````
+    ///
+    /// - Important: Do _not_ use `.wait()` if loading a secret at any time after the app has booted, such as while
+    ///   handling a `Request`. Chain the result as you would any other future instead.
     public static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
-        guard let filePath = self.get(key) else { return eventLoop.future(nil) }
+        guard let filePath = self.get(key) else {
+            return eventLoop.future(nil)
+        }
         return self.secret(path: filePath, fileIO: fileIO, on: eventLoop)
     }
 
 
-    /// Reads a file's content for a secret. The path is a file path to the file that contains the secret in plain text
+    /// Load the content of a file at a given path as a secret.
+    ///
     /// - Parameters:
-    ///     - path: Path to the file that contains the secret
-    ///     - fileIO: FileIO handler provided by NIO
-    ///     - on: EventLoop to operate on while opening the file
-    /// - Throws: Error.environmentVariableNotFound if the environment variable with the key name does not exist
+    ///   - path: Path to the file containing the secret
+    ///   - fileIO: `NonBlockingFileIO` handler provided by NIO
+    ///   - eventLoop: `EventLoop` for NIO to use for working with the file
+    ///
+    /// - Returns:
+    ///   - On success, a succeeded future with the loaded content of the file.
+    ///   - On any kind of error, a succeeded future with a value of `nil`. It is not currently possible to get error details.
     public static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
         return fileIO
             .openFile(path: path, eventLoop: eventLoop)
-            .flatMap({ (arg) -> EventLoopFuture<ByteBuffer> in
+            .flatMap { handle, region in
                 return fileIO
-                    .read(fileRegion: arg.1, allocator: .init(), eventLoop: eventLoop)
-                    .flatMapThrowing({ (buffer) -> ByteBuffer in
-                        try arg.0.close()
-                        return buffer
-                    })
-            })
-            .map({ (buffer) -> (String) in
-                var buffer = buffer
-                return buffer.readString(length: buffer.writerIndex) ?? ""
-            })
-            .map({ (secret) -> (String) in
-                secret.trimmingCharacters(in: .whitespacesAndNewlines)
-            })
-            .recover ({ (_) -> String? in
+                    .read(fileRegion: region, allocator: .init(), eventLoop: eventLoop)
+                    .always { _ in try? handle.close() }
+            }
+            .map { buffer -> String in
+                return buffer
+                       .getString(at: buffer.readerIndex, length: buffer.readableBytes)!
+                       .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .recover { _ -> String? in
                 nil
-            })
+            }
     }
 
 }

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -1,5 +1,4 @@
 extension Environment {
-    
     /// Reads a file's content for a secret. The secret key is the name of the environment variable that is expected to
     /// specify the path of the file containing the secret.
     ///
@@ -59,5 +58,4 @@ extension Environment {
                 nil
             }
     }
-
 }

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -60,9 +60,6 @@ public struct Environment: Equatable {
         // followed by a value argument. Since this is mainly just to get around Xcode's habit of
         // passing a bunch of these when no other arguments are specified in a test scheme, we ignore
         // any that don't match the Apple patterns and assume the app knows what it's doing.
-        //
-        // Note that we also perform this behavior more forcefully when the `.testing` environment is
-        // constructed, even if it means
         while (commandInput.arguments.first?.prefix(6) == "-Apple" || commandInput.arguments.first?.prefix(3) == "-NS"),
               commandInput.arguments.count > 1 {
             commandInput.arguments.removeFirst(2)

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -12,6 +12,9 @@
 ///     print(Environment.get("DB_PASSWORD"))
 ///
 public struct Environment: Equatable {
+    
+    // MARK: - Detection
+    
     /// Detects the environment from `CommandLine.arguments`. Invokes `detect(from:)`.
     /// - parameters:
     ///     - arguments: Command line arguments to detect environment from.
@@ -44,7 +47,7 @@ public struct Environment: Equatable {
         return env
     }
     
-    // MARK: Presets
+    // MARK: - Presets
 
     /// An environment for deploying your application to consumers.
     public static var production: Environment { .init(name: "production") }
@@ -58,18 +61,11 @@ public struct Environment: Equatable {
     /// Creates a custom environment.
     public static func custom(name: String) -> Environment { .init(name: name) }
 
-    // MARK: Env
+    // MARK: - Env
 
     /// Gets a key from the process environment
     public static func get(_ key: String) -> String? {
         return ProcessInfo.processInfo.environment[key]
-    }
-
-    // MARK: Equatable
-
-    /// See `Equatable`
-    public static func ==(lhs: Environment, rhs: Environment) -> Bool {
-        return lhs.name == rhs.name && lhs.isRelease == rhs.isRelease
     }
 
     /// The current process of the environment.
@@ -77,7 +73,14 @@ public struct Environment: Equatable {
         return Process()
     }
     
-    // MARK: Properties
+    // MARK: - Equatable
+
+    /// See `Equatable`
+    public static func ==(lhs: Environment, rhs: Environment) -> Bool {
+        return lhs.name == rhs.name
+    }
+
+    // MARK: - Properties
 
     /// The environment's unique name.
     public let name: String
@@ -97,7 +100,7 @@ public struct Environment: Equatable {
         set { arguments = newValue.executablePath + newValue.arguments }
     }
     
-    // MARK: Init
+    // MARK: - Init
 
     /// Create a new `Environment`.
     public init(name: String, arguments: [String] = CommandLine.arguments) {

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -41,7 +41,7 @@ public struct Environment: Equatable {
 
         var env: Environment
         switch try EnvironmentSignature(from: &commandInput).environment ??
-               Environment.process.VAPOR_ENV
+            Environment.process.VAPOR_ENV
         {
             case "prod", "production": env = .production
             case "dev", "development", .none: env = .development

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -14,7 +14,6 @@ import ConsoleKit
 ///     print(Environment.get("DB_PASSWORD"))
 ///
 public struct Environment: Equatable {
-    
     // MARK: - Detection
     
     /// Detects the environment from `CommandLine.arguments`. Invokes `detect(from:)`.

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -30,6 +30,7 @@ public struct Environment: Equatable {
             @Option(name: "env", short: "e", help: "Change the application's environment")
             var environment: String?
         }
+
         var env: Environment
         switch try EnvironmentSignature(from: &commandInput).environment ??
                Environment.process.VAPOR_ENV

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -89,6 +89,12 @@ public struct Environment: Equatable {
     ///
     /// This usually means reducing logging, disabling debug information, and sometimes
     /// providing warnings about configuration states that are not suitable for production.
+    ///
+    /// - Warning: This value is determined at compile time by configuration; it is not
+    ///   based on the actual environment name. This can lead to unxpected results, such
+    ///   as `Environment.production.isRelease == false`. This is done intentionally to
+    ///   allow scenarios, such as testing production environment behaviors while retaining
+    ///   availability of debug information.
     public var isRelease: Bool { !_isDebugAssertConfiguration() }
 
     /// The command-line arguments for this `Environment`.

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -67,6 +67,19 @@ public struct Environment: Equatable {
               commandInput.arguments.count > 1 {
             commandInput.arguments.removeFirst(2)
         }
+        #elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        // When tests are invoked directly through SwiftPM using `--filter`, SwiftPM will pass `-XCTest <filter>` to the
+        // runner binary, and also the test bundle path unconditionally. These must be stripped for Vapor to be satisifed
+        // with the validity of the arguments. We detect this case reliably the hard way, by looking for the `xctest`
+        // runner executable and a leading argument with the `.xctest` bundle suffix.
+        if commandInput.executable.hasSuffix("/usr/bin/xctest") {
+            if commandInput.arguments.first?.lowercased() == "-xctest" && commandInput.arguments.count > 1 {
+                commandInput.arguments.removeFirst(2)
+            }
+            if commandInput.arguments.first?.hasSuffix(".xctest") ?? false {
+                commandInput.arguments.removeFirst()
+            }
+        }
         #endif
     }
     

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -22,6 +22,6 @@ extension LoggingSystem {
 }
 
 extension Logger.Level: LosslessStringConvertible {
-    public init?(_ description: String) { self.init(rawValue: description) }
+    public init?(_ description: String) { self.init(rawValue: description.lowercased()) }
     public var description: String { self.rawValue }
 }

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -22,28 +22,6 @@ extension LoggingSystem {
 }
 
 extension Logger.Level: LosslessStringConvertible {
-    public init?(_ description: String) {
-        switch description.lowercased() {
-        case "trace": self = .trace
-        case "debug": self = .debug
-        case "info": self = .info
-        case "notice": self = .notice
-        case "warning": self = .warning
-        case "error": self = .error
-        case "critical": self = .critical
-        default: return nil
-        }
-    }
-
-    public var description: String {
-        switch self {
-        case .trace: return "trace"
-        case .debug: return "debug"
-        case .info: return "info"
-        case .notice: return "notice"
-        case .warning: return "warning"
-        case .error: return "error"
-        case .critical: return "critical"
-        }
-    }
+    public init?(_ description: String) { self.init(rawValue: description) }
+    public var description: String { self.rawValue }
 }


### PR DESCRIPTION
- Clean up `Environment`'s implementation.

- Add the ability to specify the application environment using the environment variable `VAPOR_ENV` (**partial** implementation of #2333). If both `VAPOR_ENV` and `--env` are provided, the latter always takes precedence.

- `Environment` now recognizes and strips the spurious arguments Xcode passes to test runners when a scheme doesn't specify any arguments of its own. It will do this especially specifically for the `testing` environment, which is often explicitly specified to `Application`'s initializers instead of `.detect()` in unit tests. This behavior is only enabled when building in Xcode or with `xcodebuild`. This negates the need to explicitly override the input arguments in the non-production presets, meaning command line arguments no longer occasionally seem to vanish into thin air in certain cases.

- Redo the documentation comments for both versions of `Environment.secret()` and significantly simplify the implementation. **Important**: This is an interim cleanup step pending a complete revamp of the `secret()` API.

**Note**: Pains have been taken not to change the observable behavior of any public APIs and to remain otherwise behaviorally consistent. The addition of `VAPOR_ENV` counts as new public API and thus drives this being a `semver-minor` change, but in all other respects it should have no visible effect.