### PR TITLE
Add case-insensitive routing

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -12,7 +12,10 @@ internal struct DefaultResponder: Responder {
 
     /// Creates a new `ApplicationResponder`
     public init(routes: Routes, middleware: [Middleware] = []) {
-        let router = TrieRouter(CachedRoute.self)
+        let options = routes.caseInsenstive ?
+            Set(arrayLiteral: TrieRouter<CachedRoute>.ConfigurationOption.caseInsensitive) : []
+        let router = TrieRouter(CachedRoute.self, options: options)
+        
         for route in routes.all {
             // Make a copy of the route to cache middleware chaining.
             let cached = CachedRoute(

--- a/Sources/Vapor/Routing/Routes.swift
+++ b/Sources/Vapor/Routing/Routes.swift
@@ -3,6 +3,8 @@ public final class Routes: RoutesBuilder, CustomStringConvertible {
     
     /// Default value used by `HTTPBodyStreamStrategy.collect` when `maxSize` is `nil`.
     public var defaultMaxBodySize: ByteCount
+    /// Default routing behavior of `DefaultResponder` is case-sensitive; configure to `true` prior to
+    /// Application start handle `Constant` `PathComponents` in a case-insensitive manner.
     public var caseInsenstive: Bool
 
     public var description: String {

--- a/Sources/Vapor/Routing/Routes.swift
+++ b/Sources/Vapor/Routing/Routes.swift
@@ -3,6 +3,7 @@ public final class Routes: RoutesBuilder, CustomStringConvertible {
     
     /// Default value used by `HTTPBodyStreamStrategy.collect` when `maxSize` is `nil`.
     public var defaultMaxBodySize: ByteCount
+    public var caseInsenstive: Bool
 
     public var description: String {
         return self.all.description
@@ -11,6 +12,7 @@ public final class Routes: RoutesBuilder, CustomStringConvertible {
     public init() {
         self.all = []
         self.defaultMaxBodySize = "16kb"
+        self.caseInsenstive = false
     }
 
     public func add(_ route: Route) {

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -56,6 +56,25 @@ final class RouteTests: XCTestCase {
             XCTAssertEqual(res.body.string, "foo")
         }
     }
+    
+    func testInsensitiveRoutes() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        app.routes.caseInsenstive = true
+        
+        app.routes.get("foo") { req -> String in
+            return "foo"
+        }
+
+        try app.testable().test(.GET, "/foo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foo")
+        }.test(.GET, "/FOO") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foo")
+        }
+    }
 
     func testAnyResponse() throws {
         let app = Application(.testing)


### PR DESCRIPTION
Allows configuring case-insensitive routing (#2354).

```swift
// Enables case-insensitive routing.
// Defaults to false.
app.routes.caseInsensitive = true
```