### PR TITLE
HTTP streaming improvements

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -336,7 +336,7 @@ final class HTTPServerErrorHandler: ChannelInboundHandler {
     }
 }
 
-private extension ChannelPipeline {
+extension ChannelPipeline {
     func addVaporHTTP2Handlers(
         application: Application,
         responder: Responder,

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -414,19 +414,19 @@ private extension ChannelPipeline {
         case .disabled:
             break
         }
-        
-        // add NIO -> HTTP request decoder
-        let serverReqDecoder = HTTPServerRequestDecoder(
-            application: application
-        )
-        handlers.append(serverReqDecoder)
-        
+
         // add NIO -> HTTP response encoder
         let serverResEncoder = HTTPServerResponseEncoder(
             serverHeader: configuration.serverName,
             dateCache: .eventLoop(self.eventLoop)
         )
         handlers.append(serverResEncoder)
+        
+        // add NIO -> HTTP request decoder
+        let serverReqDecoder = HTTPServerRequestDecoder(
+            application: application
+        )
+        handlers.append(serverReqDecoder)
         // add server request -> response delegate
         let handler = HTTPServerHandler(responder: responder)
 

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -13,22 +13,25 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let request = self.unwrapInboundIn(data)
         self.responder.respond(to: request).whenComplete { response in
-            if case .stream(let stream) = request.bodyStorage, !stream.isClosed {
-                // If streaming request body has not been closed yet,
-                // drain it before sending the response.
-                stream.read { (result, promise) in
-                    switch result {
-                    case .buffer: break
-                    case .end:
-                        self.serialize(response, for: request, context: context)
-                    case .error(let error):
-                        self.serialize(.failure(error), for: request, context: context)
-                    }
-                    promise?.succeed(())
-                }
-            } else {
+            #warning("TODO: handle should read input after response sent")
+//            print("responder: \(response)")
+//            if case .stream(let stream) = request.bodyStorage, !stream.isClosed {
+//                print("stream not closed!")
+//                // If streaming request body has not been closed yet,
+//                // drain it before sending the response.
+//                stream.read { (result, promise) in
+//                    switch result {
+//                    case .buffer: break
+//                    case .end:
+//                        self.serialize(response, for: request, context: context)
+//                    case .error(let error):
+//                        self.serialize(.failure(error), for: request, context: context)
+//                    }
+//                    promise?.succeed(())
+//                }
+//            } else {
                 self.serialize(response, for: request, context: context)
-            }
+//            }
         }
     }
 

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -13,25 +13,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let request = self.unwrapInboundIn(data)
         self.responder.respond(to: request).whenComplete { response in
-            #warning("TODO: handle should read input after response sent")
-//            print("responder: \(response)")
-//            if case .stream(let stream) = request.bodyStorage, !stream.isClosed {
-//                print("stream not closed!")
-//                // If streaming request body has not been closed yet,
-//                // drain it before sending the response.
-//                stream.read { (result, promise) in
-//                    switch result {
-//                    case .buffer: break
-//                    case .end:
-//                        self.serialize(response, for: request, context: context)
-//                    case .error(let error):
-//                        self.serialize(.failure(error), for: request, context: context)
-//                    }
-//                    promise?.succeed(())
-//                }
-//            } else {
-                self.serialize(response, for: request, context: context)
-//            }
+            self.serialize(response, for: request, context: context)
         }
     }
 

--- a/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
@@ -30,6 +30,8 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
         assert(context.channel.eventLoop.inEventLoop)
         let part = self.unwrapInboundIn(data)
         self.logger.trace("Decoded HTTP part: \(part)")
+        self.logger.trace("Request state: \(self.requestState)")
+        self.logger.trace("Body stream state: \(self.bodyStreamState)")
         switch part {
         case .head(let head):
             switch self.requestState {

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -30,7 +30,8 @@ extension Request {
             case .collected(let buffer):
                 _ = handler(.buffer(buffer))
                 _ = handler(.end)
-            case .none: break
+            case .none:
+                _ = handler(.end)
             }
         }
         

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -7,6 +7,10 @@ extension Request {
 
         let eventLoop: EventLoop
 
+        var isBeingRead: Bool {
+            self.handler != nil
+        }
+
         init(on eventLoop: EventLoop) {
             self.eventLoop = eventLoop
             self.isClosed = false

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -37,7 +37,7 @@ extension Response {
         }
         
         /// The size of the HTTP body's data.
-        /// `nil` is a stream.
+        /// `-1` is a chunked stream.
         public var count: Int {
             switch self.storage {
             case .data(let data): return data.count
@@ -146,6 +146,10 @@ extension Response {
         
         public init(stream: @escaping (BodyStreamWriter) -> (), count: Int) {
             self.storage = .stream(.init(count: count, callback: stream))
+        }
+
+        public init(stream: @escaping (BodyStreamWriter) -> ()) {
+            self.init(stream: stream, count: -1)
         }
         
         /// `ExpressibleByStringLiteral` conformance.

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -162,9 +162,17 @@ public final class Response: CustomStringConvertible {
 extension HTTPHeaders {
     mutating func updateContentLength(_ contentLength: Int) {
         let count = contentLength.description
-        self.remove(name: .transferEncoding)
-        if count != self[.contentLength].first {
-            self.replaceOrAdd(name: .contentLength, value: count)
+        switch contentLength {
+        case -1:
+            self.remove(name: .contentLength)
+            if "chunked" != self.first(name: .transferEncoding) {
+                self.add(name: .transferEncoding, value: "chunked")
+            }
+        default:
+            self.remove(name: .transferEncoding)
+            if count != self.first(name: .contentLength) {
+                self.replaceOrAdd(name: .contentLength, value: count)
+            }
         }
     }
 }

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -71,11 +71,7 @@ final class ClientTests: XCTestCase {
     }
     
     func testBoilerplateClient() throws {
-        let app = Application(.init(
-            name: "xctest",
-            arguments: ["vapor", "serve", "-b", "localhost:8080", "--log", "trace"]
-        ))
-        try LoggingSystem.bootstrap(from: &app.environment)
+        let app = Application(.testing)
         defer { app.shutdown() }
 
         app.get("foo") { req -> EventLoopFuture<String> in

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -28,22 +28,14 @@ final class PipelineTests: XCTestCase {
             configuration: app.http.server.configuration
         ).wait()
 
-        //
-        // First chunk.
-        //
         try channel.writeInbound(ByteBuffer(string: "POST /echo HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n1\r\na\r\n"))
         try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
 
-        //
-        // Second chunk.
-        //
         try channel.writeInbound(ByteBuffer(string: "1\r\nb\r\n"))
-        do {
-            let chunk = try channel.readOutbound(as: ByteBuffer.self)?.string
-            XCTAssertContains(chunk, "HTTP/1.1 200 OK")
-            XCTAssertContains(chunk, "connection: keep-alive")
-            XCTAssertContains(chunk, "transfer-encoding: chunked")
-        }
+        let chunk = try channel.readOutbound(as: ByteBuffer.self)?.string
+        XCTAssertContains(chunk, "HTTP/1.1 200 OK")
+        XCTAssertContains(chunk, "connection: keep-alive")
+        XCTAssertContains(chunk, "transfer-encoding: chunked")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "a")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
@@ -52,20 +44,48 @@ final class PipelineTests: XCTestCase {
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
         try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
 
-        //
-        // Third chunk.
-        //
         try channel.writeInbound(ByteBuffer(string: "1\r\nc\r\n"))
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "c")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
         try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
 
-        //
-        // Final chunk.
-        //
         try channel.writeInbound(ByteBuffer(string: "0\r\n\r\n"))
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "0\r\n\r\n")
         try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+    }
+
+    func testEOFFraming() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.on(.POST, "echo", body: .stream) { request -> Response in
+            Response(body: .init(stream: { writer in
+                request.body.drain { body in
+                    switch body {
+                    case .buffer(let buffer):
+                        return writer.write(.buffer(buffer))
+                    case .error(let error):
+                        return writer.write(.error(error))
+                    case .end:
+                        return writer.write(.end)
+                    }
+                }
+            }))
+        }
+
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addVaporHTTP1Handlers(
+            application: app,
+            responder: app.responder,
+            configuration: app.http.server.configuration
+        ).wait()
+
+        try channel.writeInbound(ByteBuffer(string: "POST /echo HTTP/1.1\r\n\r\n"))
+        try XCTAssertContains(channel.readOutbound(as: ByteBuffer.self)?.string, "HTTP/1.1 200 OK")
+    }
+
+    override class func setUp() {
+        XCTAssert(isLoggingConfigured)
     }
 }

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -1,0 +1,71 @@
+@testable import Vapor
+import XCTest
+
+final class PipelineTests: XCTestCase {
+    func testEchoHandlers() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.on(.POST, "echo", body: .stream) { request -> Response in
+            Response(body: .init(stream: { writer in
+                request.body.drain { body in
+                    switch body {
+                    case .buffer(let buffer):
+                        return writer.write(.buffer(buffer))
+                    case .error(let error):
+                        return writer.write(.error(error))
+                    case .end:
+                        return writer.write(.end)
+                    }
+                }
+            }))
+        }
+
+        let channel = EmbeddedChannel()
+        try channel.pipeline.addVaporHTTP1Handlers(
+            application: app,
+            responder: app.responder,
+            configuration: app.http.server.configuration
+        ).wait()
+
+        //
+        // First chunk.
+        //
+        try channel.writeInbound(ByteBuffer(string: "POST /echo HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n1\r\na\r\n"))
+        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+
+        //
+        // Second chunk.
+        //
+        try channel.writeInbound(ByteBuffer(string: "1\r\nb\r\n"))
+        do {
+            let chunk = try channel.readOutbound(as: ByteBuffer.self)?.string
+            XCTAssertContains(chunk, "HTTP/1.1 200 OK")
+            XCTAssertContains(chunk, "connection: keep-alive")
+            XCTAssertContains(chunk, "transfer-encoding: chunked")
+        }
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "a")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "b")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
+        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+
+        //
+        // Third chunk.
+        //
+        try channel.writeInbound(ByteBuffer(string: "1\r\nc\r\n"))
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "c")
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
+        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+
+        //
+        // Final chunk.
+        //
+        try channel.writeInbound(ByteBuffer(string: "0\r\n\r\n"))
+        try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "0\r\n\r\n")
+        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+    }
+}

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -218,6 +218,11 @@ final class ServerTests: XCTestCase {
 
         let context = Context()
 
+
+        app.on(.POST, "echo", body: .stream) { request in
+            "hello, world"
+        }
+
         app.on(.POST, "echo", body: .stream) { request -> Response in
             let r = Response(body: .init(stream: { writer in
                 request.body.drain { body in

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -218,7 +218,7 @@ final class ServerTests: XCTestCase {
         let context = Context()
 
         app.on(.POST, "echo", body: .stream) { request -> Response in
-            let r = Response(body: .init(stream: { writer in
+            Response(body: .init(stream: { writer in
                 request.body.drain { body in
                     switch body {
                     case .buffer(let buffer):
@@ -227,14 +227,10 @@ final class ServerTests: XCTestCase {
                     case .error(let error):
                         return writer.write(.error(error))
                     case .end:
-                        writer.write(.buffer(ByteBuffer(string: "")), promise: nil)
                         return writer.write(.end)
                     }
                 }
-            }, count: 0))
-            #warning("TODO: fix hack")
-            r.headers.remove(name: "content-length")
-            return r
+            }))
         }
 
         let port = 1337

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -233,6 +233,7 @@ final class ServerTests: XCTestCase {
                     }
                 }
             }, count: 0))
+            #warning("TODO: fix hack")
             r.headers.remove(name: "content-length")
             return r
         }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1,5 +1,6 @@
 import Vapor
 import XCTest
+import protocol AsyncHTTPClient.HTTPClientResponseDelegate
 
 final class ServerTests: XCTestCase {
     func testPortOverride() throws {
@@ -200,6 +201,93 @@ final class ServerTests: XCTestCase {
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
         })
+    }
+
+    func testEchoServer() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        final class Context {
+            var server: [String]
+            var client: [String]
+            init() {
+                self.server = []
+                self.client = []
+            }
+        }
+
+        let context = Context()
+
+        app.on(.POST, "echo", body: .stream) { request -> Response in
+            let r = Response(body: .init(stream: { writer in
+                request.body.drain { body in
+                    switch body {
+                    case .buffer(let buffer):
+                        context.server.append(buffer.string)
+                        return writer.write(.buffer(buffer))
+                    case .error(let error):
+                        return writer.write(.error(error))
+                    case .end:
+                        writer.write(.buffer(ByteBuffer(string: "")), promise: nil)
+                        return writer.write(.end)
+                    }
+                }
+            }, count: 0))
+            r.headers.remove(name: "content-length")
+            return r
+        }
+
+        let port = 1337
+        app.http.server.configuration.port = port
+        try app.start()
+
+        let request = try HTTPClient.Request(
+            url: "http://localhost:\(port)/echo",
+            method: .POST,
+            headers: [
+                "transfer-encoding": "chunked"
+            ],
+            body: .stream(length: nil, { stream in
+                stream.write(.byteBuffer(.init(string: "foo"))).flatMap {
+                    stream.write(.byteBuffer(.init(string: "bar")))
+                }.flatMap {
+                    stream.write(.byteBuffer(.init(string: "baz")))
+                }
+            })
+        )
+
+        final class ResponseDelegate: HTTPClientResponseDelegate {
+            typealias Response = HTTPClient.Response
+
+            let context: Context
+            init(context: Context) {
+                self.context = context
+            }
+
+            func didReceiveBodyPart(
+                task: HTTPClient.Task<HTTPClient.Response>,
+                _ buffer: ByteBuffer
+            ) -> EventLoopFuture<Void> {
+                self.context.client.append(buffer.string)
+                return task.eventLoop.makeSucceededFuture(())
+            }
+
+            func didFinishRequest(task: HTTPClient.Task<HTTPClient.Response>) throws -> HTTPClient.Response {
+                .init(host: "", status: .ok, headers: [:], body: nil)
+            }
+        }
+        let response = ResponseDelegate(context: context)
+        _ = try app.http.client.shared.execute(
+            request: request,
+            delegate: response
+        ).wait()
+
+        XCTAssertEqual(context.server, ["foo", "bar", "baz"])
+        XCTAssertEqual(context.client, ["foo", "bar", "baz"])
+    }
+
+    override class func setUp() {
+        XCTAssertTrue(isLoggingConfigured)
     }
 }
 

--- a/Tests/VaporTests/Utilities/TestLogging.swift
+++ b/Tests/VaporTests/Utilities/TestLogging.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Logging
+
+let isLoggingConfigured: Bool = {
+    LoggingSystem.bootstrap { label in
+        var handler = StreamLogHandler.standardOutput(label: label)
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
+        return handler
+    }
+    return true
+}()
+
+func env(_ name: String) -> String? {
+    ProcessInfo.processInfo.environment[name]
+}


### PR DESCRIPTION
Improves HTTP request and response streaming (#2404).

- Streaming request body skipping will only happen if the entire response has been sent before the user _starts_ reading the request body (fixes #2393).

> Note: Previously, streaming request bodies would be drained automatically by Vapor as soon as the response head was sent. This made it impossible to implement realtime streaming, like an echo server. With these changes, you have much more control over streaming HTTP while still preventing hanging if the request body is ignored entirely. 

- Response body stream now supports omitting the `count` parameter (fixes #2393).

> Note: Previously streaming bodies required a count and would always set the `content-length` header. Now, setting a count of `-1` indicates a stream with indeterminate length. `-1` will be used if the stream count is omitted. This results in `transfer-encoding: chunked` being used automatically. 

- Response writer provides a better error message if stream is never ended (fixes #2390).

- Fixes an issue causing EOF framing to result in promise leak (fixes #2391).

- Response streams with determinate length that write too few or too many bytes will now result in an error (fixes #2392).
