### PR TITLE
Add FileIO.writeFile

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -195,7 +195,7 @@ public struct FileIO {
     /// - returns: `Future` that will complete when the file write is finished.
     public func write(to path: String, buffer: ByteBuffer) -> EventLoopFuture<Void> {
         do {
-            let fd = try NIOFileHandle.init(path: path, mode: .write, flags: .allowFileCreation())
+            let fd = try NIOFileHandle(path: path, mode: .write, flags: .allowFileCreation())
             let done = io.write(fileHandle: fd, buffer: buffer, eventLoop: self.request.eventLoop)
             done.whenComplete { _ in
                 try? fd.close()

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -186,4 +186,23 @@ public struct FileIO {
             return self.request.eventLoop.makeFailedFuture(error)
         }
     }
+    
+    /// Write the contents of buffer to a file at the supplied path.
+    ///
+    /// - parameters:
+    ///     - path: Path to file on the disk.
+    ///     - buffer: The `ByteBuffer` to write.
+    /// - returns: `Future` that will complete when the file write is finished.
+    public func write(to path: String, buffer: ByteBuffer) -> EventLoopFuture<Void> {
+        do {
+            let fd = try NIOFileHandle.init(path: path, mode: .write, flags: .allowFileCreation())
+            let done = io.write(fileHandle: fd, buffer: buffer, eventLoop: self.request.eventLoop)
+            done.whenComplete { _ in
+                try? fd.close()
+            }
+            return done
+        } catch {
+            return self.request.eventLoop.makeFailedFuture(error)
+        }
+    }
 }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -193,7 +193,7 @@ public struct FileIO {
     ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.
     /// - returns: `Future` that will complete when the file write is finished.
-    public func write(to path: String, buffer: ByteBuffer) -> EventLoopFuture<Void> {
+    public func writeFile(_ buffer: ByteBuffer, at path: String) -> EventLoopFuture<Void> {
         do {
             let fd = try NIOFileHandle(path: path, mode: .write, flags: .allowFileCreation())
             let done = io.write(fileHandle: fd, buffer: buffer, eventLoop: self.request.eventLoop)

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -189,6 +189,9 @@ public struct FileIO {
     
     /// Write the contents of buffer to a file at the supplied path.
     ///
+    ///     let data = ByteBuffer(string: "ByteBuffer")
+    ///     try req.fileio.writeFile(data, at: "/path/to/file.txt").wait()
+    ///
     /// - parameters:
     ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -39,16 +39,13 @@ final class FileTests: XCTestCase {
         
         let request = Request(application: app, on: app.eventLoopGroup.next())
         
-        let data = "Hello".data(using: .utf8)!
+        let data = "Hello"
         let path = "/tmp/fileio_write.txt"
         
-        try request.fileio.writeFile(ByteBuffer(data: data), at: path).wait()
+        try request.fileio.writeFile(ByteBuffer(string: data), at: path).wait()
         defer { try? FileManager.default.removeItem(atPath: path) }
         
-        let content = try request.fileio.collectFile(at: path).wait()
-        
-        let result = Data(content.readableBytesView)
-        
+        let result = try String(contentsOfFile: path)
         XCTAssertEqual(result, data)
     }
 

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -42,7 +42,7 @@ final class FileTests: XCTestCase {
         let data = "Hello".data(using: .utf8)!
         let path = "/tmp/fileio_write.txt"
         
-        try request.fileio.write(to: path, buffer: ByteBuffer(data: data)).wait()
+        try request.fileio.writeFile(ByteBuffer(data: data), at: path).wait()
         defer { try? FileManager.default.removeItem(atPath: path) }
         
         let content = try request.fileio.collectFile(at: path).wait()

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -32,6 +32,25 @@ final class FileTests: XCTestCase {
             XCTAssertContains(res.body.string, test)
         }
     }
+    
+    func testFileWrite() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        
+        let data = "Hello".data(using: .utf8)!
+        let path = "/tmp/fileio_write.txt"
+        
+        try request.fileio.write(to: path, buffer: ByteBuffer(data: data)).wait()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        
+        let content = try request.fileio.collectFile(at: path).wait()
+        
+        let result = Data(content.readableBytesView)
+        
+        XCTAssertEqual(result, data)
+    }
 
     func testPercentDecodedFilePath() throws {
         let app = Application(.testing)


### PR DESCRIPTION
Adds `writeFile` method to request's `FileIO` helper (#2418).

```swift
// Writes "hello" to /path/to/file.txt
// Returns a future indicating when the write has completed. 
req.fileio.writeFile(.init(string: "hello"), at: "/path/to/file.txt")
```