### PR TITLE
Support for Unix Domain Sockets

### DIFF
--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -13,6 +13,9 @@ public final class ServeCommand: Command {
         
         @Option(name: "bind", short: "b", help: "Convenience for setting hostname and port together.")
         var bind: String?
+        
+        @Option(name: "unix-socket", short: nil, help: "Set the path for the unix domain socket file the server will bind to.")
+        var socketPath: String?
 
         public init() { }
     }
@@ -44,8 +47,13 @@ public final class ServeCommand: Command {
         let port = signature.port
             // 0.0.0.0:8080, :8080, parse port
             ?? signature.bind?.split(separator: ":").last.flatMap(String.init).flatMap(Int.init)
-
-        try context.application.server.start(hostname: hostname, port: port)
+        let socketPath = signature.socketPath // /tmp/vapor.socket
+        
+        if let socketPath = socketPath, !socketPath.isEmpty {
+            try context.application.server.start(socketPath: socketPath)
+        } else {
+            try context.application.server.start(hostname: hostname, port: port)
+        }
         self.server = context.application.server
 
         // allow the server to be stopped or waited for

--- a/Sources/Vapor/Error/UnixDomainSocketPathError.swift
+++ b/Sources/Vapor/Error/UnixDomainSocketPathError.swift
@@ -1,0 +1,41 @@
+import NIO
+
+/// Unix domain socket errors may be thrown when attepting to start the server from a unix domain socket path.
+public enum UnixDomainSocketPathError: AbortError {
+    case inaccessible(IOError)
+    case unsupportedFile(mode_t, String)
+    case couldNotRemove(IOError)
+    case socketInUse(IOError)
+    case noSuchDirectory(IOError)
+    
+    /// See `AbortError.status`
+    public var status: HTTPResponseStatus {
+        return .internalServerError
+    }
+
+    /// See `AbortError.identifier`
+    public var identifier: String {
+        switch self {
+        case .inaccessible: return "inaccessible"
+        case .unsupportedFile: return "unsupportedFile"
+        case .couldNotRemove: return "couldNotRemove"
+        case .socketInUse: return "socketInUse"
+        case .noSuchDirectory: return "noSuchDirectory"
+        }
+    }
+    
+    /// See `CustomStringConvertible`.
+    public var description: String {
+        return "Unix Domain Socket Path error: \(self.reason)"
+    }
+
+    /// See `AbortError.reason`
+    public var reason: String {
+        switch self {
+        case .inaccessible(let ioError), .couldNotRemove(let ioError), .socketInUse(let ioError), .noSuchDirectory(let ioError):
+            return ioError.description
+        case .unsupportedFile(_, let message):
+            return message
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -16,7 +16,7 @@ private struct EventLoopHTTPClient: Client {
     ) -> EventLoopFuture<ClientResponse> {
         do {
             let request = try HTTPClient.Request(
-                url: URL(string: client.url.string)!,
+                url: client.url.socketURL ?? URL(string: client.url.string)!,
                 method: client.method,
                 headers: client.headers,
                 body: client.body.map { .byteBuffer($0) }

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -321,30 +321,27 @@ private final class HTTPServerConnection {
         
         // Check if a socket path has been configured, and use it if it has been.
         if let socketPath = configuration.unixDomainSocketPath {
-            return prepareSocketFile(
+            return prepareSocketFileForBinding(
                 for: configuration,
                 with: application.eventLoopGroup.next(),
                 in: application.threadPool
-            ).flatMap { _ in
-                return bootstrap.bind(unixDomainSocketPath: socketPath).map { channel in
-                    return .init(
-                        channel: channel,
-                        quiesce: quiesce,
-                        configuration: configuration
-                    )
-                }
+            ).flatMap {
+                return bootstrap.bind(unixDomainSocketPath: socketPath)
+            }.map { channel in
+                return .init(
+                    channel: channel,
+                    quiesce: quiesce,
+                    configuration: configuration
+                )
             }.flatMapErrorThrowing { error -> HTTPServerConnection in
                 quiesce.initiateShutdown(promise: nil)
                 
-                // Transform `bind(descriptor:ptr:bytes:): Address already in use (errno: 48)` to a form the user can test for
-                if let ioError = error as? IOError {
-                    switch ioError.errnoCode {
-                    case EADDRINUSE: throw UnixDomainSocketPathError.socketInUse(ioError)
-                    case ENOENT: throw UnixDomainSocketPathError.noSuchDirectory(ioError)
-                    default: break
-                    }
+                // Transform `bind(descriptor:ptr:bytes:): Address already in use (errno: 48)`/`No such file or directory (errno: 2)` into a form the user can test for
+                switch error as? IOError {
+                case .some(let io) where io.errnoCode == EADDRINUSE: throw UnixDomainSocketPathError.socketInUse(io)
+                case .some(let io) where io.errnoCode == ENOENT: throw UnixDomainSocketPathError.noSuchDirectory(io)
+                default: throw error
                 }
-                throw error
             }
         }
         
@@ -373,26 +370,12 @@ private final class HTTPServerConnection {
             promise.fail(Abort(.internalServerError, reason: "Server stop took too long."))
         }
         self.quiesce.initiateShutdown(promise: promise)
-        return promise.futureResult.flatMapAlways { [configuration, channel] result in
-            let threadPool = NIOThreadPool(numberOfThreads: 1)
-            threadPool.start()
-            
-            return prepareSocketFile(
-                for: configuration,
-                with: channel.eventLoop,
-                in: threadPool
-            ).flatMapAlways { result in
-                let promise = channel.eventLoop.makePromise(of: Void.self)
-                threadPool.shutdownGracefully { error in
-                    if let error = error {
-                        promise.fail(error)
-                    } else {
-                        promise.succeed(())
-                    }
-                }
-                return promise.futureResult.flatMapThrowing { try result }
-            }.flatMapThrowing { try result }
+        do { // remove the socket file if it exists. This is ok to block since we are shutting down, and are not in an event loop
+            try removeSocketFileIfPresent(for: configuration)
+        } catch {
+            promise.fail(error)
         }
+        return promise.futureResult
     }
     
     var onClose: EventLoopFuture<Void> {
@@ -410,52 +393,56 @@ private final class HTTPServerConnection {
 ///   - eventLoop: An event loop to report the future on.
 ///   - threadPool: A thread pool to use when performing IO.
 /// - Returns: A future representing the completion of the necessary checks.
-private func prepareSocketFile(for configuration: HTTPServer.Configuration, with eventLoop: EventLoop, in threadPool: NIOThreadPool) -> EventLoopFuture<Void> {
+private func prepareSocketFileForBinding(for configuration: HTTPServer.Configuration, with eventLoop: EventLoop, in threadPool: NIOThreadPool) -> EventLoopFuture<Void> {
+    return threadPool.runIfActive(eventLoop: eventLoop) {
+        try removeSocketFileIfPresent(for: configuration)
+    }
+}
+
+/// Check for and remove a unix domain socket file specified by the configuration if one exists. **This call is blocking.**
+/// - Parameters:
+///   - configuration: A configuration with a socket path and logger.
+/// - Returns: A future representing the completion of the necessary checks.
+/// - Throws: `UnixDomainSocketPathError` if the file exists and cannot be removed.
+private func removeSocketFileIfPresent(for configuration: HTTPServer.Configuration) throws {
     // If there is no socket path configured, don't do anything and report success. This will be called every-time on server shutdown.
     guard let socketPath = configuration.unixDomainSocketPath else {
-        return eventLoop.makeSucceededFuture(())
+        return
     }
     
-    return threadPool.runIfActive(eventLoop: eventLoop) {
-        var socketFileStat = stat()
-        let (statResults, statError) = socketPath.withCString { path in
-            (stat(path, &socketFileStat), errno)
-        }
+    var socketFileStat = stat()
+    let statResults = lstat(socketPath, &socketFileStat)
+    
+    // Since we only want to continue if there is a socket file, stop here if an error occurred with stat().
+    guard statResults == 0 else {
+        let statError = errno
         
-        // Since we only want to continue if there is a socket file, stop here if an error occurred with stat().
-        guard statResults == 0 else {
+        if statError == ENOENT {
             // If stat() failed because a file doesn't exist, then don't do anything and report success — the socket file won't need to be removed.
-            guard statError == ENOENT else {
-                // If stat reports another error, we likely can't remove the file either, which means NIO will fail when binding, so tell the user by logging it so they can take action.
-                configuration.logger.critical("Could not access an existing socket file located at \(socketPath): POSIX Error \(statError). Please remove this file in order to start the server.")
-                throw UnixDomainSocketPathError.inaccessible(IOError(errnoCode: statError, reason: "Could not access an existing socket file located at \(socketPath)"))
-            }
-            
-            // stat() reported that the file doesn't exist, indicating NIO can go ahead and create it when it binds, so don't do anything and report success.
             return
         }
         
-        let mode = socketFileStat.st_mode
-        
-        // We only want to remove a socket file if it is actually a socket file - the user may have mistyped something, and it would be unfortunate for them to lose anything important otherwise.
-        guard mode&S_IFSOCK == S_IFSOCK else {
-            // A different type of file was found, so tell the user by logging it so they can take action.
-            configuration.logger.notice("An item at \(socketPath) already exists, but it is not a socket file. The socket file must not already exist before binding the server to a unix domain socket path.")
-            throw UnixDomainSocketPathError.unsupportedFile(mode, "An item at \(socketPath) already exists, but it is not a socket file")
-        }
-        
-        // The file exists, and is a socket file, so try to unlink it.
-        let (unlinkResults, unlinkError) = socketPath.withCString { path in
-            (unlink(path), errno)
-        }
-
-        guard unlinkResults == 0 else {
-            // If an error occurs during unlink, NIO will fail when binding, so report the error.
-            throw UnixDomainSocketPathError.couldNotRemove(IOError(errnoCode: unlinkError, reason: "Could not remove an existing socket file located at \(socketPath)"))
-        }
-        
-        // unlink() reported success, so NIO should be able to bind to the path.
+        // If stat reports another error, we likely can't remove the file either, which means NIO will fail when binding, so tell the user by logging it so they can take action.
+        configuration.logger.critical("Could not access an existing socket file located at \(socketPath): POSIX Error \(statError). Please remove this file in order to start the server.")
+        throw UnixDomainSocketPathError.inaccessible(IOError(errnoCode: statError, reason: "Could not access an existing socket file located at \(socketPath)"))
     }
+    
+    let mode = socketFileStat.st_mode
+    
+    // We only want to remove a socket file if it is actually a socket file - the user may have mistyped something, and it would be unfortunate for them to lose anything important otherwise.
+    guard mode & S_IFSOCK == S_IFSOCK else {
+        // A different type of file was found, so tell the user by logging it so they can take action.
+        configuration.logger.notice("An item at \(socketPath) already exists, but it is not a socket file. The socket file must not already exist before binding the server to a unix domain socket path.")
+        throw UnixDomainSocketPathError.unsupportedFile(mode, "An item at \(socketPath) already exists, but it is not a socket file")
+    }
+    
+    // The file exists, and is a socket file, so try to unlink it.
+    guard unlink(socketPath) == 0 else {
+        // If an error occurs during unlink, NIO will fail when binding, so report the error.
+        throw UnixDomainSocketPathError.couldNotRemove(IOError(errnoCode: errno, reason: "Could not remove an existing socket file located at \(socketPath)"))
+    }
+    
+    // unlink() reported success, so NIO should be able to bind to the path now.
 }
 
 final class HTTPServerErrorHandler: ChannelInboundHandler {

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -181,7 +181,23 @@ public final class HTTPServer: Server {
         var configuration = self.configuration
         configuration.hostname = hostname ?? configuration.hostname
         configuration.port = port ?? configuration.port
-
+        // clear out the unix domain socket path if a new hostname/port is provided so it won't be used
+        if hostname != nil || port != nil {
+            configuration.unixDomainSocketPath = nil
+        }
+        
+        try start(with: configuration)
+    }
+    
+    public func start(socketPath: String) throws {
+        // override the socket path to bind to
+        var configuration = self.configuration
+        configuration.unixDomainSocketPath = socketPath
+        
+        try start(with: configuration)
+    }
+    
+    private func start(with configuration: Configuration) throws {
         // print starting message
         let scheme = configuration.tlsConfiguration == nil ? "http" : "https"
         let address: String

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -17,6 +17,9 @@ public final class HTTPServer: Server {
     ///     services.register(serverConfig)
     ///
     public struct Configuration {
+        /// Socket path the server will bind to. If specified, the hostname and port will not be used to bind the server.
+        public var unixDomainSocketPath: String?
+        
         /// Host name the server will bind to.
         public var hostname: String
         
@@ -108,6 +111,7 @@ public final class HTTPServer: Server {
         public var logger: Logger
 
         public init(
+            socketPath: String? = nil,
             hostname: String = "127.0.0.1",
             port: Int = 8080,
             backlog: Int = 256,
@@ -121,6 +125,7 @@ public final class HTTPServer: Server {
             serverName: String? = nil,
             logger: Logger? = nil
         ) {
+            self.unixDomainSocketPath = socketPath
             self.hostname = hostname
             self.port = port
             self.backlog = backlog

--- a/Sources/Vapor/Server/Server.swift
+++ b/Sources/Vapor/Server/Server.swift
@@ -1,11 +1,28 @@
 public protocol Server {
     var onShutdown: EventLoopFuture<Void> { get }
+    
+    /// Start the server with the specified hostname and port, if provided. If left blank, the server will be started with its default configuration.
+    /// - Parameters:
+    ///   - hostname: The hostname to start the server with, or nil if the default one should be used.
+    ///   - port: The port to start the server with, or nil if the default one should be used.
     func start(hostname: String?, port: Int?) throws
+    
+    /// Start the server with the specified socket file.
+    /// - Parameter socketPath: The path to the unix domain socket file.
+    func start(socketPath: String) throws
+    
     func shutdown()
 }
 
 extension Server {
+    /// Start the server with its default configuration.
+    /// - Throws: An error if the server could not be started.
     public func start() throws {
         try self.start(hostname: nil, port: nil)
+    }
+    
+    /// A default implementation that throws an unimplemented assertion.
+    public func start(socketPath: String) throws {
+        preconditionFailure("\(self) does not support being started with a socketPath")
     }
 }

--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -175,3 +175,66 @@ public struct URI: ExpressibleByStringLiteral, CustomStringConvertible {
         return String(self.string[start..<end])
     }
 }
+
+
+extension URI {
+    /// Create a URI using a unix domain socket path.
+    /// - Parameters:
+    ///   - socketPath: The socket path the server is listening on.
+    ///   - path: The URI path to request from the server.
+    ///   - query: The URI path to request from the server.
+    ///   - fragment: The URI fragment to request from the server.
+    /// - Returns: A correctly formatted URI that encodes the socket path as the hostname.
+    public static func withSocketPath(
+        _ socketPath: String,
+        path: String = "/",
+        query: String? = nil,
+        fragment: String? = nil
+    ) -> URI {
+        return .init(
+            scheme: "http+unix",
+            host: socketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed),
+            path: path,
+            query: query,
+            fragment: fragment
+        )
+    }
+    
+    /// Create an HTTPS URI using a unix domain socket path.
+    /// - Parameters:
+    ///   - socketPath: The socket path the server is listening on.
+    ///   - path: The URI path to request from the server.
+    ///   - query: The URI path to request from the server.
+    ///   - fragment: The URI fragment to request from the server.
+    /// - Returns: A correctly formatted URI that encodes the socket path as the hostname.
+    public static func withSecureSocketPath(
+        _ socketPath: String,
+        path: String = "/",
+        query: String? = nil,
+        fragment: String? = nil
+    ) -> URI {
+        return .init(
+            scheme: "https+unix",
+            host: socketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed),
+            path: path,
+            query: query,
+            fragment: fragment
+        )
+    }
+    
+    /// The socket URL that can be passed to an instance of HTTPClient.
+    public var socketURL: URL? {
+        guard
+            let originalURL = URL(string: self.string),
+            let scheme = originalURL.scheme,
+            scheme == "http+unix" || scheme == "https+unix",
+            let host = originalURL.host,
+            let baseURL = URL(string: "unix://\(host)")
+        else { return nil }
+        
+        // prepare a new URL with a base URL that contains the path to the socket file.
+        // FIXME: We likely won't need this anymore once https://github.com/swift-server/async-http-client/pull/228 is merged
+        return URL(string: originalURL.path, relativeTo: baseURL)
+    }
+}
+

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -201,6 +201,80 @@ final class ServerTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         })
     }
+    
+    func testStartWithValidSocketFile() throws {
+        let socketPath = "/tmp/valid.vapor.socket"
+        
+        let app = Application(.testing)
+        app.http.server.configuration.unixDomainSocketPath = socketPath
+        defer {
+            app.shutdown()
+            XCTAssertFalse(FileManager().fileExists(atPath: socketPath), "Socket file was not removed: \(socketPath)")
+        }
+        
+        XCTAssertNoThrow(try app.start())
+    }
+    
+    func testStartWithExistingSocketFile() throws {
+        let socketPath = "/tmp/existing.vapor.socket"
+        
+        let app1 = Application(.testing)
+        app1.http.server.configuration.unixDomainSocketPath = socketPath
+        defer {
+            app1.shutdown()
+            XCTAssertFalse(FileManager().fileExists(atPath: socketPath), "Socket file was not removed: \(socketPath)")
+        }
+        
+        XCTAssertNoThrow(try app1.start())
+        
+        let app2 = Application(.testing)
+        app2.http.server.configuration.unixDomainSocketPath = socketPath
+        defer {
+            app2.shutdown()
+            XCTAssertFalse(FileManager().fileExists(atPath: socketPath), "Socket file was not removed: \(socketPath)")
+        }
+        
+        // app2 should succeed in unlinking and claiming the existing socket file
+        XCTAssertNoThrow(try app2.start())
+    }
+    
+    func testStartWithUnsupportedSocketFile() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.unixDomainSocketPath = "/tmp"
+        defer { app.shutdown() }
+        
+        XCTAssertThrowsError(try app.start()) { (error) in
+            XCTAssertNotNil(error as? UnixDomainSocketPathError)
+            guard let socketError = error as? UnixDomainSocketPathError else {
+                XCTFail("\(error) is not a UnixDomainSocketPathError")
+                return
+            }
+            
+            guard case UnixDomainSocketPathError.unsupportedFile = socketError else {
+                XCTFail("\(socketError) is not .unsupportedFile")
+                return
+            }
+        }
+    }
+    
+    func testStartWithInvalidSocketFilePath() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.unixDomainSocketPath = "/tmp/nonexistent/vapor.socket"
+        defer { app.shutdown() }
+        
+        XCTAssertThrowsError(try app.start()) { (error) in
+            XCTAssertNotNil(error as? UnixDomainSocketPathError)
+            guard let socketError = error as? UnixDomainSocketPathError else {
+                XCTFail("\(error) is not a UnixDomainSocketPathError")
+                return
+            }
+            
+            guard case UnixDomainSocketPathError.noSuchDirectory = socketError else {
+                XCTFail("\(socketError) is not .noSuchDirectory")
+                return
+            }
+        }
+    }
 }
 
 extension Application.Servers.Provider {

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -242,6 +242,10 @@ final class CustomServer: Server {
     func start(hostname: String?, port: Int?) throws {
         self.didStart = true
     }
+    
+    func start(socketPath: String) throws {
+        self.didStart = true
+    }
 
     func shutdown() {
         self.didShutdown = true

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -19,6 +19,29 @@ final class ServerTests: XCTestCase {
         let res = try app.client.get("http://127.0.0.1:8123/foo").wait()
         XCTAssertEqual(res.body?.string, "bar")
     }
+    
+    func testSocketPathOverride() throws {
+        let socketPath = "/tmp/vapor.test.socket"
+        
+        let env = Environment(
+            name: "testing",
+            arguments: ["vapor", "serve", "--port", "8123", "--unix-socket", socketPath]
+        )
+
+        let app = Application(env)
+        defer { app.shutdown() }
+
+        app.get("foo") { req in
+            return "bar"
+        }
+        try app.start()
+
+        let res = try app.client.get(.withSocketPath(socketPath, path: "/foo")).wait()
+        XCTAssertEqual(res.body?.string, "bar")
+        
+        // no server should be bound to the port despite one being set on the configuration.
+        XCTAssertThrowsError(try app.client.get("http://127.0.0.1:8123/foo").wait())
+    }
 
     func testConfigureHTTPDecompressionLimit() throws {
         let app = Application(.testing)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
These changes add support for Unix Domain Sockets (#2226) to Vapor.

A server can be started using the `serve` command:
```
$ swift run Run serve --unix-socket /tmp/vapor.socket
```

Alternatively, the app can be configured in code to connect to a socket:
```swift
app.http.server.configuration.unixDomainSocketPath = "/tmp/vapor.socket"
```

In either scenario, if a socket path is specified, it takes precedence over binding the server to a hostname/port. Note that TLS may be combined with this options if you wish the server to only listen to encrypted connections made to the socket file.

The socket file must not exist prior to starting the server. If one is left behind during an incomplete shutdown, however, and the app has permission to delete it, it will be overidden.

To assist with making connections to socket paths, URI has also been extended with a static `withSocketPath()` constructor:
```swift
try app.client.get(.withSocketPath("/tmp/vapor.socket", path: "/foo"))
```
Note that making requests to other socket-path-based services requires AsyncHTTPClient 1.1.0 or newer.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
