### PR TITLE
Rename CORSMiddleware allowable origins case

### DIFF
--- a/Sources/Vapor/Deprecations/CORSMiddleware+AllowOriginSetting.swift
+++ b/Sources/Vapor/Deprecations/CORSMiddleware+AllowOriginSetting.swift
@@ -1,0 +1,6 @@
+extension CORSMiddleware.AllowOriginSetting {
+    @available(*, deprecated, renamed: "any")
+    public static func whitelist(_ origins: [String]) -> Self {
+        .any(origins)
+    }
+}

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -9,7 +9,7 @@ public final class CORSMiddleware: Middleware {
     /// - none: Disallows any origin.
     /// - originBased: Uses value of the origin header in the request.
     /// - all: Uses wildcard to allow any origin.
-    /// - whitelist: Uses a whitelist of allowable origins.
+    /// - any: A list of allowable origins.
     /// - custom: Uses custom string provided as an associated value.
     public enum AllowOriginSetting {
         /// Disallow any origin.
@@ -21,8 +21,8 @@ public final class CORSMiddleware: Middleware {
         /// Uses wildcard to allow any origin.
         case all
         
-        // Uses a whitelist of allowable origins.
-        case whitelist([String])
+        /// A list of allowable origins.
+        case any([String])
 
         /// Uses custom string provided as an associated value.
         case custom(String)
@@ -36,7 +36,7 @@ public final class CORSMiddleware: Middleware {
             case .none: return ""
             case .originBased: return req.headers[.origin].first ?? ""
             case .all: return "*"
-            case .whitelist(let origins):
+            case .any(let origins):
                 guard let origin = req.headers[.origin].first else {
                     return ""
                 }


### PR DESCRIPTION
Renames `CORSMiddleware.AllowOriginSetting`'s list of allowable origins case to `.any` (#2397). 