### PR TITLE
Support a closure for instantiating RedirectMiddleware

### DIFF
--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -10,7 +10,7 @@ extension Authenticatable {
     /// Basic middleware to redirect unauthenticated requests to the supplied path
     ///
     /// - parameters:
-    ///    - pathClosure: The closure that returns the redirect path based on the given URI path
+    ///    - pathClosure: The closure that returns the redirect path based on the given `Request` object
     public static func redirectMiddleware(_ pathClosure: @escaping (Request) -> String) -> Middleware {
         return RedirectMiddleware<Self>(Self.self, pathClosure: pathClosure)
     }

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -4,15 +4,14 @@ extension Authenticatable {
     /// - parameters:
     ///    - path: The path to redirect to if the request is not authenticated
     public static func redirectMiddleware(path: String) -> Middleware {
-        return RedirectMiddleware<Self>(Self.self, path: path)
+        return RedirectMiddleware<Self>(Self.self, pathClosure: { _ in return path })
     }
     
     /// Basic middleware to redirect unauthenticated requests to the supplied path
     ///
     /// - parameters:
     ///    - pathClosure: The closure that returns the redirect path based on the given URI path
-    ///    - input: The original `Request` object of the request
-    public static func redirectMiddleware(pathClosure: @escaping (_ input: Request) -> String) -> Middleware {
+    public static func redirectMiddleware(_ pathClosure: @escaping (Request) -> String) -> Middleware {
         return RedirectMiddleware<Self>(Self.self, pathClosure: pathClosure)
     }
 }
@@ -21,15 +20,9 @@ extension Authenticatable {
 private final class RedirectMiddleware<A>: Middleware
     where A: Authenticatable
 {
-    let pathClosure: PathClosure
+    let pathClosure: (Request) -> String
     
-    typealias PathClosure = (Request) -> String
-
-    init(_ authenticatableType: A.Type = A.self, path: String) {
-        self.pathClosure = { _ in return path }
-    }
-    
-    init(_ authenticatableType: A.Type = A.self, pathClosure: @escaping PathClosure) {
+    init(_ authenticatableType: A.Type = A.self, pathClosure: @escaping (Request) -> String) {
         self.pathClosure = pathClosure
     }
 
@@ -39,7 +32,7 @@ private final class RedirectMiddleware<A>: Middleware
             return next.respond(to: req)
         }
         
-        let redirectPath = pathClosure(req)
+        let redirectPath = self.pathClosure(req)
         
         let redirect = req.redirect(to: redirectPath)
         return req.eventLoop.makeSucceededFuture(redirect)

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -11,8 +11,8 @@ extension Authenticatable {
     ///
     /// - parameters:
     ///    - pathClosure: The closure that returns the redirect path based on the given URI path
-    ///    - input: The original request path
-    public static func redirectMiddleware(pathClosure: @escaping (_ input: String) -> String) -> Middleware {
+    ///    - input: The original `Request` object of the request
+    public static func redirectMiddleware(pathClosure: @escaping (_ input: Request) -> String) -> Middleware {
         return RedirectMiddleware<Self>(Self.self, pathClosure: pathClosure)
     }
 }
@@ -23,7 +23,7 @@ private final class RedirectMiddleware<A>: Middleware
 {
     let pathClosure: PathClosure
     
-    typealias PathClosure = (String) -> String
+    typealias PathClosure = (Request) -> String
 
     init(_ authenticatableType: A.Type = A.self, path: String) {
         self.pathClosure = { _ in return path }
@@ -39,7 +39,7 @@ private final class RedirectMiddleware<A>: Middleware
             return next.respond(to: req)
         }
         
-        let redirectPath = pathClosure(req.url.path)
+        let redirectPath = pathClosure(req)
         
         let redirect = req.redirect(to: redirectPath)
         return req.eventLoop.makeSucceededFuture(redirect)


### PR DESCRIPTION
`RedirectMiddleware` now supports a closure with a `Request` object where you can setup a custom redirect based on the original request. (#2364, fixes #2363)

```swift
Authenticatable.redirectMiddleware(makePath: { req in
    "/login?orig=\(req.url.path)"
})
```