### PR TITLE
Add Vapor 3 API shims

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),
-        .library(name: "XCTVapor", targets: ["XCTVapor"])
+        .library(name: "XCTVapor", targets: ["XCTVapor"]),
+        .library(name: "_Vapor3", targets: ["_Vapor3"]),
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
@@ -83,10 +84,16 @@ let package = Package(
             .product(name: "RoutingKit", package: "routing-kit"),
             .product(name: "WebSocketKit", package: "websocket-kit"),
         ]),
+        // Vapor 3 API shim
+        .target(name: "_Vapor3", dependencies: [
+            .target(name: "Vapor"),
+            .product(name: "_NIO1APIShims", package: "swift-nio")
+        ]),
 
         // Development
         .target(name: "Development", dependencies: [
             .target(name: "Vapor"),
+            .target(name: "_Vapor3"),
         ]),
 
         // Testing

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -1,4 +1,5 @@
 import Vapor
+import _Vapor3
 
 struct Creds: Content {
     var email: String
@@ -18,7 +19,7 @@ public func routes(_ app: Application) throws {
         var total = 0
         req.body.drain { result in
             let promise = req.eventLoop.makePromise(of: Void.self)
-
+            
             switch result {
             case .buffer(let buffer):
                 req.eventLoop.scheduleTask(in: .milliseconds(1000)) {

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -13,13 +13,13 @@ public func routes(_ app: Application) throws {
 
 
     // ( echo -e 'POST /slow-stream HTTP/1.1\r\nContent-Length: 1000000000\r\n\r\n'; dd if=/dev/zero; ) | nc localhost 8080
-    app.on(.POST, "slow-stream", body: .stream) { req -> EventLoopFuture<String> in
+    app.on(.POST, "slow-stream", body: .stream) { req -> Future<String> in
         let done = req.eventLoop.makePromise(of: String.self)
 
         var total = 0
         req.body.drain { result in
             let promise = req.eventLoop.makePromise(of: Void.self)
-            
+
             switch result {
             case .buffer(let buffer):
                 req.eventLoop.scheduleTask(in: .milliseconds(1000)) {

--- a/Sources/_Vapor3/Config.swift
+++ b/Sources/_Vapor3/Config.swift
@@ -1,0 +1,2 @@
+@available(*, unavailable, message: "Use `Application` instead.")
+public typealias Config = Void

--- a/Sources/_Vapor3/Exports.swift
+++ b/Sources/_Vapor3/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import _NIO1APIShims

--- a/Sources/_Vapor3/Future.swift
+++ b/Sources/_Vapor3/Future.swift
@@ -1,0 +1,42 @@
+import Vapor
+
+@available(*, deprecated, renamed: "EventLoopFuture")
+public typealias Future = EventLoopFuture
+
+extension EventLoopFuture {
+    public typealias Expectation = Value
+
+    @available(*, deprecated, message: "The `to` parameter has been removed and this method can no longer throw.")
+    public func map<T>(to type: T.Type, _ callback: @escaping (Expectation) throws -> T) -> EventLoopFuture<T> {
+        return self.flatMapThrowing(callback)
+    }
+
+
+    @available(*, deprecated, message: "The `to` parameter has been removed and this method can no longer throw.")
+    public func flatMap<T>(to type: T.Type, _ callback: @escaping (Expectation) throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+        return self.flatMap { input in
+            do {
+                return try callback(input)
+            } catch {
+                return self.eventLoop.makeFailedFuture(error)
+            }
+        }
+    }
+
+    @available(*, deprecated, renamed: "flatMapErrorThrowing")
+    public func catchMap(_ callback: @escaping (Error) throws -> (Expectation)) -> EventLoopFuture<Expectation> {
+        return self.flatMapErrorThrowing(callback)
+    }
+
+
+    @available(*, deprecated, message: "Use `flatMapError` with internal do / catch that returns a failed future.")
+    public func catchFlatMap(_ callback: @escaping (Error) throws -> (EventLoopFuture<Expectation>)) -> EventLoopFuture<Expectation> {
+        return self.flatMapError { inputError in
+            do {
+                return try callback(inputError)
+            } catch {
+                return self.eventLoop.makeFailedFuture(error)
+            }
+        }
+    }
+}

--- a/Sources/_Vapor3/Future.swift
+++ b/Sources/_Vapor3/Future.swift
@@ -8,13 +8,13 @@ extension EventLoopFuture {
     public typealias Expectation = Value
 
     @available(*, deprecated, message: "The `to` parameter has been removed and this method can no longer throw.")
-    public func map<T>(to type: T.Type, _ callback: @escaping (Expectation) throws -> T) -> EventLoopFuture<T> {
+    public func map<T>(to type: T.Type, _ callback: @escaping (Value) throws -> T) -> EventLoopFuture<T> {
         return self.flatMapThrowing(callback)
     }
 
 
     @available(*, deprecated, message: "The `to` parameter has been removed and this method can no longer throw.")
-    public func flatMap<T>(to type: T.Type, _ callback: @escaping (Expectation) throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
+    public func flatMap<T>(to type: T.Type, _ callback: @escaping (Value) throws -> EventLoopFuture<T>) -> EventLoopFuture<T> {
         return self.flatMap { input in
             do {
                 return try callback(input)
@@ -25,13 +25,13 @@ extension EventLoopFuture {
     }
 
     @available(*, deprecated, renamed: "flatMapErrorThrowing")
-    public func catchMap(_ callback: @escaping (Error) throws -> (Expectation)) -> EventLoopFuture<Expectation> {
+    public func catchMap(_ callback: @escaping (Error) throws -> (Value)) -> EventLoopFuture<Value> {
         return self.flatMapErrorThrowing(callback)
     }
 
 
     @available(*, deprecated, message: "Use `flatMapError` with internal do / catch that returns a failed future.")
-    public func catchFlatMap(_ callback: @escaping (Error) throws -> (EventLoopFuture<Expectation>)) -> EventLoopFuture<Expectation> {
+    public func catchFlatMap(_ callback: @escaping (Error) throws -> (EventLoopFuture<Value>)) -> EventLoopFuture<Value> {
         return self.flatMapError { inputError in
             do {
                 return try callback(inputError)

--- a/Sources/_Vapor3/Future.swift
+++ b/Sources/_Vapor3/Future.swift
@@ -4,6 +4,7 @@ import Vapor
 public typealias Future = EventLoopFuture
 
 extension EventLoopFuture {
+    @available(*, deprecated, renamed: "Value")
     public typealias Expectation = Value
 
     @available(*, deprecated, message: "The `to` parameter has been removed and this method can no longer throw.")

--- a/Sources/_Vapor3/NIOServerConfig.swift
+++ b/Sources/_Vapor3/NIOServerConfig.swift
@@ -1,0 +1,2 @@
+@available(*, unavailable, message: "Use `app.http.server.configuration` instead.")
+public typealias NIOServerConfig = Void

--- a/Sources/_Vapor3/Promise.swift
+++ b/Sources/_Vapor3/Promise.swift
@@ -1,0 +1,4 @@
+import Vapor
+
+@available(*, deprecated, renamed: "EventLoopPromise")
+public typealias Promise = EventLoopPromise

--- a/Sources/_Vapor3/Services.swift
+++ b/Sources/_Vapor3/Services.swift
@@ -1,0 +1,2 @@
+@available(*, unavailable, message: "Use `Application` instead.")
+public typealias Services = Void


### PR DESCRIPTION
Adds `_Vapor3` module that contains deprecations for Vapor 3 APIs (#2373). 

To use this module, add the product as a dependency to your App target in `Package.swift`. For example:

```swift
.target(name: "App", dependencies: [
    .product(name: "Vapor", package: "vapor"),
    .product(name: "_Vapor3", package: "vapor"),
]),
```

Then import the `_Vapor3` module to enable deprecations. 

```swift
import Vapor
import _Vapor3

...

app.get("test") { req -> Future<String> in
//                       ^~~~~~
// 'Future' is deprecated: renamed to 'EventLoopFuture'
    ...
}
```

> Note: This module only deprecates part of the Vapor 3 API. Some things are missing and not everything can be deprecated. If you'd like to add something, please open up a PR! 


