### PR TITLE
Fix #file usage for 5.3

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -104,7 +104,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = (#file),
+        file: StaticString = #file,
         line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) throws -> () = { _ in },
         afterResponse: (XCTHTTPResponse) throws -> () = { _ in }
@@ -120,7 +120,7 @@ extension XCTApplicationTester {
             let response = try self.performTest(request: request)
             try afterResponse(response)
         } catch {
-            XCTFail("\(error)", file: file, line: line)
+            XCTFail("\(error)", file: (file), line: line)
             throw error
         }
         return self

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -42,7 +42,7 @@ extension Response.Body {
 public func XCTAssertContent<D>(
     _ type: D.Type,
     _ res: XCTHTTPResponse,
-    file: StaticString = (#file),
+    file: StaticString = #file,
     line: UInt = #line,
     _ closure: (D) -> ()
 )
@@ -57,11 +57,12 @@ public func XCTAssertContent<D>(
         let content = try decoder.decode(D.self, from: res.body, headers: res.headers)
         closure(content)
     } catch {
-        XCTFail("could not decode body: \(error)", file: file, line: line)
+        XCTFail("could not decode body: \(error)", file: (file), line: line)
     }
 }
 
-public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: StaticString = (#file), line: UInt = #line) {
+public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: StaticString = #file, line: UInt = #line) {
+    let file = (file)
     switch (haystack, needle) {
     case (.some(let haystack), .some(let needle)):
         XCTAssert(haystack.contains(needle), "\(haystack) does not contain \(needle)", file: file, line: line)
@@ -74,7 +75,7 @@ public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: Stat
     }
 }
 
-public func XCTAssertEqualJSON<T>(_ data: String?, _ test: T, file: StaticString = (#file), line: UInt = #line)
+public func XCTAssertEqualJSON<T>(_ data: String?, _ test: T, file: StaticString = #file, line: UInt = #line)
     where T: Codable & Equatable
 {
     guard let data = data else {

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -154,9 +154,10 @@ final class ErrorTests: XCTestCase {
 func XCTAssertContains(
     _ haystack: String?,
     _ needle: String,
-    file: StaticString = (#file),
+    file: StaticString = #file,
     line: UInt = #line
 ) {
+    let file = (file)
     guard let haystack = haystack else {
         XCTFail("\(needle) not found in: nil", file: file, line: line)
         return

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -82,7 +82,7 @@ final class PasswordTests: XCTestCase {
     private func assertAsyncApplicationPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = (#file),
+        file: StaticString = #file,
         line: UInt = #line
     ) throws {
         app.passwords.use(provider)
@@ -97,13 +97,13 @@ final class PasswordTests: XCTestCase {
             .verify("vapor", created: asyncHash)
             .wait()
         
-        XCTAssertTrue(asyncVerifiy, file: file, line: line)
+        XCTAssertTrue(asyncVerifiy, file: (file), line: line)
     }
     
     private func assertAsyncRequestPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = (#file),
+        file: StaticString = #file,
         line: UInt = #line
     ) throws {
         app.passwords.use(provider)
@@ -122,7 +122,7 @@ final class PasswordTests: XCTestCase {
         }
         
         try app.test(.GET, "test", afterResponse: { res in
-            XCTAssertEqual(res.body.string, "true", file: file, line: line)
+            XCTAssertEqual(res.body.string, "true", file: (file), line: line)
         })
     }
 }

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -329,9 +329,10 @@ private func assert<T>(
     _ data: T,
     fails validator: Validator<T>,
     _ description: String,
-    file: StaticString = (#file),
+    file: StaticString = #file,
     line: UInt = #line
 ) {
+    let file = (file)
     let result = validator.validate(data)
     XCTAssert(result.isFailure, result.successDescription ?? "n/a", file: file, line: line)
     XCTAssertEqual(description, result.failureDescription ?? "n/a", file: file, line: line)
@@ -340,9 +341,10 @@ private func assert<T>(
 private func assert<T>(
     _ data: T,
     passes validator: Validator<T>,
-    file: StaticString = (#file),
+    file: StaticString = #file,
     line: UInt = #line
 ) {
+    let file = (file)
     let result = validator.validate(data)
     XCTAssert(!result.isFailure, result.failureDescription ?? "n/a", file: file, line: line)
 }


### PR DESCRIPTION
Fixes issue with previous `#file` warning fix in [4.10.1](https://github.com/vapor/vapor/releases/tag/4.10.1) that caused incorrect file paths to be passed (#2411).

Wrapping the default `#file` parameter in parentheses prevents it from forwarding to the call site. The parentheses must be added before passing to the methods accepting `#filePath`. 

See new discussion of [SE-0274](https://forums.swift.org/t/revisiting-the-source-compatibility-impact-of-se-0274-concise-magic-file-names/37720) for more information. 