### PR TITLE
Improved Session Update/Expiration Control

### DIFF
--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -53,7 +53,7 @@ public protocol SessionAuthenticatable: Authenticatable {
 
 private extension SessionAuthenticatable {
     static var sessionName: String {
-        return "\(Self.self)"
+        return "\(Self.self)_Session"
     }
 }
 
@@ -62,14 +62,14 @@ extension Session {
     public func authenticate<A>(_ a: A)
         where A: SessionAuthenticatable
     {
-        self.data["_" + A.sessionName + "Session"] = a.sessionID.description
+        self.data.appStorage[A.sessionName] = a.sessionID.description
     }
 
     /// Un-authenticates the model from the session.
     public func unauthenticate<A>(_ a: A.Type)
         where A: SessionAuthenticatable
     {
-        self.data["_" + A.sessionName + "Session"] = nil
+        self.data.appStorage[A.sessionName] = nil
     }
 
     /// Returns the authenticatable type's ID if it exists
@@ -77,7 +77,6 @@ extension Session {
     public func authenticated<A>(_ a: A.Type) -> A.SessionID?
         where A: SessionAuthenticatable
     {
-        self.data["_" + A.sessionName + "Session"]
-            .flatMap { A.SessionID.init($0) }
+        self.data.appStorage[A.sessionName].flatMap { A.SessionID.init($0) }
     }
 }

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -1,28 +1,27 @@
 /// Simple in-memory sessions implementation.
 public struct MemorySessions: SessionDriver {
-    public let storage: Storage
+    internal let storage: Storage
     
-    public final class Storage {
-        public var sessions: [SessionID: (SessionData, Date)]
-        public let queue: DispatchQueue
-        public init() {
+    internal final class Storage {
+        var sessions: [SessionID: SessionData]
+        let queue: DispatchQueue
+        init() {
             self.sessions = [:]
             self.queue = DispatchQueue(label: "MemorySessions.Storage")
         }
     }
 
-    public init(storage: Storage) {
+    internal init(storage: Storage) {
         self.storage = storage
     }
 
     public func createSession(
         _ data: SessionData,
-        expiring: Date,
         for request: Request
     ) -> EventLoopFuture<SessionID> {
         let sessionID = self.generateID()
         self.storage.queue.sync {
-            self.storage.sessions[sessionID] = (data, expiring)
+            self.storage.sessions[sessionID] = data
         }
         return request.eventLoop.makeSucceededFuture(sessionID)
     }
@@ -30,28 +29,17 @@ public struct MemorySessions: SessionDriver {
     public func readSession(
         _ sessionID: SessionID,
         for request: Request
-    ) -> EventLoopFuture<(SessionData, Date)?> {
+    ) -> EventLoopFuture<SessionData?> {
         let session = self.storage.queue.sync { self.storage.sessions[sessionID] }
         return request.eventLoop.makeSucceededFuture(session)
     }
     
     public func updateSession(
         _ sessionID: SessionID,
-        to data: SessionData?,
-        expiring: Date?,
+        to data: SessionData,
         for request: Request
     ) -> EventLoopFuture<SessionID> {
-        var failed = false
-        if data != nil || expiring != nil {
-            self.storage.queue.sync {
-                let temp = self.storage.sessions[sessionID]
-                if var temp = temp {
-                    if let data = data { temp.0 = data }
-                    if let expiring = expiring { temp.1 = expiring }
-                    self.storage.sessions[sessionID] = temp
-                } else { failed = true }
-            }
-        }
+        self.storage.queue.sync { self.storage.sessions[sessionID] = data }
         return request.eventLoop.makeSucceededFuture(sessionID)
     }
     
@@ -70,8 +58,8 @@ public struct MemorySessions: SessionDriver {
     ) -> EventLoopFuture<Void> {
         self.storage.queue.sync {
             self.storage.sessions.forEach { session in
-                if session.value.1 < before {
-                    self.storage.sessions[session.key] = nil
+                if session.1.expiration < before {
+                    self.storage.sessions[session.0] = nil
                 }
             }
         }

--- a/Sources/Vapor/Sessions/Session.swift
+++ b/Sources/Vapor/Sessions/Session.swift
@@ -10,9 +10,6 @@ public final class Session {
 
     /// This session's data.
     public var data: SessionData
-    
-    /// Session's expiration date
-    var expiration: Date?
 
     /// `true` if this session is still valid.
     var isValid: Bool
@@ -22,11 +19,9 @@ public final class Session {
     /// Normally you will use `Request.session()` to do this.
     public init(
         id: SessionID? = nil,
-        data: SessionData = .init(),
-        expiration: Date? = nil) {
+        data: SessionData = .init()) {
         self.id = id
         self.data = data
-        self.expiration = expiration
         self.isValid = true
     }
 

--- a/Sources/Vapor/Sessions/Session.swift
+++ b/Sources/Vapor/Sessions/Session.swift
@@ -10,6 +10,9 @@ public final class Session {
 
     /// This session's data.
     public var data: SessionData
+    
+    /// Session's expiration date
+    var expiration: Date?
 
     /// `true` if this session is still valid.
     var isValid: Bool
@@ -17,14 +20,18 @@ public final class Session {
     /// Create a new `Session`.
     ///
     /// Normally you will use `Request.session()` to do this.
-    public init(id: SessionID? = nil, data: SessionData = .init()) {
+    public init(
+        id: SessionID? = nil,
+        data: SessionData = .init(),
+        expiration: Date? = nil) {
         self.id = id
         self.data = data
+        self.expiration = expiration
         self.isValid = true
     }
 
-    /// Invalidates the current session, removing persisted data from the session driver
-    /// and invalidating the cookie.
+    /// Flag the current session as invalid. Persisted data will be removed from the session
+    /// driver when `SessionsMiddleware` checks this flag at response time.
     public func destroy() {
         self.isValid = false
     }

--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -3,8 +3,11 @@
 /// Direct user interaction to `SessionData` is limited to subscripting accessors which read/store only
 /// in `SessionData.storage`; any other fields are limited to internal access only
 public struct SessionData: Codable {
+    public typealias Data = [String: String]
+    public typealias Expiration = Date
+    
     /// Session codable object storage for user info
-    public internal(set) var storage: [String: String] {
+    public internal(set) var storage: Data {
         /// Unilaterally set update flag when a key/value is set
         didSet {
             self.userStorageChanged = true
@@ -12,7 +15,7 @@ public struct SessionData: Codable {
     }
     
     /// Session codable object storage for Vapor
-    public internal(set) var appStorage: [String: String] {
+    public internal(set) var appStorage: Data {
        /// Unilaterally set update flag when a key/value is set
        didSet {
            self.appStorageChanged = true
@@ -20,7 +23,7 @@ public struct SessionData: Codable {
     }
     
     /// Expiration time of the session
-    public internal(set) var expiration: Date {
+    public internal(set) var expiration: Expiration {
         didSet {
             self.expiryChanged = true
         }

--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -1,15 +1,24 @@
 /// Codable session data.
 public struct SessionData: Codable {
     /// Session codable object storage.
-    internal var storage: [String: String]
-
-    /// Create a new, empty session data.
+    internal var storage: [String: String] {
+        /// Unilaterally set update flag when a key/value is set
+        didSet {
+            self.update = true
+        }
+    }
+    /// Flag for wheter session data has changed state (through initial creation or mutation)
+    internal var update: Bool
+    
+    /// Create a new, empty session data
     public init(_ data: [String: String] = [:]) {
         self.storage = data
+        self.update = false
     }
 
     public init(from decoder: Decoder) throws {
         self.storage = try .init(from: decoder)
+        self.update = false
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -1,33 +1,84 @@
 /// Codable session data.
+///
+/// Direct user interaction to `SessionData` is limited to subscripting accessors which read/store only
+/// in `SessionData.storage`; any other fields are limited to internal access only
 public struct SessionData: Codable {
-    /// Session codable object storage.
-    internal var storage: [String: String] {
+    /// Session codable object storage for user info
+    public internal(set) var storage: [String: String] {
         /// Unilaterally set update flag when a key/value is set
         didSet {
-            self.update = true
+            self.userStorageChanged = true
         }
     }
-    /// Flag for wheter session data has changed state (through initial creation or mutation)
-    internal var update: Bool
+    
+    /// Session codable object storage for Vapor
+    public internal(set) var appStorage: [String: String] {
+       /// Unilaterally set update flag when a key/value is set
+       didSet {
+           self.appStorageChanged = true
+       }
+    }
+    
+    /// Expiration time of the session
+    public internal(set) var expiration: Date {
+        didSet {
+            self.expiryChanged = true
+        }
+    }
+
+    /// Flags for whether session data has changed state (through initial creation or mutation)
+    public internal(set) var userStorageChanged: Bool
+    public internal(set) var appStorageChanged: Bool
+    public internal(set) var expiryChanged: Bool
+    
     
     /// Create a new, empty session data
     public init(_ data: [String: String] = [:]) {
         self.storage = data
-        self.update = false
+        self.userStorageChanged = false
+        self.appStorage = [:]
+        self.appStorageChanged = false
+        self.expiration = .distantFuture
+        self.expiryChanged = false
+    }
+    
+    internal init(user: [String: String] = [:], app: [String: String] = [:], expiration: Date) {
+        self.storage = user
+        self.appStorage = app
+        self.expiration = expiration
+        self.userStorageChanged = false
+        self.appStorageChanged = false
+        self.expiryChanged = false
     }
 
     public init(from decoder: Decoder) throws {
         self.storage = try .init(from: decoder)
-        self.update = false
+        self.appStorage = try .init(from: decoder)
+        self.expiration = try .init(from: decoder)
+        self.userStorageChanged = false
+        self.appStorageChanged = false
+        self.expiryChanged = false
     }
 
     public func encode(to encoder: Encoder) throws {
         try self.storage.encode(to: encoder)
+        try self.appStorage.encode(to: encoder)
+        try self.expiration.encode(to: encoder)
     }
     
     /// Convenience `[String: String]` accessor.
     public subscript(_ key: String) -> String? {
         get { return self.storage[key] }
         set { self.storage[key] = newValue }
+    }
+    
+    public mutating func resetFlags() {
+        userStorageChanged = false
+        appStorageChanged = false
+        expiryChanged = false
+    }
+    
+    public var anyUpdated: Bool {
+        return userStorageChanged || appStorageChanged || expiryChanged
     }
 }

--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -34,26 +34,16 @@ public struct SessionData: Codable {
     public internal(set) var appStorageChanged: Bool
     public internal(set) var expiryChanged: Bool
     
-    
     /// Create a new, empty session data
-    public init(_ data: [String: String] = [:]) {
+    public init(_ data: Data = [:], app: Data = [:], expiration: Expiration = .distantFuture) {
         self.storage = data
-        self.userStorageChanged = false
-        self.appStorage = [:]
-        self.appStorageChanged = false
-        self.expiration = .distantFuture
-        self.expiryChanged = false
-    }
-    
-    internal init(user: [String: String] = [:], app: [String: String] = [:], expiration: Date) {
-        self.storage = user
         self.appStorage = app
         self.expiration = expiration
         self.userStorageChanged = false
         self.appStorageChanged = false
         self.expiryChanged = false
     }
-
+    
     public init(from decoder: Decoder) throws {
         self.storage = try .init(from: decoder)
         self.appStorage = try .init(from: decoder)

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -2,22 +2,29 @@
 public protocol SessionDriver {
     func createSession(
         _ data: SessionData,
+        expiring: Date,
         for request: Request
     ) -> EventLoopFuture<SessionID>
     
     func readSession(
         _ sessionID: SessionID,
         for request: Request
-    ) -> EventLoopFuture<SessionData?>
+    ) -> EventLoopFuture<(SessionData, Date)?>
     
     func updateSession(
         _ sessionID: SessionID,
-        to data: SessionData,
+        to data: SessionData?,
+        expiring: Date?,
         for request: Request
     ) -> EventLoopFuture<SessionID>
     
     func deleteSession(
         _ sessionID: SessionID,
         for request: Request
+    ) -> EventLoopFuture<Void>
+    
+    func deleteExpiredSessions(
+        before: Date,
+        on request: Request
     ) -> EventLoopFuture<Void>
 }

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -2,19 +2,17 @@
 public protocol SessionDriver {
     func createSession(
         _ data: SessionData,
-        expiring: Date,
         for request: Request
     ) -> EventLoopFuture<SessionID>
     
     func readSession(
         _ sessionID: SessionID,
         for request: Request
-    ) -> EventLoopFuture<(SessionData, Date)?>
+    ) -> EventLoopFuture<SessionData?>
     
     func updateSession(
         _ sessionID: SessionID,
-        to data: SessionData?,
-        expiring: Date?,
+        to data: SessionData,
         for request: Request
     ) -> EventLoopFuture<SessionID>
     

--- a/Sources/Vapor/Sessions/SessionsConfiguration.swift
+++ b/Sources/Vapor/Sessions/SessionsConfiguration.swift
@@ -5,6 +5,13 @@ public struct SessionsConfiguration {
 
     /// Name of HTTP cookie, used as a key for the cookie value.
     public var cookieName: String
+    
+    /// Session lifetime interval and time-to-update in seconds
+    /// `lifetime == 0`, indefinite lifetime
+    /// `timeToUpdate == 0`, always update
+    public let lifetime: Double
+    public let timeToUpdate: Double
+    public let threshold: Double
 
     /// Create a new `SessionsConfig` with the supplied cookie factory.
     ///
@@ -14,27 +21,82 @@ public struct SessionsConfiguration {
     ///
     /// - parameters:
     ///     - cookieName: Name of HTTP cookie, used as a key for the cookie value.
+    ///     - cookieLifetime: Duration in seconds of cookie lifetime - if `nil`, implicit cookie expiration
+    ///         time will be used as the duration. If cookies set an expiration time, should be the same as
+    ///         `maxAge`/`expires` time or with a 5 second increase to allow some variance for client-side latency.
+    ///         If cookies set no expiration (ephemeral session cookies), `cookieLifetime` can be used to
+    ///         enforce killing "dead" sessions
+    ///     - cookieTTU: Duration in seconds of interval past when cookie expiration should be updated and re-sent
+    ///         to client, to minimize update frequency (or preventing refreshed cookies at all for security). `Lifetime`
+    ///         must be set to use; clamped between `0...cookieLifetime` with `0` meaning "update on
+    ///         every request" and `== cookieLifetime` being never extend. Practically this value is application-
+    ///         dependent and should be evaluated. EG; a 7 day expiration lifetime for a persistent cookie with a 1 day
+    ///         TTU still permits at least 6 days of inactivity before the cookie expires, greatly reducing packet overhead
+    ///         and backend updating of the session data store if no changes to the session data occur during a request.
     ///     - cookieFactory: Creates a new `HTTPCookieValue` for the supplied value `String`.
-    public init(cookieName: String, cookieFactory: @escaping (SessionID) -> HTTPCookies.Value) {
+    public init( cookieName: String,
+                 cookieLifetime: UInt? = nil,
+                 cookieTTU: UInt? = nil,
+                 cookieFactory: @escaping (SessionID) -> HTTPCookies.Value) {
         self.cookieName = cookieName
         self.cookieFactory = cookieFactory
+        
+        let sampleCookie = self.cookieFactory(SessionID(string: "test"))
+        let expireAge = Int(sampleCookie.expires?.timeIntervalSinceNow ?? -1)
+        let maxAge = sampleCookie.maxAge ?? -1
+        let neitherSet = sampleCookie.expires == nil && sampleCookie.maxAge == nil
+        
+        /// Set cookie `calculatedAge` to the greatest value present
+        /// Could be -1 if neither is set or is misconfigured to negative values, 0 if misconfigured, or postiive.
+        let calculatedAge = max(expireAge, maxAge)
+        /// Sanity checks if values between expire and maxAge are different or cookies are set to immediately expire. 1 second tick variance
+        if (sampleCookie.expires != nil && sampleCookie.maxAge != nil) {
+            assert(abs(expireAge-maxAge) <= 1, "Ensure consistent setting between maxAge & expires")
+        }
+        assert(calculatedAge > 0 || neitherSet, "Cookie factory shouldn't set immediately expiring age for sessions")
+        
+        /// Set lifetime to the greater of implicit cookie age or explicit lifetime, if set
+        let maxLife = max(UInt(calculatedAge), cookieLifetime ?? 0)
+        /// Non-expiring session cookies with no server-side expiration time set is very unwise. If it's really desirable, it should
+        /// still be configured explicitly with an extremely long `cookieLifetime` since malicious clients could indefinitely
+        /// persist a cookie otherwise expected by the server to be eventually expiring.
+        assert(maxLife > 0,
+            "Configure at least one expiration deadline either implicitly via cookie expiry or explicit configuration")
+        if calculatedAge > 0, maxLife > 0 {
+            /// Expiring cookies with a stated lifetime - check that we're not off by more than 5 seconds between the two
+            /// or assert that we're mis-configured. 5 seconds is an arbitrary limit to allow some over-setting of
+            /// `cookieLifetime` to account for latency between server-client communications.
+            assert((0...5).contains(maxLife - UInt(calculatedAge)), "Ensure your cookie configuration is consistent")
+        }
+        
+        self.lifetime = Double(maxLife)
+        
+        /// Ensure `cookieTTU`, if set, is valid within the range of the cookie lifetime, clamp it anyway, or set to 0 if we're not using a TTU
+        if let cookieTTU = cookieTTU {
+            assert(cookieTTU <= maxLife, "timeToUpdate must be <= \(maxLife)")
+            self.timeToUpdate = Double(min(cookieTTU, maxLife))
+        } else { self.timeToUpdate = 0 }
+        
+        self.threshold = self.lifetime - self.timeToUpdate
     }
 
     /// `SessionsConfig` with basic cookie factory.
-    public static func `default`() -> SessionsConfiguration {
-        return .init(cookieName: "vapor-session") { sessionID in
-            return HTTPCookies.Value(
-                string: sessionID.string,
-                expires: Date(
-                    timeIntervalSinceNow: 60 * 60 * 24 * 7 // one week
-                ),
-                maxAge: nil,
-                domain: nil,
-                path: "/",
-                isSecure: false,
-                isHTTPOnly: false,
-                sameSite: nil
-            )
-        }
+    public static func `default`(life: UInt = 60 * 60 * 24 * 7,  // Default lifetime of 1 Week
+                                 ttu: UInt? = nil)
+        -> SessionsConfiguration {
+            return .init(cookieName: "vapor-session", cookieLifetime: life, cookieTTU: ttu) { sessionID in
+                return HTTPCookies.Value(
+                    string: sessionID.string,
+                    expires: Date(
+                        timeIntervalSinceNow: Double(life)
+                    ),
+                    maxAge: nil,
+                    domain: nil,
+                    path: "/",
+                    isSecure: false,
+                    isHTTPOnly: false,
+                    sameSite: nil
+                )
+            }
     }
 }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -12,7 +12,6 @@
 ///     services.register(middlewareConfig)
 ///
 /// See `SessionsConfig` and `Sessions` for more information.
-import Foundation
 
 public final class SessionsMiddleware: Middleware {
     /// The cookie to work with
@@ -70,7 +69,7 @@ public final class SessionsMiddleware: Middleware {
             return request.eventLoop.makeSucceededFuture(response)
         }
         
-        let interval = Date().distance(to: session.data.expiration)
+        let interval = Date().timeIntervalSinceReferenceDate.distance(to: session.data.expiration.timeIntervalSinceReferenceDate)
         // If the session's expiration time is before this moment invalidate the session
         if interval < 0 {  session.isValid = false }
         // ... or set the cookie expiration if we're past the time to update

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -77,12 +77,8 @@ public final class SessionsMiddleware: Middleware {
         else if interval < configuration.threshold || session.id == nil {
             session.data.expiration = Date(timeIntervalSinceNow: configuration.lifetime)
         }
- 
-//        print(Date())
-//        print(session.data.expiration)
-//        print("+=Exp \(Date().distance(to: session.data.expiration))")
 
-        // If the session is valid and nothing has updated, no need to set cookie
+        // If the session is valid and nothing has updated, respond now
         if session.isValid && !session.data.anyUpdated {
             return request.eventLoop.makeSucceededFuture(response)
         }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -12,6 +12,7 @@
 ///     services.register(middlewareConfig)
 ///
 /// See `SessionsConfig` and `Sessions` for more information.
+
 public final class SessionsMiddleware: Middleware {
     /// The cookie to work with
     let configuration: SessionsConfiguration
@@ -41,13 +42,13 @@ public final class SessionsMiddleware: Middleware {
         if let cookieValue = request.cookies[self.configuration.cookieName] {
             // A cookie value exists, get the session for it.
             let id = SessionID(string: cookieValue.string)
-            return self.session.readSession(id, for: request).flatMap { data in
-                if let data = data {
+            return self.session.readSession(id, for: request).flatMap { session in
+                if let session = session {
                     // Session found, restore data and id.
-                    request._sessionCache.session = .init(id: id, data: data)
+                    request._sessionCache.session = .init(id: id, data: session.0, expiration: session.1)
                 } else {
                     // Session id not found, create new session.
-                    request._sessionCache.session = .init()
+                    request._sessionCache.session = .init(data: .init())
                 }
                 return next.respond(to: request).flatMap { res in
                     return self.addCookies(to: res, for: request)
@@ -63,35 +64,76 @@ public final class SessionsMiddleware: Middleware {
 
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) -> EventLoopFuture<Response> {
-        if let session = request._sessionCache.session, session.isValid {
-            // A session exists or has been created. we must
-            // set a cookie value on the response
-            let createOrUpdate: EventLoopFuture<SessionID>
-            if let id = session.id {
-                // A cookie exists, just update this session.
-                createOrUpdate = self.session.updateSession(id, to: session.data, for: request)
-            } else {
-                // No cookie, this is a new session.
-                createOrUpdate = self.session.createSession(session.data, for: request)
+        // Update expiration time of cookie if necessary, and invalidate if it's expired
+        if let session = request._sessionCache.session {
+            var newExpire: Date? = nil
+            if let expiration = session.expiration {
+                // If we're past expiration time - invalidate session
+                if (Date().distance(to: expiration)) <= 0.0 { session.isValid = false; }
+                // ... or time to expiration is less than the threshold - refresh
+                else if (Date().distance(to: expiration)) < configuration.threshold {
+                    newExpire = Date(timeIntervalSinceNow: configuration.lifetime)
+                }
+                // Otherwise we're still before the expiration threshold - nothing needs to happen
+                else {
+                    newExpire = nil
+                }
+            } else if session.expiration == nil {
+                // No expiration was set (new session) - create one
+                newExpire = Date(timeIntervalSinceNow: configuration.lifetime)
             }
 
-            // After create or update, set cookie on the response.
-            return createOrUpdate.map { id in
-                // the session has an id, set the cookie
-                response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id)
-                return response
+            if session.isValid {
+                let createOrUpdate: EventLoopFuture<SessionID>
+                if let id = session.id, session.data.update {
+                    // Session is an existing one and either data or expiration was updated
+                    // Optionals for data and expiry if they need to be updated, nil otherwise
+                    let data = session.data.update ? session.data : nil
+                    createOrUpdate = self.session.updateSession(id, to: data, expiring: newExpire, for: request)
+                } else if session.id == nil {
+                    // No cookie, this is a new session.
+                    createOrUpdate = self.session.createSession(session.data, expiring: newExpire!, for: request)
+                } else {
+                    // Session is existing but no changes happened and expiration is still valid
+                    // We can just return the response directly
+                    return request.eventLoop.makeSucceededFuture(response)
+                }
+
+                return createOrUpdate.map { id in
+                    // Only Set-Cookie to a new one when the session is new or if TTU has passed
+                    if newExpire != nil {
+                        response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id)
+                    }
+                    return response
+                }
+            } else {
+                // The request had a session cookie, but now there is no valid session.
+                // we need to perform cleanup.
+                let cookieValue = request.cookies[self.configuration.cookieName]!
+                let id = SessionID(string: cookieValue.string)
+                return self.session.deleteSession(id, for: request).map {
+                    response.cookies[self.configuration.cookieName] = .expired
+                    return response
+                }
             }
-        } else if let cookieValue = request.cookies[self.configuration.cookieName] {
-            // The request had a session cookie, but now there is no valid session.
-            // we need to perform cleanup.
-            let id = SessionID(string: cookieValue.string)
-            return self.session.deleteSession(id, for: request).map {
-                response.cookies[self.configuration.cookieName] = .expired
-                return response
-            }
-        } else {
-            // no session or existing cookie
-            return request.eventLoop.makeSucceededFuture(response)
         }
+        // There's no session.
+        return request.eventLoop.makeSucceededFuture(response)
+    }
+    
+    private func updateExpiration(for sess: Session) -> Date? {
+        if let expiration = sess.expiration {
+            // We're past expiration time - invalidate session
+            if Date() > expiration { sess.isValid = false; return nil }
+            // We're still before the expiration threshold - nothing needs to happen
+            if expiration - configuration.threshold > Date() { return nil }
+            
+            // No expiration was set (new session) or we're past the threshold - refresh it
+            return Date(timeIntervalSinceNow: configuration.lifetime)
+        } else {
+            // No expiration was set (new session) or we're past the threshold - refresh it
+            return Date(timeIntervalSinceNow: configuration.lifetime)
+        }
+        
     }
 }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -45,10 +45,10 @@ public final class SessionsMiddleware: Middleware {
             return self.session.readSession(id, for: request).flatMap { session in
                 if let session = session {
                     // Session found, restore data and id.
-                    request._sessionCache.session = .init(id: id, data: session.0, expiration: session.1)
+                    request._sessionCache.session = .init(id: id, data: session)
                 } else {
                     // Session id not found, create new session.
-                    request._sessionCache.session = .init(data: .init())
+                    request._sessionCache.session = .init(data: .init(expiration: Date(timeIntervalSinceNow: self.configuration.lifetime)))
                 }
                 return next.respond(to: request).flatMap { res in
                     return self.addCookies(to: res, for: request)
@@ -64,76 +64,55 @@ public final class SessionsMiddleware: Middleware {
 
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) -> EventLoopFuture<Response> {
-        // Update expiration time of cookie if necessary, and invalidate if it's expired
-        if let session = request._sessionCache.session {
-            var newExpire: Date? = nil
-            if let expiration = session.expiration {
-                // If we're past expiration time - invalidate session
-                if (Date().distance(to: expiration)) <= 0.0 { session.isValid = false; }
-                // ... or time to expiration is less than the threshold - refresh
-                else if (Date().distance(to: expiration)) < configuration.threshold {
-                    newExpire = Date(timeIntervalSinceNow: configuration.lifetime)
-                }
-                // Otherwise we're still before the expiration threshold - nothing needs to happen
-                else {
-                    newExpire = nil
-                }
-            } else if session.expiration == nil {
-                // No expiration was set (new session) - create one
-                newExpire = Date(timeIntervalSinceNow: configuration.lifetime)
-            }
-
-            if session.isValid {
-                let createOrUpdate: EventLoopFuture<SessionID>
-                if let id = session.id, session.data.update {
-                    // Session is an existing one and either data or expiration was updated
-                    // Optionals for data and expiry if they need to be updated, nil otherwise
-                    let data = session.data.update ? session.data : nil
-                    createOrUpdate = self.session.updateSession(id, to: data, expiring: newExpire, for: request)
-                } else if session.id == nil {
-                    // No cookie, this is a new session.
-                    createOrUpdate = self.session.createSession(session.data, expiring: newExpire!, for: request)
-                } else {
-                    // Session is existing but no changes happened and expiration is still valid
-                    // We can just return the response directly
-                    return request.eventLoop.makeSucceededFuture(response)
-                }
-
-                return createOrUpdate.map { id in
-                    // Only Set-Cookie to a new one when the session is new or if TTU has passed
-                    if newExpire != nil {
-                        response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id)
-                    }
-                    return response
-                }
-            } else {
-                // The request had a session cookie, but now there is no valid session.
-                // we need to perform cleanup.
-                let cookieValue = request.cookies[self.configuration.cookieName]!
-                let id = SessionID(string: cookieValue.string)
-                return self.session.deleteSession(id, for: request).map {
-                    response.cookies[self.configuration.cookieName] = .expired
-                    return response
-                }
-            }
-        }
-        // There's no session.
-        return request.eventLoop.makeSucceededFuture(response)
-    }
-    
-    private func updateExpiration(for sess: Session) -> Date? {
-        if let expiration = sess.expiration {
-            // We're past expiration time - invalidate session
-            if Date() > expiration { sess.isValid = false; return nil }
-            // We're still before the expiration threshold - nothing needs to happen
-            if expiration - configuration.threshold > Date() { return nil }
-            
-            // No expiration was set (new session) or we're past the threshold - refresh it
-            return Date(timeIntervalSinceNow: configuration.lifetime)
-        } else {
-            // No expiration was set (new session) or we're past the threshold - refresh it
-            return Date(timeIntervalSinceNow: configuration.lifetime)
+        // If there's no session, continue immediately
+        guard let session = request._sessionCache.session else {
+            return request.eventLoop.makeSucceededFuture(response)
         }
         
+        let interval = Date().distance(to: session.data.expiration)
+        // If the session's expiration time is before this moment invalidate the session
+        if interval < 0 {  session.isValid = false }
+        // ... or set the cookie expiration if we're past the time to update
+        // threshold, or this is a new session
+        else if interval < configuration.threshold || session.id == nil {
+            session.data.expiration = Date(timeIntervalSinceNow: configuration.lifetime)
+        }
+ 
+//        print(Date())
+//        print(session.data.expiration)
+//        print("+=Exp \(Date().distance(to: session.data.expiration))")
+
+        // If the session is valid and nothing has updated, no need to set cookie
+        if session.isValid && !session.data.anyUpdated {
+            return request.eventLoop.makeSucceededFuture(response)
+        }
+        
+        if session.isValid {
+            let updatedExpiration = session.data.expiryChanged
+            session.data.resetFlags()
+            let createOrUpdate: EventLoopFuture<SessionID>
+            if let id = session.id {
+                // Session is an existing one and something was updated
+                createOrUpdate = self.session.updateSession(id, to: session.data, for: request)
+            } else {
+                // No cookie, this is a new session.
+                createOrUpdate = self.session.createSession(session.data, for: request)
+            }
+            
+            return createOrUpdate.map { id in
+                if updatedExpiration {
+                    response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id) }
+                return response
+            }
+        } else {
+            // The request had a session cookie, but now there is no valid session.
+            // we need to perform cleanup.
+            let cookieValue = request.cookies[self.configuration.cookieName]!
+            let id = SessionID(string: cookieValue.string)
+            return self.session.deleteSession(id, for: request).map {
+                response.cookies[self.configuration.cookieName] = .expired
+                return response
+            }
+        }        
     }
 }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -12,6 +12,7 @@
 ///     services.register(middlewareConfig)
 ///
 /// See `SessionsConfig` and `Sessions` for more information.
+import Foundation
 
 public final class SessionsMiddleware: Middleware {
     /// The cookie to work with

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -7,23 +7,33 @@ final class SessionTests: XCTestCase {
             init() { }
 
 
-            func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
+            func createSession(_ data: SessionData, expiring: Date, for request: Request) -> EventLoopFuture<SessionID> {
                 Self.ops.append("create \(data)")
                 return request.eventLoop.makeSucceededFuture(.init(string: "a"))
             }
 
-            func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
+            func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<(SessionData, Date)?> {
                 Self.ops.append("read \(sessionID)")
-                return request.eventLoop.makeSucceededFuture(SessionData())
+                return request.eventLoop.makeSucceededFuture((SessionData(), .distantFuture))
             }
 
-            func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
-                Self.ops.append("update \(sessionID) to \(data)")
+            func updateSession(_ sessionID: SessionID, to data: SessionData?, expiring: Date?, for request: Request) -> EventLoopFuture<SessionID> {
+                switch (data, expiring) {
+                    case (.none, .none): Self.ops.append("update \(sessionID) - no-op")
+                    case (.some, .none): Self.ops.append("update \(sessionID) data to \(data!)")
+                    case (.none, .some): Self.ops.append("update \(sessionID) expiration to \(expiring!)")
+                    case (.some, .some): Self.ops.append("update \(sessionID) to \(data!) expiring \(expiring!)")
+                }
                 return request.eventLoop.makeSucceededFuture(sessionID)
             }
 
             func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
                 Self.ops.append("delete \(sessionID)")
+                return request.eventLoop.makeSucceededFuture(())
+            }
+            
+            func deleteExpiredSessions(before: Date, on request: Request) -> EventLoopFuture<Void> {
+                Self.ops.append("delete sessions expiring before \(before)")
                 return request.eventLoop.makeSucceededFuture(())
             }
         }
@@ -50,7 +60,7 @@ final class SessionTests: XCTestCase {
             cookie = res.headers.setCookie?["vapor-session"]
             XCTAssertNotNil(cookie)
             XCTAssertEqual(MockKeyedCache.ops, [
-                #"create SessionData(storage: ["foo": "bar"])"#,
+                #"create SessionData(storage: ["foo": "bar"], update: true)"#,
             ])
             MockKeyedCache.ops = []
         }
@@ -127,4 +137,150 @@ final class SessionTests: XCTestCase {
         headers.replaceOrAdd(name: .cookie, value: #"foo= "+cookie/value" "#)
         XCTAssertEqual(headers.cookie?["foo"]?.string, "+cookie/value")
     }
+    
+    
+    func testBenchmarks() {
+        try! _benchmarkSessions(clients: 200, duration: 10, lifetime: 3, timeToUpdate: 1, mutateRate: 10, dataSize: 16, requestSize: 64)
+    }
+    
+    func _benchmarkSessions(clients c: UInt16,        // number of clients to simulate
+                            duration d: UInt8,       // duration in seconds of test
+                            lifetime l: UInt8,       // cookie lifetime
+                            timeToUpdate ttu: UInt8, // cookie expiration update threshold
+                            mutateRate mr: UInt8,    // 0-100 - % rate of mutating session data
+                            dataSize ds: UInt8,      // length of session data payload
+                            requestSize rs: UInt16   // length of request body payload
+                            ) throws {
+            guard ttu <= l, l <= d, c != 0, (0...100).contains(mr) else
+                { XCTFail("Check input parameters"); fatalError("invalid input") }
+            
+            var actions: [SessionAction: Int] =
+                [.create: 0, .destroy: 0, .read: 0,
+                 .updateNothing: 0, .updateExpiry: 0,
+                 .updateData: 0, .updateAll: 0]
+            let cookieName = "benchmark-sessions"
+            var clientCookies: [HTTPCookies.Value?] = .init(repeating: nil, count: Int(c))
+            
+            let app = Application(.testing)
+            
+            defer { app.shutdown() }
+
+            // Configure sessions.
+            app.sessions.use(.memory)
+            app.sessions.configuration = .init(
+                cookieName: cookieName,
+                cookieLifetime: UInt(l),
+                cookieTTU: UInt(ttu)
+                )
+                { sessionID in
+                    return HTTPCookies.Value(
+                        string: sessionID.string,
+                        expires: Date(timeIntervalSinceNow: Double(l)),
+                        maxAge: nil,
+                        domain: nil,
+                        path: "/",
+                        isSecure: false,
+                        isHTTPOnly: false,
+                        sameSite: nil)
+                }
+            app.middleware.use(app.sessions.middleware)
+            
+            let start = Date()
+            let datalock = Lock()
+            var requests = 0
+            var completed = 0
+            
+            
+            // Randomly mutates session data and returns a body.
+            app.get("request") { req -> String in
+                if req.headers.cookie?[cookieName] == nil {
+                    req.session.data["payload"] = generateGarbage(UInt32(ds)) // Always set data when no session exists
+                } else if (0...100).randomElement()! <= mr {
+                    req.session.data["payload"] = generateGarbage(UInt32(ds)) // Or randomly decide whether to mutate
+                    datalock.withLock {
+                        actions[.updateData] = actions[.updateData]! + 1
+                    }
+                }
+                return generateGarbage(UInt32(rs))
+            }
+            
+            while Date() < start + Double(d) {
+                let progress: Double = ((Double(d) - (Date().distance(to: start))) / Double(d)) - 1.0
+                // Start with 20% of clients, pace remaining 80% up to roughly 90% progress
+                let clientMax = min(Int(Double(c) * (0.2 + (0.9 * progress))), Int(c)-1)
+                var clientMin = 0
+                // 90% chance client choice is in the last half of the available client list instead of the full range
+                if (0..<100).randomElement()! < 90 { clientMin = clientMax / 2 }
+                
+                let client = Int((clientMin...clientMax).randomElement()!)
+                
+                let cookie: HTTPCookies.Value?
+                datalock.lock()
+                requests += 1
+                cookie = clientCookies[client]
+                datalock.unlock()
+                try app.test(.GET, "request",
+                    beforeRequest: { req in
+                        if cookie != nil {
+                            req.headers.cookie = [cookieName: cookie!]
+                        }
+                    },
+                    afterResponse: { res in
+                        let responseCookie = res.headers.setCookie?[cookieName]
+                        
+                        switch (cookie, responseCookie) {
+                            // Request didn't have a cookie and response didn't provide one - this is wrong
+                            case (.none, .none): XCTFail("Cookie should have been set")
+                            // Request provided a cookie, we didn't get one back - this is normal case before threshold
+                            case (.some, .none): datalock.withLock { completed += 1 }
+                            // Request didn't have a cookie, response provided one - new session
+                            case (.none, .some(let rc)):
+                                datalock.withLock {
+                                    actions[.create] = actions[.create]! + 1
+                                    clientCookies[client] = rc;
+                                    completed += 1
+                                }
+                            // Request provided a cookie and response provided one - this is a cookie either expired or past threshold
+                            case (.some, .some(let rc)):
+                                // Expired cookie - mark destroyed, destroy client cookie store
+                                if rc.expires! < Date() {
+                                    datalock.withLock {
+                                        actions[.destroy] = actions[.destroy]! + 1
+                                        clientCookies[client] = nil
+                                        completed += 1
+                                    }
+                                }
+                                // Updated cookie - refresh the cookie store
+                                else {
+                                    datalock.withLock {
+                                        actions[.updateExpiry] = actions[.updateExpiry]! + 1
+                                        clientCookies[client] = rc
+                                        completed += 1
+                                    }
+                                }
+                        }
+                    })
+            }
+            
+            print("Completed: \(completed) of \(requests): \(actions[.create]!) cookies created, \(actions[.updateData]!) data updated, \(actions[.updateExpiry]!) expiration refreshed, \(actions[.destroy]!) expired")
+        }
+    }
+
+fileprivate enum SessionAction: Hashable {
+    case create
+    case read
+    case destroy
+    case updateNothing
+    case updateAll
+    case updateData
+    case updateExpiry
+}
+
+fileprivate func generateGarbage(_ length: UInt32) -> String {
+    var stream = String()
+    let chars: String = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890!@#$%^&*()_{}[]|~` "
+    for _ in 0..<length {
+        stream.append(chars.randomElement()!)
+    }
+    return stream
 }

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -254,10 +254,10 @@ final class SessionTests: XCTestCase {
                                     actions[.destroy] = actions[.destroy]! + 1
                                 } else {
                                     actions[.updateAll] = actions[.updateAll]! + 1
-                                    // decrement internal update counter if session data was modified
-                                    if res.body.string.first! == "!" {
-                                        actions[.updateInternal] = actions[.updateInternal]! - 1
-                                    }
+                                }
+                                // decrement internal update counter if session data was modified
+                                if res.body.string.first! == "!" {
+                                    actions[.updateInternal] = actions[.updateInternal]! - 1
                                 }
                             }
                     }

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -196,7 +196,8 @@ final class SessionTests: XCTestCase {
         }
         
         while Date() < start + Double(d) {
-            let progress = ((Double(d) - (Date().distance(to: start))) / Double(d)) - 1.0
+            let interval = Date().timeIntervalSinceReferenceDate.distance(to: start.timeIntervalSinceReferenceDate)
+            let progress = ((Double(d) - interval) / Double(d)) - 1.0
             // Start with 20% of clients, pace remaining 80% up to roughly 70% progress
             let clientMax = min(Int(Double(c) * (0.2 + ((1.0/0.7) * progress))), Int(c)-1)
             var clientMin = 0


### PR DESCRIPTION
Improves control and performance of `Session`-enabled requests by allowing configuration of server-side session cookie expiration and update thresholds for cookies, and selectively setting cookies on `Requests` only when expiration time is updated.

### Methodology

`Sessions` has two additional specifiers added controlling the behavior of returning session cookies:

* `cookieLifetime`: lifetime in seconds of a cookie
* `cookieTTU`: time to update; the threshold past which a cookie's expiration will be updated while still valid.

![Cookie Lifespace](https://raw.githubusercontent.com/tdotclare/media/master/cookielifespan.jpg)

These controls can be configured in two ways; by explicitly initializing `SessionsConfiguration` with the values, and by inferred lifetime through the `cookieFactory`.

 `SessionsConfiguration` is initialized with following parameters:

```swift
cookieName: String,
cookieLifetime: UInt? = nil,
cookieTTU: UInt? = nil,
cookieFactory: @escaping (SessionID) -> HTTPCookies.Value
```

If the `cookieFactory` produces cookies with `expires` or `maxAge` set, `SessionsConfiguration` will enforce consistency if both are set, and implicitly use that value as `cookieLifetime` if not set.

If `cookieLifetime` is set in addition to the `cookieFactory`'s implicit lifetime, it can allow **longer** server-side storage of the session; eg, a client will receive a cookie with a 7 day lifetime, while the server can store it for 14 days. It *cannot* be set to a shorter lifetime than the cookie will give to the client.

If no `cookieTTU` value is configured, then every request will always set the cookie on response. If set, it determines the threshold at which the client will receive an updated cookie.

Ideal settings are best chosen based on the application's use profile, but even small thresholds can cut down on backend overhead. A 7 day `cookieLifetime` with a 1 hour `cookieTTU`, where a user's active requests to the platform create 5,000 requests over a 30 minute period, but mutates no session data, will never hit the session store to update beyond creating the initial session creation.

### Example Results

`SessionTests._benchmarkSessions` simulates the effects of a large set of clients which make requests over a period of time, each starting with no session.

Over the duration of the test, a random client is picked to make a request from a pool of available clients, starting from 20% of the total pool and scaling to using the entire pool once the test is about 70% completed. For any given request, the client has a 80% chance of being in the second half of the current pool size (simulating recent clients being more active), or of the entire current pool size. Additionally, when a client receives a response, it may decide to "sleep" past the point of the cookie expiring (but will be forced to wake up if the size of the available pool is too small.)

When the client makes a request, the server will always generate a random body of data to return, and if the session is new, store random session data to force creating a new session. If the session is an existing one, the server may decide to modify the session data during the request according to a mutation rate (default 10% chance).

Example of running the benchmark with 200 "clients" for 60 seconds, with `cookieLifetime` of 10 seconds and `cookieTTU` of 3 seconds,  and a 10% chance of mutated session data - single core on a 2014 4GHz 27" Retina iMac in Instruments, release build:

```
Completed 154877 requests:
  - 153179 (98.90%) needed no cookie return...
    - 14449 (9.33%) mutated session data inside TTU
    - 138730 (89.57%) had no session changes inside TTU
  - 1698 (1.10%) returned a cookie...
    - 392 (0.25%) from creating new sessions
    - 193 (0.12%) from destroying sessions
    - 1113 (0.72%) from refreshing past TTU but before lifetime
```

### Internal Changes

* `SessionsConfiguration` gains the above-mentioned intializer settings and safety checks on cookie settings

* `SessionData` splits the single data store into 

  * `storage`: data store settable by the Application user
  * `appStorage`: data store settable only internally (for securing internal use like `SessionAuthenticatable`)
  * `expiration`: expiration time of the session

  Property observers flag changes to the sections to allow conforming `SessionDriver` backends to selectively update; EG, for `DatabaseSessions` to only update the relevant field as in many cases, the update may be constrained to expiration or data only.

* `SessionDriver` adds `func deleteExpiredSessions(before: Date...)` to allow scheduling jobs to purge dead `Session` s from the storage (the `MemorySessions` implementation is not particularly performant and should be used with care)

* `SessionAuthenticatable` uses `Session.data.appStorage` instead of `.storage` for security
* New test case for benchmarking session performance