### PR TITLE
Refactor request body streaming state handling

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -176,6 +176,36 @@ public func routes(_ app: Application) throws {
         print("in route")
         return .ok
     }
+
+    app.on(.POST, "upload", body: .stream) { req -> EventLoopFuture<HTTPStatus> in
+        return req.application.fileio.openFile(
+            path: "/Users/tanner/Desktop/foo.txt",
+            mode: .write,
+            flags: .allowFileCreation(),
+            eventLoop: req.eventLoop
+        ).flatMap { fileHandle in
+            let promise = req.eventLoop.makePromise(of: HTTPStatus.self)
+            req.body.drain { part in
+                switch part {
+                case .buffer(let buffer):
+                    return req.application.fileio.write(
+                        fileHandle: fileHandle,
+                        buffer: buffer,
+                        eventLoop: req.eventLoop
+                    )
+                case .error(let error):
+                    promise.fail(error)
+                    try! fileHandle.close()
+                    return req.eventLoop.makeSucceededFuture(())
+                case .end:
+                    promise.succeed(.ok)
+                    try! fileHandle.close()
+                    return req.eventLoop.makeSucceededFuture(())
+                }
+            }
+            return promise.futureResult
+        }
+    }
 }
 
 struct TestError: AbortError {

--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -10,6 +10,33 @@ public enum BodyStreamResult {
     case end
 }
 
+extension BodyStreamResult: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .buffer(let buffer):
+            return "buffer(\(buffer.readableBytes) bytes)"
+        case .error(let error):
+            return "error(\(error))"
+        case .end:
+            return "end"
+        }
+    }
+}
+
+extension BodyStreamResult: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .buffer(let buffer):
+            let value = String(decoding: buffer.readableBytesView, as: UTF8.self)
+            return "buffer(\(value))"
+        case .error(let error):
+            return "error(\(error))"
+        case .end:
+            return "end"
+        }
+    }
+}
+
 public protocol BodyStreamWriter {
     var eventLoop: EventLoop { get }
     func write(_ result: BodyStreamResult, promise: EventLoopPromise<Void>?)

--- a/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
@@ -13,18 +13,145 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
         case streamingBody(Request.BodyStream)
     }
 
+    struct BodyStreamState: CustomStringConvertible {
+        struct Result {
+            enum Action {
+                case nothing
+                case write(ByteBuffer)
+                case close(Error?)
+            }
+            let action: Action
+            let callRead: Bool
+        }
+
+        private struct BufferState {
+            var bufferedWrites: CircularBuffer<ByteBuffer>
+            var heldUpRead: Bool
+            var hasClosed: Bool
+
+            mutating func append(_ buffer: ByteBuffer) {
+                self.bufferedWrites.append(buffer)
+            }
+
+            var isEmpty: Bool {
+                return self.bufferedWrites.isEmpty
+            }
+
+            mutating func removeFirst() -> ByteBuffer {
+                return self.bufferedWrites.removeFirst()
+            }
+        }
+
+        private enum State {
+            case idle
+            case writing(BufferState)
+            case error(Error)
+        }
+
+        private var state: State
+
+        var description: String {
+            "\(self.state)"
+        }
+
+        init() {
+            self.state = .idle
+        }
+
+        mutating func write(_ buffer: ByteBuffer) -> Result {
+            switch self.state {
+            case .idle:
+                self.state = .writing(.init(
+                    bufferedWrites: .init(),
+                    heldUpRead: false,
+                    hasClosed: false
+                ))
+                return .init(action: .write(buffer), callRead: false)
+            case .writing(var buffers):
+                buffers.append(buffer)
+                self.state = .writing(buffers)
+                return .init(action: .nothing, callRead: false)
+            case .error:
+                return .init(action: .nothing, callRead: false)
+            }
+        }
+
+        mutating func read() -> Result {
+            switch self.state {
+            case .idle:
+                return .init(action: .nothing, callRead: true)
+            case .writing(var buffers):
+                buffers.heldUpRead = true
+                self.state = .writing(buffers)
+                return .init(action: .nothing, callRead: false)
+            case .error:
+                return .init(action: .nothing, callRead: false)
+            }
+        }
+
+        mutating func close() -> Result {
+            switch self.state {
+            case .idle:
+                return .init(action: .close(nil), callRead: false)
+            case .writing(var buffers):
+                buffers.hasClosed = true
+                self.state = .writing(buffers)
+                return .init(action: .nothing, callRead: false)
+            case .error:
+                return .init(action: .nothing, callRead: false)
+            }
+        }
+
+        mutating func didError(_ error: Error) -> Result {
+            switch self.state {
+            case .idle:
+                self.state = .error(error)
+                return .init(action: .close(error), callRead: false)
+            case .writing:
+                self.state = .error(error)
+                return .init(action: .nothing, callRead: false)
+            case .error:
+                return .init(action: .nothing, callRead: false)
+            }
+        }
+
+        mutating func didWrite() -> Result {
+            switch self.state {
+            case .idle:
+                self.illegalTransition()
+            case .writing(var buffers):
+                if buffers.isEmpty {
+                    self.state = .idle
+                    return .init(
+                        action: buffers.hasClosed ? .close(nil) : .nothing,
+                        callRead: buffers.heldUpRead
+                    )
+                } else {
+                    let first = buffers.removeFirst()
+                    self.state = .writing(buffers)
+                    return .init(action: .write(first), callRead: false)
+                }
+            case .error(let error):
+                return .init(action: .close(error), callRead: false)
+            }
+        }
+
+        private func illegalTransition(_ function: String = #function) -> Never {
+            preconditionFailure("illegal transition \(function) in \(self)")
+        }
+    }
+
     var requestState: RequestState
+    var bodyStreamState: BodyStreamState
+
     private let logger: Logger
-    var pendingWriteCount: Int
-    var hasReadPending: Bool
     var application: Application
     
     init(application: Application) {
         self.application = application
         self.requestState = .ready
         self.logger = Logger(label: "codes.vapor.server")
-        self.pendingWriteCount = 0
-        self.hasReadPending = false
+        self.bodyStreamState = .init()
     }
     
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -63,11 +190,23 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
                 let stream = Request.BodyStream(on: context.eventLoop)
                 request.bodyStorage = .stream(stream)
                 context.fireChannelRead(self.wrapInboundOut(request))
-                self.write(.buffer(previousBuffer), to: stream, context: context)
-                self.write(.buffer(buffer), to: stream, context: context)
+                self.handleBodyStreamStateResult(
+                    context: context,
+                    self.bodyStreamState.write(previousBuffer),
+                    stream: stream
+                )
+                self.handleBodyStreamStateResult(
+                    context: context,
+                    self.bodyStreamState.write(buffer),
+                    stream: stream
+                )
                 self.requestState = .streamingBody(stream)
             case .streamingBody(let stream):
-                self.write(.buffer(buffer), to: stream, context: context)
+                self.handleBodyStreamStateResult(
+                    context: context,
+                    self.bodyStreamState.write(buffer),
+                    stream: stream
+                )
             }
         case .end(let tailHeaders):
             assert(tailHeaders == nil, "Tail headers are not supported.")
@@ -79,43 +218,76 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
                 request.bodyStorage = .collected(buffer)
                 context.fireChannelRead(self.wrapInboundOut(request))
             case .streamingBody(let stream):
-                self.write(.end, to: stream, context: context)
+                self.handleBodyStreamStateResult(
+                    context: context,
+                    self.bodyStreamState.close(),
+                    stream: stream
+                )
             }
             self.requestState = .ready
         }
     }
 
     func read(context: ChannelHandlerContext) {
-        if self.pendingWriteCount <= 0 {
+        switch self.requestState {
+        case .streamingBody(let stream):
+            self.handleBodyStreamStateResult(
+                context: context,
+                self.bodyStreamState.read(),
+                stream: stream
+            )
+        default:
             context.read()
-        } else {
-            self.hasReadPending = true
         }
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         switch self.requestState {
         case .streamingBody(let stream):
-            stream.write(.error(error), promise: nil)
+            self.handleBodyStreamStateResult(
+                context: context,
+                self.bodyStreamState.didError(error),
+                stream: stream
+            )
         default:
             break
         }
         context.fireErrorCaught(error)
     }
 
-    func write(_ part: BodyStreamResult, to stream: Request.BodyStream, context: ChannelHandlerContext) {
-        self.pendingWriteCount += 1
-        stream.write(part).whenComplete { result in
-            self.pendingWriteCount -= 1
-            if self.hasReadPending {
-                self.hasReadPending = false
-                self.read(context: context)
+    func handleBodyStreamStateResult(
+        context: ChannelHandlerContext,
+        _ result: BodyStreamState.Result,
+        stream: Request.BodyStream
+    ) {
+        switch result.action {
+        case .nothing: break
+        case .write(let buffer):
+            stream.write(.buffer(buffer)).whenComplete { writeResult in
+                switch writeResult {
+                case .failure(let error):
+                    self.handleBodyStreamStateResult(
+                        context: context,
+                        self.bodyStreamState.didError(error),
+                        stream: stream
+                    )
+                case .success:
+                    self.handleBodyStreamStateResult(
+                        context: context,
+                        self.bodyStreamState.didWrite(),
+                        stream: stream
+                    )
+                }
             }
-            switch result {
-            case .failure(let error):
-                self.logger.error("Could not write body: \(error)")
-            case .success: break
+        case .close(let maybeError):
+            if let error = maybeError {
+                stream.write(.error(error), promise: nil)
+            } else {
+                stream.write(.end, promise: nil)
             }
+        }
+        if result.callRead {
+            context.read()
         }
     }
 }

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -28,8 +28,14 @@ extension Request {
             case .buffer: break
             }
             
-            if let handler = handler {
+            if let handler = self.handler {
                 handler(chunk, promise)
+                // remove reference to handler
+                switch chunk {
+                case .end, .error:
+                    self.handler = nil
+                default: break
+                }
             } else {
                 self.buffer.append((chunk, promise))
             }
@@ -56,20 +62,6 @@ extension Request {
 
         deinit {
             assert(self.isClosed, "Request.BodyStream deinitialized before closing.")
-        }
-    }
-}
-
-extension BodyStreamResult: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .buffer(let buffer):
-            let value = String(decoding: buffer.readableBytesView, as: UTF8.self)
-            return "buffer(\(value))"
-        case .error(let error):
-            return "error(\(error))"
-        case .end:
-            return "end"
         }
     }
 }

--- a/Tests/VaporTests/BodyStreamStateTests.swift
+++ b/Tests/VaporTests/BodyStreamStateTests.swift
@@ -1,0 +1,137 @@
+@testable import Vapor
+import XCTest
+
+final class BodyStreamStateTests: XCTestCase {
+    func testSynchronous() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString("Hello, world!")
+
+        var state = HTTPBodyStreamState()
+        XCTAssertEqual(
+            state.didReadBytes(buffer),
+            .init(action: .write(buffer), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didReceiveReadRequest(),
+            .init(action: .nothing, callRead: true)
+        )
+        XCTAssertEqual(
+            state.didReadBytes(buffer),
+            .init(action: .write(buffer), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didEnd(),
+            .init(action: .close(nil), callRead: false)
+        )
+    }
+
+    func testReadDuringWrite() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString("Hello, world!")
+
+        var state = HTTPBodyStreamState()
+        XCTAssertEqual(
+            state.didReadBytes(buffer),
+            .init(action: .write(buffer), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didReceiveReadRequest(),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .nothing, callRead: true)
+        )
+        XCTAssertEqual(
+            state.didEnd(),
+            .init(action: .close(nil), callRead: false)
+        )
+    }
+
+    func testErrorDuringWrite() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString("Hello, world!")
+        struct Test: Error { }
+
+        var state = HTTPBodyStreamState()
+        XCTAssertEqual(
+            state.didReadBytes(buffer),
+            .init(action: .write(buffer), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didReceiveReadRequest(),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didError(Test()),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didReadBytes(buffer),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .close(Test()), callRead: false)
+        )
+    }
+
+    func testBufferedWrites() throws {
+        var a = ByteBufferAllocator().buffer(capacity: 0)
+        a.writeString("a")
+        var b = ByteBufferAllocator().buffer(capacity: 0)
+        b.writeString("b")
+        struct Test: Error { }
+
+        var state = HTTPBodyStreamState()
+        XCTAssertEqual(
+            state.didReadBytes(a),
+            .init(action: .write(a), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didReadBytes(b),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didEnd(),
+            .init(action: .nothing, callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .write(b), callRead: false)
+        )
+        XCTAssertEqual(
+            state.didWrite(),
+            .init(action: .close(nil), callRead: false)
+        )
+    }
+}
+
+extension HTTPBodyStreamState.Result: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.action == rhs.action && lhs.callRead == rhs.callRead
+    }
+}
+
+extension HTTPBodyStreamState.Result.Action: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.nothing, .nothing):
+            return true
+        case (.write(let a), .write(let b)):
+            return Data(a.readableBytesView) == Data(b.readableBytesView)
+        case (.close, .close):
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
- Implements new state machine for handling streaming request bodies (#2357). 

> This new state machine ensures that calls to `req.body.drain` will only ever happen after the previously returned future has completed. This makes it easier to correctly implement streaming file writes. Addresses https://forums.swift.org/t/how-to-use-nonblockingfileio-for-repeated-writes/36206. 

- Request bodies are now automatically drained after sending a response (#2357).

> This change ensures that streaming requests will be read completely even if a route ignores their body.

- Adds a streaming file upload example to the `Development` executable (#2357).

- Improves `BodyStreamResult`'s normal and debug descriptions (#2357). 

- Fixed a reference cycle if `Request` was captured strongly within the `body.drain` closure (#2357). 