### PR TITLE
Rename arg & Fix doc comment of FileIO

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -59,11 +59,11 @@ public struct FileIO {
     ///     print(data) // file data
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     /// - returns: `Future` containing the file data.
-    public func collectFile(at file: String) -> EventLoopFuture<ByteBuffer> {
+    public func collectFile(at path: String) -> EventLoopFuture<ByteBuffer> {
         var data = self.allocator.buffer(capacity: 0)
-        return self.readFile(at: file) { new in
+        return self.readFile(at: path) { new in
             var new = new
             data.writeBuffer(&new)
             return self.request.eventLoop.makeSucceededFuture(())
@@ -77,7 +77,7 @@ public struct FileIO {
     ///     }.wait()
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     ///     - chunkSize: Maximum size for the file data chunks.
     ///     - onRead: Closure to be called sequentially for each file data chunk.
     /// - returns: `Future` that will complete when the file read is finished.
@@ -105,7 +105,7 @@ public struct FileIO {
     ///     }
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     ///     - req: `HTTPRequest` to parse `"If-None-Match"` header from.
     ///     - chunkSize: Maximum size for the file data chunks.
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.


### PR DESCRIPTION
Fixed documentation comments in FileIO.swift.
Also changed `collectFile(at file: String)` to `collectFile(at path: String)` to make it consistent with other methods.