### PR TITLE
Fix root route using a single slash.

### DIFF
--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -34,7 +34,9 @@ public final class RoutesCommand: Command {
                 pathText += "/".consoleText(.info)
                 switch path {
                 case .constant(let string):
-                    pathText += string.consoleText()
+                    if string != "/" {
+                        pathText += string.consoleText()
+                    }
                 case .parameter(let name):
                     pathText += ":".consoleText(.info)
                     pathText += name.consoleText()

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -19,11 +19,11 @@ internal struct DefaultResponder: Responder {
                 route: route,
                 responder: middleware.makeResponder(chainingTo: route.responder)
             )
-            // remove any empty path components
+            // remove any empty or single slash path components
             let path = route.path.filter { component in
                 switch component {
                 case .constant(let string):
-                    return string != ""
+                    return string != "" && string != "/"
                 default:
                     return true
                 }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -42,7 +42,7 @@ final class RouteTests: XCTestCase {
         defer { app.shutdown() }
 
         app.routes.get("") { req -> String in
-                return "root"
+            return "root"
         }
         app.routes.get("foo") { req -> String in
             return "foo"
@@ -54,6 +54,34 @@ final class RouteTests: XCTestCase {
         }.test(.GET, "/foo") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "foo")
+        }
+    }
+
+    func testRootGetExplicit() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.get("/") { req -> String in
+            return "root"
+        }
+
+        try app.testable().test(.GET, "/") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "root")
+        }
+    }
+
+    func testRootGetBlank() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.get { req -> String in
+            return "root"
+        }
+
+        try app.testable().test(.GET, "/") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "root")
         }
     }
 


### PR DESCRIPTION
This fixes defining the root route using a single slash:

```swift
app.routes.get("/") { req in
    return "root"
}
```