### PR TITLE
Immediate body streaming

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -6,7 +6,7 @@ struct Creds: Content {
 }
 
 public func routes(_ app: Application) throws {
-    app.on(.GET, "ping", body: .stream) { req in
+    app.on(.POST, "ping") { req in
         return "123" as StaticString
     }
 

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -1,15 +1,14 @@
 extension Request {
     final class BodyStream: BodyStreamWriter {
-        typealias Handler = (BodyStreamResult, EventLoopPromise<Void>?) -> ()
-        private(set) var isClosed: Bool
-        private var handler: Handler?
-        private var buffer: [(BodyStreamResult, EventLoopPromise<Void>?)]
-
         let eventLoop: EventLoop
 
         var isBeingRead: Bool {
             self.handler != nil
         }
+
+        private(set) var isClosed: Bool
+        private var handler: ((BodyStreamResult, EventLoopPromise<Void>?) -> ())?
+        private var buffer: [(BodyStreamResult, EventLoopPromise<Void>?)]
 
         init(on eventLoop: EventLoop) {
             self.eventLoop = eventLoop
@@ -17,7 +16,7 @@ extension Request {
             self.buffer = []
         }
 
-        func read(_ handler: @escaping Handler) {
+        func read(_ handler: @escaping (BodyStreamResult, EventLoopPromise<Void>?) -> ()) {
             self.handler = handler
             for (result, promise) in self.buffer {
                 handler(result, promise)

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -29,9 +29,6 @@ final class PipelineTests: XCTestCase {
         ).wait()
 
         try channel.writeInbound(ByteBuffer(string: "POST /echo HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n1\r\na\r\n"))
-        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
-
-        try channel.writeInbound(ByteBuffer(string: "1\r\nb\r\n"))
         let chunk = try channel.readOutbound(as: ByteBuffer.self)?.string
         XCTAssertContains(chunk, "HTTP/1.1 200 OK")
         XCTAssertContains(chunk, "connection: keep-alive")
@@ -39,6 +36,9 @@ final class PipelineTests: XCTestCase {
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "a")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")
+        try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+
+        try channel.writeInbound(ByteBuffer(string: "1\r\nb\r\n"))
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "1\r\n")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "b")
         try XCTAssertEqual(channel.readOutbound(as: ByteBuffer.self)?.string, "\r\n")


### PR DESCRIPTION
Refactors HTTP request body decoding to immediately make streaming bodies available via `req.body.drain` (#2413). 

Previously, Vapor's HTTP request decoder would wait for a second body chunk to arrive before initiating body streaming. This was done as a performance optimization for single-chunk bodies since streaming has overhead. However, this behavior made it difficult to implement real time streaming handlers, like a ping/pong handler.

The HTTP request decoder has been updated to initiate body streaming immediately upon receiving the first chunk. To avoid impacting performance on small, non-streaming request bodies, a check for `content-length` has been added. If the request's body is contained entirely in a single chunk, streaming overhead is avoided.

Below are performance numbers on Ubuntu 20.04 in req/s. 

|Method|Body Strategy|Previous|New|Delta|
|-|-|-|-|-|
|`GET`|`.collect`|229979.85|229333.16|0.28%|
|`POST`|`.collect`|198949.90|196567.85|1.21%|
|`POST`|`.stream`|197916.54|196178.48|0.89%|

The numbers show a negligible change in performance. 