### PR TITLE
New works-for-everything CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,13 @@ name: Test Matrix
 
 on:
   pull_request:
-  push: { branches: [ master ] }
+  push:
+    branches:
+    - master
     
 jobs:
 
-  All-tests-linux:
+  Linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,8 +24,10 @@ jobs:
           - swiftlang/swift:nightly-master-bionic
           - swiftlang/swift:nightly-master-focal
         include:
-          - { image: 'swiftlang/swift:nightly-master-centos8', depscmd: 'dnf install -y zlib-devel' }
-          - { image: 'swiftlang/swift:nightly-master-amazonlinux2', depscmd: 'yum install -y zlib-devel' }
+          - image: swiftlang/swift:nightly-master-centos8
+            depscmd: dnf install -y zlib-devel
+          - image: swiftlang/swift:nightly-master-amazonlinux2
+            depscmd: yum install -y zlib-devel
     container: ${{ matrix.image }}
     steps:
       - name: Install dependencies if needed
@@ -33,7 +37,7 @@ jobs:
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
 
-  All-tests-macos:
+  macOS:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,25 +1,45 @@
-name: test
+name: Test Matrix
+
 on:
-- pull_request
+  pull_request:
+  push: { branches: [ master ] }
+    
 jobs:
-  vapor_macos:
+
+  All-tests-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - swift:5.2-xenial
+          - swift:5.2-bionic
+          - swiftlang/swift:nightly-5.2-xenial
+          - swiftlang/swift:nightly-5.2-bionic
+          - swiftlang/swift:nightly-5.3-xenial
+          - swiftlang/swift:nightly-5.3-bionic
+          - swiftlang/swift:nightly-master-xenial
+          - swiftlang/swift:nightly-master-bionic
+          - swiftlang/swift:nightly-master-focal
+        include:
+          - { image: 'swiftlang/swift:nightly-master-centos8', depscmd: 'dnf install -y zlib-devel' }
+          - { image: 'swiftlang/swift:nightly-master-amazonlinux2', depscmd: 'yum install -y zlib-devel' }
+    container: ${{ matrix.image }}
+    steps:
+      - name: Install dependencies if needed
+        run: ${{ matrix.depscmd }}
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread
+
+  All-tests-macos:
     runs-on: macos-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_11.4.1.app/Contents/Developer
     steps:
-    - uses: actions/checkout@v2
-    - run: xcrun swift test --enable-test-discovery --sanitize=thread
-  vapor_xenial:
-    container: 
-      image: vapor/swift:5.2-xenial
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: swift test --enable-test-discovery --sanitize=thread
-  vapor_bionic:
-    container: 
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: swift test --enable-test-discovery --sanitize=thread
+      - name: Select latest available Xcode
+        uses: maxim-lobanov/setup-xcode@1.0
+        with: { 'xcode-version': 'latest' }
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread


### PR DESCRIPTION
This version of the test workflow is designed to be pasted _**unchanged**_ into any repo whose tests don't have additional dependencies (such as `fluent-kit`) _and_ don't need to separately test compatibility with Vapor (such as `console-kit`).

Carries these improvements over the existing CI that was in use for this repo:

- Runs on pushes to master as well as PRs (in case of changes not made by PR, or cases where the PR's checks weren't allowed to finish)
- Full coverage of all available Swift runner images for Linux (the new 5.2 ones aren't available yet so aren't listed)
- Uses latest Xcode without hardcoding on macOS
- Pretty names for each test step ("Checking out code" instead of "actions/checkout@v2" etc.)
- Pretty name for the workflow itself ("Test Matrix" instead of "test")

Affects CI only, no semver label attached.

Hopefully there's a way to do two important things that would make this much nicer (above and beyond the improvements already given):

1. If we could get GitHub to read an entire workflow from an external repository ("actions" don't suffice for this), it would be very nice to be able to have just the needed three versions of this workflow in a `vapor-ci` repo that would apply to every other repo at once so we wouldn't have to keep updating them one at a time as more innovations are added.

2. In the same vein, it would be nice if the list of Swift runner images wasn't static, so that the addition of new runner images also didn't necessitate rolling out updates across all the repos.

It's not clear that GitHub's workflows are capable of either of these levels of abstraction - in fact there are strong suggestions that it not only isn't, but doesn't even want to be. That's never stopped me before, of course, but there's also a limit to the time that should be spent on such things. If anyone has suggestions for how to make these happen, please share!