### PR TITLE
Fix for decoding percent escaped query keys (#2383)

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -33,20 +33,20 @@ internal struct URLEncodedFormParser {
         }
         return result
     }
-    
+
     func parseKey(key: Substring) throws -> [String] {
+        guard let percentDecodedKey = key.removingPercentEncoding else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unable to remove percent encoding for \(key)"))
+        }
         var path = [String]()
-        for var element in key.split(separator: "[") {
+        for var element in percentDecodedKey.split(separator: "[") {
             if path.count > 0 { //First one is not wrapped with `[]`
                 guard element.last == "]" else {
                     throw URLEncodedFormError.malformedKey(key: .init(key))
                 }
                 element = element.prefix(element.count-1) //Remove the `]`
             }
-            guard let percentDecodedElement = element.removingPercentEncoding else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unable to remove percent encoding for \(element)"))
-            }
-            path.append(percentDecodedElement)
+            path.append(String(element))
         }
         return path
     }

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -505,7 +505,7 @@ final class URLEncodedFormTests: XCTestCase {
     func testPercentDecoding() throws {
         let data = "aaa%5B%5D=%2Bbbb%20+ccc&d[]=1&d[]=2"
         let form = try URLEncodedFormParser().parse(data)
-        XCTAssertEqual(form, ["aaa[]": "+bbb  ccc", "d": ["": ["1","2"]]])
+        XCTAssertEqual(form, ["aaa": ["": "+bbb  ccc"], "d": ["": ["1","2"]]])
     }
     
     func testNestedParsing() throws {


### PR DESCRIPTION
This change fixes #2383 and brings consistency to how query array values are accessed.

Previously getting an array from the URL query you would have to include `[]` in the key. This is not needed for any other value access, and with this change is no longer needed to access arrays. This means the query string:

`emailsToSearch%5B%5D=xyz`

Used to be accessed by calling:

`request.query.get([String].self, at: "emailsToSearch[]")`

Now it can be accessed by calling:

`request.query.get([String].self, at: "emailsToSearch")`
