### PR TITLE
Remove percent encoding when logging url path

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -36,7 +36,7 @@ internal struct DefaultResponder: Responder {
 
     /// See `Responder`
     public func respond(to request: Request) -> EventLoopFuture<Response> {
-        request.logger.info("\(request.method) \(request.url.path)")
+        request.logger.info("\(request.method) \(request.url.path.removingPercentEncoding ?? request.url.path)")
         let startTime = DispatchTime.now().uptimeNanoseconds
         let response: EventLoopFuture<Response>
         let path: String


### PR DESCRIPTION
## Remove percent encoding when logging url path (#2399)

The `DefaultResponder` now removes the percent encoding when logging the url request's path.

Previous log:
```
[ INFO ] GET /users/auth0%7C59abc/
```

After this change:
```
[ INFO ] GET /users/auth0|59abc/
```