### PR TITLE
Add require(_:) extension to Parameters.

### DIFF
--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -12,9 +12,13 @@ public extension Parameters {
     /// Grabs the named parameter from the parameter bag, casting it to
     /// a `LosslessStringConvertible` type.
     /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
-    func require<T>(_ name: String, as type: T.Type = T.self, or error: Error = Abort(.unprocessableEntity)) throws -> T?
+    func require<T>(_ name: String, as type: T.Type = T.self, or error: Error = Abort(.unprocessableEntity)) throws -> T
         where T: LosslessStringConvertible
     {
-        try T.init(require(name, or: error))
+        guard let value = try T.init(require(name, or: error)) else {
+            throw error
+        }
+
+        return value
     }
 }

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -1,22 +1,29 @@
-public extension Parameters {
+extension Parameters {
     /// Grabs the named parameter from the parameter bag.
-    /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
-    func require(_ name: String, or error: Error = Abort(.unprocessableEntity)) throws -> String {
-        guard let value = get(name) else {
-            throw error
-        }
-
-        return value
+    /// If the parameter does not exist, `Abort(.internalServerError)` is thrown.
+    /// If the parameter value cannot be converted to `String`, `Abort(.unprocessableEntity)` is thrown.
+    ///
+    /// - parameters:
+    ///     - name: The name of the parameter.
+    public func require(_ name: String) throws -> String {
+        return try self.require(name, as: String.self)
     }
 
-    /// Grabs the named parameter from the parameter bag, casting it to
-    /// a `LosslessStringConvertible` type.
-    /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
-    func require<T>(_ name: String, as type: T.Type = T.self, or error: Error = Abort(.unprocessableEntity)) throws -> T
+    /// Grabs the named parameter from the parameter bag, casting it to a `LosslessStringConvertible` type.
+    /// If the parameter does not exist, `Abort(.internalServerError)` is thrown.
+    /// If the parameter value cannot be converted to the generic type, `Abort(.unprocessableEntity)` is thrown.
+    ///
+    /// - parameters:
+    ///     - name: The name of the parameter.
+    public func require<T>(_ name: String, as type: T.Type = T.self) throws -> T
         where T: LosslessStringConvertible
     {
-        guard let value = try T.init(require(name, or: error)) else {
-            throw error
+        guard let stringValue: String = get(name) else {
+            throw Abort(.internalServerError)
+        }
+
+        guard let value = T.init(stringValue) else {
+            throw Abort(.unprocessableEntity)
         }
 
         return value

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -11,10 +11,11 @@ extension Parameters {
 
     /// Grabs the named parameter from the parameter bag, casting it to a `LosslessStringConvertible` type.
     /// If the parameter does not exist, `Abort(.internalServerError)` is thrown.
-    /// If the parameter value cannot be converted to the generic type, `Abort(.unprocessableEntity)` is thrown.
+    /// If the parameter value cannot be converted to the required type, `Abort(.unprocessableEntity)` is thrown.
     ///
     /// - parameters:
     ///     - name: The name of the parameter.
+    ///     - type: The required parameter value type.
     public func require<T>(_ name: String, as type: T.Type = T.self) throws -> T
         where T: LosslessStringConvertible
     {

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -1,7 +1,7 @@
 public extension Parameters {
     /// Grabs the named parameter from the parameter bag.
     /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
-    func require(_ name: String, error: Error = Abort(.unprocessableEntity)) throws -> String {
+    func require(_ name: String, or error: Error = Abort(.unprocessableEntity)) throws -> String {
         guard let value = get(name) else {
             throw error
         }
@@ -12,9 +12,9 @@ public extension Parameters {
     /// Grabs the named parameter from the parameter bag, casting it to
     /// a `LosslessStringConvertible` type.
     /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
-    func require<T>(_ name: String, as type: T.Type = T.self, error: Error = Abort(.unprocessableEntity)) throws -> T?
+    func require<T>(_ name: String, as type: T.Type = T.self, or error: Error = Abort(.unprocessableEntity)) throws -> T?
         where T: LosslessStringConvertible
     {
-        try T.init(require(name, error: error))
+        try T.init(require(name, or: error))
     }
 }

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -1,0 +1,20 @@
+public extension Parameters {
+    /// Grabs the named parameter from the parameter bag.
+    /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
+    func require(_ name: String, error: Error = Abort(.unprocessableEntity)) throws -> String {
+        guard let value = get(name) else {
+            throw error
+        }
+
+        return value
+    }
+
+    /// Grabs the named parameter from the parameter bag, casting it to
+    /// a `LosslessStringConvertible` type.
+    /// An `Abort(.unprocessableEntity)` error is thrown if the parameter does not exist.
+    func require<T>(_ name: String, as type: T.Type = T.self, error: Error = Abort(.unprocessableEntity)) throws -> T?
+        where T: LosslessStringConvertible
+    {
+        try T.init(require(name, error: error))
+    }
+}

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -22,6 +22,28 @@ final class RouteTests: XCTestCase {
         }
     }
 
+    func testRequiredParameter() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.get("string", ":value") { req in
+            return try req.parameters.require("value")
+        }
+
+        app.routes.get("int", ":value") { req -> String in
+            let value = try req.parameters.require("value", as: Int.self) ?? 0
+            return String(value)
+        }
+
+        try app.testable().test(.GET, "/string/test") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, "test")
+        }.test(.GET, "/int/123") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "123")
+        }
+    }
+
     func testJSON() throws {
         let app = Application(.testing)
         defer { app.shutdown() }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -35,12 +35,18 @@ final class RouteTests: XCTestCase {
             return String(value)
         }
 
+        app.routes.get("missing") { req in
+            return try req.parameters.require("value")
+        }
+
         try app.testable().test(.GET, "/string/test") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertContains(res.body.string, "test")
         }.test(.GET, "/int/123") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "123")
+        }.test(.GET, "/missing") { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
         }
     }
 

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -31,7 +31,7 @@ final class RouteTests: XCTestCase {
         }
 
         app.routes.get("int", ":value") { req -> String in
-            let value = try req.parameters.require("value", as: Int.self) ?? 0
+            let value = try req.parameters.require("value", as: Int.self)
             return String(value)
         }
 
@@ -45,6 +45,8 @@ final class RouteTests: XCTestCase {
         }.test(.GET, "/int/123") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "123")
+        }.test(.GET, "/int/not-int") { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
         }.test(.GET, "/missing") { res in
             XCTAssertEqual(res.status, .unprocessableEntity)
         }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -48,7 +48,7 @@ final class RouteTests: XCTestCase {
         }.test(.GET, "/int/not-int") { res in
             XCTAssertEqual(res.status, .unprocessableEntity)
         }.test(.GET, "/missing") { res in
-            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertEqual(res.status, .internalServerError)
         }
     }
 


### PR DESCRIPTION
Adds a `require(_:)` helper to Parameters, allowing for more succinct parameter handling. (#2402)

Previously the optional case needed to be handled explicitly:

```swift
guard let name = req.parameters.get("name") else {
    throw Abort(.internalServerError)
}
```

Now it can be written as:

```swift
let name = try req.parameters.require("name")
```

