### PR TITLE
Fixing Vapor build errors on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "vapor",
     platforms: [
-       .macOS(.v10_15)
+        .macOS(.v10_15),
+        .iOS(.v13)
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),
@@ -79,7 +80,9 @@ let package = Package(
             .product(name: "NIOHTTP2", package: "swift-nio-http2"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
+//            #if !canImport(CryptoKit)
             .product(name: "Crypto", package: "swift-crypto"),
+//            #endif
             .product(name: "RoutingKit", package: "routing-kit"),
             .product(name: "WebSocketKit", package: "websocket-kit"),
         ]),

--- a/Package.swift
+++ b/Package.swift
@@ -80,9 +80,7 @@ let package = Package(
             .product(name: "NIOHTTP2", package: "swift-nio-http2"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
-//            #if !canImport(CryptoKit)
             .product(name: "Crypto", package: "swift-crypto"),
-//            #endif
             .product(name: "RoutingKit", package: "routing-kit"),
             .product(name: "WebSocketKit", package: "websocket-kit"),
         ]),

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -3,7 +3,11 @@
 @_exported import class AsyncHTTPClient.HTTPClient
 @_exported import struct AsyncHTTPClient.HTTPClientError
 
+#if canImport(CryptoKit)
+@_exported import CryptoKit
+#else
 @_exported import Crypto
+#endif
 @_exported import RoutingKit
 @_exported import ConsoleKit
 @_exported import Foundation

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -36,7 +36,7 @@ public final class HTTPServer: Server {
         public var responseCompression: CompressionConfiguration
         
         /// Only  for macOS. If true the service is reachable over all interfaces.
-        public var runOnAllInterfaces: Bool
+        public var runOnAllInterfaces: Bool = false 
 
         /// Supported HTTP compression options.
         public struct CompressionConfiguration {
@@ -230,7 +230,7 @@ private final class HTTPServerConnection {
             // Specify backlog and enable SO_REUSEADDR for the server itself
             .serverChannelOption(ChannelOptions.backlog, value: Int32(configuration.backlog))
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: configuration.reuseAddress ? SocketOptionValue(1) : SocketOptionValue(0))
-            // macOS specific options to make socket available on all interfaces 
+            // macOS specific options to make socket available on all interfaces
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), 0x1104), value: configuration.runOnAllInterfaces ? SocketOptionValue(1) : SocketOptionValue(0))
             // Set handlers that are applied to the Server's channel
             .serverChannelInitializer { channel in

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -34,6 +34,9 @@ public final class HTTPServer: Server {
 
         /// Response compression configuration.
         public var responseCompression: CompressionConfiguration
+        
+        /// Only  for macOS. If true the service is reachable over all interfaces.
+        public var runOnAllInterfaces: Bool
 
         /// Supported HTTP compression options.
         public struct CompressionConfiguration {
@@ -227,7 +230,8 @@ private final class HTTPServerConnection {
             // Specify backlog and enable SO_REUSEADDR for the server itself
             .serverChannelOption(ChannelOptions.backlog, value: Int32(configuration.backlog))
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: configuration.reuseAddress ? SocketOptionValue(1) : SocketOptionValue(0))
-            
+            // macOS specific options to make socket available on all interfaces 
+            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), 0x1104), value: configuration.runOnAllInterfaces ? SocketOptionValue(1) : SocketOptionValue(0))
             // Set handlers that are applied to the Server's channel
             .serverChannelInitializer { channel in
                 channel.pipeline.addHandler(quiesce.makeServerChannelHandler(channel: channel))


### PR DESCRIPTION

Using Swift-Crypto leads to a build error on iOS. CryptoKit uses the exact same API and it is therefore possible to link against CryptoKit rather than Swift-Crypto. 

To fix the build error I performed the following steps: 
1. Added iOS as a supported platform (starting from iOS 13, because of CryptoKit) 
2. In `Exports.swift` I used `#if canImport(CryptoKit)` to check if CryptoKit or Crypto should be exported 

This should not affect the build on Linux or macOS.

## Why is it necessary to support iOS ? 
In general iOS has been supported already, it was just a small fix that needed to be done to use Vapor on iOS like on macOS. 
There can be several reasons why an https Server is necessary on iOS. Starting from file transfer to peer-to-peer communication or hosting a web server on an iPad in house. 
We use it for peer-to-peer communication. 

I hope this fix helps to make Vapor more versatile. 

Kind regards
Alexander Heinrich 
