### PR TITLE
Support periods in cookie names

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -224,9 +224,12 @@ private extension Character {
     static var underscore: Self {
         .init("_")
     }
+    static var period: Self {
+        .init(".")
+    }
 
     var isDirectiveKey: Bool {
-        self.isLetter || self.isNumber || self == .dash || self == .underscore
+        self.isLetter || self.isNumber || self == .dash || self == .underscore || self == .period
     }
 }
 

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -176,6 +176,15 @@ final class HTTPHeaderValueTests: XCTestCase {
         XCTAssertEqual(headers.cookie?["oauth2_consent_csrf"]?.string, "MTU4NjkzNzgwMnxEdi1CQkFFQ180SUFBUkFCRUFBQVB2LUNBQUVHYzNSeWFXNW5EQVlBQkdOemNtWUdjM1J5YVc1bkRDSUFJR1ExWVRnM09USmhOamRsWXpSbU4yRmhOR1UwTW1KaU5tRXpPRGczTmpjMHweHbVecAf193ev3_1Tcf60iY9jSsq5-IQxGTyoztRTfg==")
     }
 
+    func testCookie_dotParsing() throws {
+        let headers = HTTPHeaders([
+            ("cookie", "cookie_one=1;cookie.two=2")
+        ])
+
+        XCTAssertEqual(headers.cookie?["cookie_one"]?.string, "1")
+        XCTAssertEqual(headers.cookie?["cookie.two"]?.string, "2")
+    }
+
     func testMediaTypeMainTypeCaseInsensitive() throws {
         let lower = HTTPMediaType(type: "foo", subType: "")
         let upper = HTTPMediaType(type: "FOO", subType: "")


### PR DESCRIPTION
Adds support for `.` in HTTP header value directive keys, like cookie names (#2372, fixes #2359).