### PR TITLE
Add storage accessors that can set value

### DIFF
--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -36,10 +36,10 @@ public struct Storage {
 
     public subscript<Key>(
         _ key: Key.Type,
-        orSetDefault default: @autoclosure () -> Key.Value
+        orSetDefault fallback: @autoclosure () -> Key.Value
     ) -> Key.Value where Key: StorageKey {
         mutating get {
-            self.get(Key.self, orSetDefault: `default`())
+            self.get(Key.self, orSetDefault: fallback())
         }
     }
 
@@ -58,10 +58,10 @@ public struct Storage {
 
     public mutating func get<Key>(
         _ key: Key.Type, 
-        orSetDefault default: @autoclosure () -> Key.Value
+        orSetDefault fallback: @autoclosure () -> Key.Value
     ) -> Key.Value where Key: StorageKey {
         guard let value = self.get(key) else {
-            let value = `default`()
+            let value = fallback()
             self.set(key, to: value)
             return value
         }

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -34,6 +34,15 @@ public struct Storage {
         }
     }
 
+    public subscript<Key>(
+        _ key: Key.Type,
+        orSetDefault default: @autoclosure () -> Key.Value
+    ) -> Key.Value where Key: StorageKey {
+        mutating get {
+            self.get(Key.self, orSetDefault: default)
+        }
+    }
+
     public func contains<Key>(_ key: Key.Type) -> Bool {
         self.storage.keys.contains(ObjectIdentifier(Key.self))
     }
@@ -45,6 +54,18 @@ public struct Storage {
             return nil
         }
         return value.value
+    }
+
+    public mutating func get<Key>(
+        _ key: Key.Type, 
+        orSetDefault default: @autoclosure () -> Key.Value
+    ) -> Key.Value where Key: StorageKey {
+        guard let value = self.get(key) else {
+            let value = `default`()
+            self.set(key, to: value)
+            return value
+        }
+        return value
     }
 
     public mutating func set<Key>(

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -39,7 +39,7 @@ public struct Storage {
         orSetDefault default: @autoclosure () -> Key.Value
     ) -> Key.Value where Key: StorageKey {
         mutating get {
-            self.get(Key.self, orSetDefault: default)
+            self.get(Key.self, orSetDefault: `default`())
         }
     }
 


### PR DESCRIPTION
Adds the possibility to set and return a fallback value to Storage when accessing a non-existing value.

```swift
storage[Key.self, orSetDefault: fallbackValue]
```

or
```swift
storage.get(Key.self, orSetDefault: fallbackValue]
```
