### PR TITLE
Add the new stable 5.2 runner images to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          # 5.2 Stable
           - swift:5.2-xenial
           - swift:5.2-bionic
+          - swift:5.2-focal
+          - swift:5.2-centos8
+          - swift:5.2-amazonlinux2
+          # 5.2 Unstable
           - swiftlang/swift:nightly-5.2-xenial
           - swiftlang/swift:nightly-5.2-bionic
+          # 5.3 Unstable
           - swiftlang/swift:nightly-5.3-xenial
           - swiftlang/swift:nightly-5.3-bionic
+          # Master Unstable
           - swiftlang/swift:nightly-master-xenial
           - swiftlang/swift:nightly-master-bionic
           - swiftlang/swift:nightly-master-focal


### PR DESCRIPTION
5.2.4 Docker images for Ubuntu Focal, CentOS 8, and Amazon Linux 2 are now available, so let's use 'em.