### PR TITLE
Abort and StackTrace improvements 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,11 @@
-name: Test Matrix
-
+name: test
 on:
   pull_request:
   push:
     branches:
     - master
-    
 jobs:
-
-  Linux:
+  linux:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,13 +35,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
-
   macOS:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@1.0
-        with: { 'xcode-version': 'latest' }
+        with:
+          xcode-version: latest
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -3,7 +3,7 @@
 ///
 ///     throw Abort(.badRequest, reason: "Something's not quite right...")
 ///
-public struct Abort: AbortError {
+public struct Abort: AbortError, DebuggableError {
     /// Creates a redirecting `Abort` error.
     ///
     ///     throw Abort.redirect(to: "https://vapor.codes")"
@@ -28,9 +28,11 @@ public struct Abort: AbortError {
     /// See `AbortError`
     public var reason: String
 
-    /// Wrap this error's source location into a usable struct for
-    /// the `AbortError` protocol.
-    public var source: ErrorSource
+    /// Source location where this error was created.
+    public var source: ErrorSource?
+
+    /// Stack trace at point of error creation.
+    public var stackTrace: StackTrace?
 
     /// Create a new `Abort`, capturing current source location info.
     public init(
@@ -43,7 +45,8 @@ public struct Abort: AbortError {
         function: String = #function,
         line: UInt = #line,
         column: UInt = #column,
-        range: Range<UInt>? = nil
+        range: Range<UInt>? = nil,
+        stackTrace: StackTrace? = .capture()
     ) {
         self.identifier = identifier ?? status.code.description
         self.headers = headers
@@ -56,5 +59,6 @@ public struct Abort: AbortError {
             column: column,
             range: range
         )
+        self.stackTrace = stackTrace
     }
 }

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -46,7 +46,7 @@ public struct Abort: AbortError, DebuggableError {
         line: UInt = #line,
         column: UInt = #column,
         range: Range<UInt>? = nil,
-        stackTrace: StackTrace? = .capture()
+        stackTrace: StackTrace? = .capture(skip: 1)
     ) {
         self.identifier = identifier ?? status.code.description
         self.headers = headers

--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -1,3 +1,9 @@
+extension Optional where Wrapped == StackTrace {
+    public static func capture() -> Self {
+        StackTrace.capture()
+    }
+}
+
 public struct StackTrace {
     public static var isCaptureEnabled: Bool = true
 
@@ -43,8 +49,8 @@ public struct StackTrace {
     }
 
     public struct Frame {
-        var file: String
-        var function: String
+        public var file: String
+        public var function: String
     }
 
     let raw: [String]

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -132,15 +132,6 @@ final class ErrorTests: XCTestCase {
     }
 
     func testAbortDebuggable() throws {
-        func foo() throws {
-            try bar()
-        }
-        func bar() throws {
-            try baz()
-        }
-        func baz() throws {
-            throw Abort(.internalServerError, reason: "Oops")
-        }
         do {
             try foo()
         } catch let error as DebuggableError {
@@ -149,6 +140,16 @@ final class ErrorTests: XCTestCase {
             XCTAssertContains(error.stackTrace?.frames[3].function, "foo")
         }
     }
+}
+
+func foo() throws {
+    try bar()
+}
+func bar() throws {
+    try baz()
+}
+func baz() throws {
+    throw Abort(.internalServerError, reason: "Oops")
 }
 
 func XCTAssertContains(

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -132,24 +132,23 @@ final class ErrorTests: XCTestCase {
     }
 
     func testAbortDebuggable() throws {
+        func foo() throws {
+            try bar()
+        }
+        func bar() throws {
+            try baz()
+        }
+        func baz() throws {
+            throw Abort(.internalServerError, reason: "Oops")
+        }
         do {
             try foo()
         } catch let error as DebuggableError {
-            XCTAssertContains(error.stackTrace?.frames[1].function, "baz")
-            XCTAssertContains(error.stackTrace?.frames[2].function, "bar")
-            XCTAssertContains(error.stackTrace?.frames[3].function, "foo")
+            XCTAssertContains(error.stackTrace?.frames[0].function, "baz")
+            XCTAssertContains(error.stackTrace?.frames[1].function, "bar")
+            XCTAssertContains(error.stackTrace?.frames[2].function, "foo")
         }
     }
-}
-
-func foo() throws {
-    try bar()
-}
-func bar() throws {
-    try baz()
-}
-func baz() throws {
-    throw Abort(.internalServerError, reason: "Oops")
 }
 
 func XCTAssertContains(

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -130,6 +130,40 @@ final class ErrorTests: XCTestCase {
             XCTAssertEqual(abort.reason, "After decode")
         })
     }
+
+    func testAbortDebuggable() throws {
+        func foo() throws {
+            try bar()
+        }
+        func bar() throws {
+            try baz()
+        }
+        func baz() throws {
+            throw Abort(.internalServerError, reason: "Oops")
+        }
+        do {
+            try foo()
+        } catch let error as DebuggableError {
+            XCTAssertContains(error.stackTrace?.frames[1].function, "baz")
+            XCTAssertContains(error.stackTrace?.frames[2].function, "bar")
+            XCTAssertContains(error.stackTrace?.frames[3].function, "foo")
+        }
+    }
+}
+
+func XCTAssertContains(
+    _ haystack: String?,
+    _ needle: String,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+    guard let haystack = haystack else {
+        XCTFail("\(needle) not found in: nil", file: file, line: line)
+        return
+    }
+    if !haystack.contains(needle) {
+        XCTFail("\(needle) not found in: \(haystack)", file: file, line: line)
+    }
 }
 
 private struct Foo: Content {


### PR DESCRIPTION
### `Abort` now conforms to  `DebuggableError` (#2400).  

`Abort` now exposes `source`, `reason`, `identifier`, and `stackTrace` via the `DebuggableError` protocol. 

⚠️ `Abort.source` is now an optional as required by `DebuggableError`.

`Abort` now captures `StackTrace` by default. 

```swift
func foo() throws {
    try bar()
}
func bar() throws {
    try baz()
}
func baz() throws {
    throw Abort(.internalServerError, reason: "Oops")
}
do {
    try foo()
} catch let error as DebuggableError {
    XCTAssertContains(error.stackTrace?.frames[0].function, "baz")
    XCTAssertContains(error.stackTrace?.frames[1].function, "bar")
    XCTAssertContains(error.stackTrace?.frames[2].function, "foo")
}
```

To avoid capturing a stack trace, pass `nil`:

```swift
Abort(.internalServerError, reason: "Oops", stackTrace: nil)
```

To disable stack traces globally, use:

```swift
StackTrace.isCaptureEnabled = false
```

### Improved `StackTrace.capture` on Linux (#2400).

`StackTrace.capture` on Linux now utilizes `libbacktrace` to provide symbol names.

```
0 VaporTests baz #1 () throws -> () in VaporTests.ErrorTests.testAbortDebuggable() throws -> ()
1 VaporTests bar #1 () throws -> () in VaporTests.ErrorTests.testAbortDebuggable() throws -> ()
2 VaporTests foo #1 () throws -> () in VaporTests.ErrorTests.testAbortDebuggable() throws -> ()
3 VaporTests VaporTests.ErrorTests.testAbortDebuggable() throws -> ()
...
```

`StackFrame.capture` now accepts an optional `skip` parameter. Use this to exclude any extraneous stack frames from the captured result. 

```swift
// Captures stack trace, excluding this init call.
init(stackTrace: StackTrace? = .capture(skip: 1)) {
    ...
}
```