### PR TITLE
Fix `routes` command symbol usage

### DIFF
--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -27,14 +27,16 @@ public final class RoutesCommand: Command {
         let includeDescription = !routes.all.filter { $0.userInfo["description"] != nil }.isEmpty
         let pathSeparator = "/".consoleText()
         context.console.outputASCIITable(routes.all.map { route -> [ConsoleText] in
-            let pathText = pathSeparator + route.path.map {
-                switch $0 {
-                case .constant:
-                    return $0.description.consoleText()
-                default:
-                    return $0.description.consoleText(.info)
+            let pathText = route.path.isEmpty ? pathSeparator : route.path.map {
+                    switch $0 {
+                    case .constant:
+                        return $0.description.consoleText()
+                    default:
+                        return $0.description.consoleText(.info)
+                    }
                 }
-            }.joined(separator: pathSeparator)
+                .map { pathSeparator + $0 }
+                .reduce("".consoleText(), +)
             var column = [route.method.string.consoleText(), pathText]
             if includeDescription {
                 let desc = route.userInfo["description"]
@@ -44,17 +46,6 @@ public final class RoutesCommand: Command {
             }
             return column
         })
-    }
-}
-
-extension Collection where Element == ConsoleText {
-    func joined(separator: ConsoleText) -> ConsoleText {
-        guard let result: ConsoleText = self.first else {
-            return ""
-        }
-        return self.dropFirst().reduce(into: result) {
-            $0 += separator + $1
-        }
     }
 }
 

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -27,17 +27,15 @@ public final class RoutesCommand: Command {
         let includeDescription = !routes.all.filter { $0.userInfo["description"] != nil }.isEmpty
         let pathSeparator = "/".consoleText()
         context.console.outputASCIITable(routes.all.map { route -> [ConsoleText] in
-            let pathText = route.path.isEmpty ? pathSeparator : route.path.map {
-                    switch $0 {
-                    case .constant:
-                        return $0.description.consoleText()
-                    default:
-                        return $0.description.consoleText(.info)
-                    }
-                }
-                .map { pathSeparator + $0 }
-                .reduce("".consoleText(), +)
-            var column = [route.method.string.consoleText(), pathText]
+            var column = [route.method.string.consoleText()]
+            if route.path.isEmpty {
+                column.append(pathSeparator)
+            } else {
+                column.append(route.path
+                    .map { pathSeparator + $0.consoleText() }
+                    .reduce("".consoleText(), +)
+                )
+            }
             if includeDescription {
                 let desc = route.userInfo["description"]
                     .flatMap { $0 as? String }
@@ -46,6 +44,17 @@ public final class RoutesCommand: Command {
             }
             return column
         })
+    }
+}
+
+extension PathComponent {
+    func consoleText() -> ConsoleText {
+        switch self {
+        case .constant:
+            return description.consoleText()
+        default:
+            return description.consoleText(.info)
+        }
     }
 }
 

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -10,7 +10,7 @@
 /// A colon preceding a path component indicates a variable parameter. A colon with no text following
 /// is a parameter whose result will be discarded.
 ///
-/// An asterisk indicates a catch-all. Any path components after a catch-all will be discarded and ignored.
+/// The path will be displayed with the same syntax that is used to register a route.
 public final class RoutesCommand: Command {
     public struct Signature: CommandSignature {
         public init() { }
@@ -25,25 +25,16 @@ public final class RoutesCommand: Command {
     public func run(using context: CommandContext, signature: Signature) throws {
         let routes = context.application.routes
         let includeDescription = !routes.all.filter { $0.userInfo["description"] != nil }.isEmpty
+        let pathSeparator = "/".consoleText()
         context.console.outputASCIITable(routes.all.map { route -> [ConsoleText] in
-            var pathText: ConsoleText = ""
-            if route.path.isEmpty {
-                pathText += "/".consoleText(.info)
-            }
-            for path in route.path {
-                pathText += "/".consoleText(.info)
-                switch path {
-                case .constant(let string):
-                    pathText += string.consoleText()
-                case .parameter(let name):
-                    pathText += ":".consoleText(.info)
-                    pathText += name.consoleText()
-                case .anything:
-                    pathText += ":".consoleText(.info)
-                case .catchall:
-                    pathText += "*".consoleText(.info)
+            let pathText = pathSeparator + route.path.map {
+                switch $0 {
+                case .constant:
+                    return $0.description.consoleText()
+                default:
+                    return $0.description.consoleText(.info)
                 }
-            }
+            }.joined(separator: pathSeparator)
             var column = [route.method.string.consoleText(), pathText]
             if includeDescription {
                 let desc = route.userInfo["description"]
@@ -53,6 +44,17 @@ public final class RoutesCommand: Command {
             }
             return column
         })
+    }
+}
+
+extension Collection where Element == ConsoleText {
+    func joined(separator: ConsoleText) -> ConsoleText {
+        guard let result: ConsoleText = self.first else {
+            return ""
+        }
+        return self.dropFirst().reduce(into: result) {
+            $0 += separator + $1
+        }
     }
 }
 


### PR DESCRIPTION
Update `routes` command to keep consistency with symbols used by RoutingKit like `*`, `:`, etc (#2366).