### PR TITLE
Add validate(query:) method to Validatable protocol

### DIFF
--- a/Sources/Vapor/Deprecations/Validatable+validate.swift
+++ b/Sources/Vapor/Deprecations/Validatable+validate.swift
@@ -1,0 +1,6 @@
+extension Validatable {
+    @available(*, deprecated, renamed: "validate(content:)")
+    public static func validate(_ request: Request) throws {
+        try self.validations().validate(request: request).assert()
+    }
+}

--- a/Sources/Vapor/Validation/Validatable.swift
+++ b/Sources/Vapor/Validation/Validatable.swift
@@ -17,6 +17,10 @@ extension Validatable {
         try self.validations().validate(request).assert()
     }
     
+    public static func validate(_ uri: URI) throws {
+        try self.validations().validate(uri).assert()
+    }
+    
     public static func validate(json: String) throws {
         try self.validations().validate(json: json).assert()
     }

--- a/Sources/Vapor/Validation/Validatable.swift
+++ b/Sources/Vapor/Validation/Validatable.swift
@@ -13,16 +13,20 @@ public protocol Validatable {
 }
 
 extension Validatable {
-    public static func validate(_ request: Request) throws {
-        try self.validations().validate(request).assert()
+    public static func validate(content request: Request) throws {
+        try self.validations().validate(request: request).assert()
     }
     
-    public static func validate(_ uri: URI) throws {
-        try self.validations().validate(uri).assert()
+    public static func validate(query request: Request) throws {
+        try self.validations().validate(query: request.url).assert()
     }
     
     public static func validate(json: String) throws {
         try self.validations().validate(json: json).assert()
+    }
+    
+    public static func validate(query: URI) throws {
+        try self.validations().validate(query: query).assert()
     }
     
     public static func validate(_ decoder: Decoder) throws {

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -34,7 +34,7 @@ public struct Validations {
         self.storage.append(validation)
     }
     
-    public func validate(_ request: Request) throws -> ValidationsResult {
+    public func validate(request: Request) throws -> ValidationsResult {
         guard let contentType = request.headers.contentType else {
             throw Abort(.unprocessableEntity)
         }
@@ -46,12 +46,10 @@ public struct Validations {
         return try self.validate(decoder.decoder)
     }
     
-    public func validate(_ uri: URI) throws -> ValidationsResult {
-        
+    public func validate(query: URI) throws -> ValidationsResult {
         let urlDecoder = try ContentConfiguration.global.requireURLDecoder()
-        let decoder = try urlDecoder.decode(DecoderUnwrapper.self, from: uri)
+        let decoder = try urlDecoder.decode(DecoderUnwrapper.self, from: query)
         return try self.validate(decoder.decoder)
-        
     }
     
     public func validate(json: String) throws -> ValidationsResult {

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -46,6 +46,14 @@ public struct Validations {
         return try self.validate(decoder.decoder)
     }
     
+    public func validate(_ uri: URI) throws -> ValidationsResult {
+        
+        let urlDecoder = try ContentConfiguration.global.requireURLDecoder()
+        let decoder = try urlDecoder.decode(DecoderUnwrapper.self, from: uri)
+        return try self.validate(decoder.decoder)
+        
+    }
+    
     public func validate(json: String) throws -> ValidationsResult {
         let decoder = try JSONDecoder().decode(DecoderUnwrapper.self, from: Data(json.utf8))
         return try self.validate(decoder.decoder)

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -150,7 +150,7 @@ final class RouteTests: XCTestCase {
         defer { app.shutdown() }
 
         app.post("users") { req -> User in
-            try User.validate(req)
+            try User.validate(content: req)
             return try req.content.decode(User.self)
         }
 

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -22,7 +22,7 @@ class ValidationTests: XCTestCase {
         """
         let validUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: valid))
-        XCTAssertNoThrow(try User.validate(validUrl))
+        XCTAssertNoThrow(try User.validate(query: validUrl))
         let invalidUser = """
         {
             "name": "Tan!ner",
@@ -45,7 +45,7 @@ class ValidationTests: XCTestCase {
                            "name contains '!' (allowed: A-Z, a-z, 0-9)")
             
         }
-        XCTAssertThrowsError(try User.validate(invalidUserUrl)) { error in
+        XCTAssertThrowsError(try User.validate(query: invalidUserUrl)) { error in
             XCTAssertEqual("\(error)",
                            "name contains '!' (allowed: A-Z, a-z, 0-9)")
         }
@@ -70,7 +70,7 @@ class ValidationTests: XCTestCase {
             XCTAssertEqual("\(error)",
                            "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
-        XCTAssertThrowsError(try User.validate(invalidPetURL)) { error in
+        XCTAssertThrowsError(try User.validate(query: invalidPetURL)) { error in
             XCTAssertEqual("\(error)",
                        "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
@@ -95,7 +95,7 @@ class ValidationTests: XCTestCase {
             XCTAssertEqual("\(error)",
                            "isAdmin is not a(n) Bool")
         }
-        XCTAssertThrowsError(try User.validate(invalidPetBool)) { error in
+        XCTAssertThrowsError(try User.validate(query: invalidPetBool)) { error in
             XCTAssertEqual("\(error)",
                        "isAdmin is not a(n) Bool")
         }
@@ -121,7 +121,7 @@ class ValidationTests: XCTestCase {
         """
         let validOptionalFavoritePetUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&favoritePet[name]=Zizek&favoritePet[age]=3&&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: validOptionalFavoritePet))
-        XCTAssertNoThrow(try User.validate(validOptionalFavoritePetUrl))
+        XCTAssertNoThrow(try User.validate(query: validOptionalFavoritePetUrl))
         let invalidOptionalFavoritePet = """
         {
             "name": "Tanner",
@@ -147,7 +147,7 @@ class ValidationTests: XCTestCase {
             XCTAssertEqual("\(error)",
                            "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
-        XCTAssertThrowsError(try User.validate(invalidOptionalFavoritePetUrl)) { error in
+        XCTAssertThrowsError(try User.validate(query: invalidOptionalFavoritePetUrl)) { error in
             XCTAssertEqual("\(error)",
                            "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
@@ -186,7 +186,7 @@ class ValidationTests: XCTestCase {
             XCTAssertEqual(character.invalidSlice, "!")
         }
         do {
-            try User.validate(invalidUserUrl)
+            try User.validate(query: invalidUserUrl)
         } catch let error as ValidationsError {
             XCTAssertEqual(error.failures.count, 1)
             let name = error.failures[0]

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -20,10 +20,7 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let validUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: valid))
-        XCTAssertNoThrow(try User.validate(validUrl))
-        
         let invalidUser = """
         {
             "name": "Tan!ner",
@@ -40,16 +37,10 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let invalidUserUrl: URI = "https://tanner.xyz/user?name=Tan!ner&age=24&gender=other&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidUser)) { error in
             XCTAssertEqual("\(error)",
                            "name contains '!' (allowed: A-Z, a-z, 0-9)")
         }
-        XCTAssertThrowsError(try User.validate(invalidUserUrl)) { error in
-            XCTAssertEqual("\(error)",
-                           "name contains '!' (allowed: A-Z, a-z, 0-9)")
-        }
-        
         let invalidPet = """
         {
             "name": "Tanner",
@@ -66,16 +57,10 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let invalidPetURL: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zi!ek&pet[age]=3&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidPet)) { error in
             XCTAssertEqual("\(error)",
                            "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
-        XCTAssertThrowsError(try User.validate(invalidPetURL)) { error in
-            XCTAssertEqual("\(error)",
-                       "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
-        }
-        
         let invalidBool = """
         {
             "name": "Tanner",
@@ -92,14 +77,9 @@ class ValidationTests: XCTestCase {
             "isAdmin": "true"
         }
         """
-        let invalidPetBool: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin='true'"
         XCTAssertThrowsError(try User.validate(json: invalidBool)) { error in
             XCTAssertEqual("\(error)",
                            "isAdmin is not a(n) Bool")
-        }
-        XCTAssertThrowsError(try User.validate(invalidPetBool)) { error in
-            XCTAssertEqual("\(error)",
-                       "isAdmin is not a(n) Bool")
         }
 
         let validOptionalFavoritePet = """
@@ -122,9 +102,7 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let validOptionalFavoritePetUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&favoritePet[name]=Zizek&favoritePet[age]=3&&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: validOptionalFavoritePet))
-        XCTAssertNoThrow(try User.validate(validOptionalFavoritePetUrl))
 
         let invalidOptionalFavoritePet = """
         {
@@ -146,12 +124,7 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let invalidOptionalFavoritePetUrl: URI = "https://tanner.xyz/model?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&favoritePet[name]=Zi!ek&favoritePet[age]=3&&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidOptionalFavoritePet)) { error in
-            XCTAssertEqual("\(error)",
-                           "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
-        }
-        XCTAssertThrowsError(try User.validate(invalidOptionalFavoritePetUrl)) { error in
             XCTAssertEqual("\(error)",
                            "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
@@ -174,23 +147,8 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
-        let invalidUserUrl: URI = "https://tanner.xyz/user?name=Tan!ner&age=24&gender=other&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         do {
             try User.validate(json: invalidUser)
-        } catch let error as ValidationsError {
-            XCTAssertEqual(error.failures.count, 1)
-            let name = error.failures[0]
-            XCTAssertEqual(name.key.stringValue, "name")
-            XCTAssertEqual(name.result.isFailure, true)
-            XCTAssertEqual(name.result.failureDescription, "contains '!' (allowed: A-Z, a-z, 0-9)")
-            let and = name.result as! ValidatorResults.And
-            let count = and.left as! ValidatorResults.Range<Int>
-            XCTAssertEqual(count.result, .greaterThanOrEqualToMin(5))
-            let character = and.right as! ValidatorResults.CharacterSet
-            XCTAssertEqual(character.invalidSlice, "!")
-        }
-        do {
-            try User.validate(invalidUserUrl)
         } catch let error as ValidationsError {
             XCTAssertEqual(error.failures.count, 1)
             let name = error.failures[0]

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -20,7 +20,10 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let validUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: valid))
+        XCTAssertNoThrow(try User.validate(validUrl))
+        
         let invalidUser = """
         {
             "name": "Tan!ner",
@@ -37,10 +40,16 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let invalidUserUrl: URI = "https://tanner.xyz/user?name=Tan!ner&age=24&gender=other&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidUser)) { error in
             XCTAssertEqual("\(error)",
                            "name contains '!' (allowed: A-Z, a-z, 0-9)")
         }
+        XCTAssertThrowsError(try User.validate(invalidUserUrl)) { error in
+            XCTAssertEqual("\(error)",
+                           "name contains '!' (allowed: A-Z, a-z, 0-9)")
+        }
+        
         let invalidPet = """
         {
             "name": "Tanner",
@@ -57,10 +66,16 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let invalidPetURL: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zi!ek&pet[age]=3&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidPet)) { error in
             XCTAssertEqual("\(error)",
                            "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
+        XCTAssertThrowsError(try User.validate(invalidPetURL)) { error in
+            XCTAssertEqual("\(error)",
+                       "pet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
+        }
+        
         let invalidBool = """
         {
             "name": "Tanner",
@@ -77,9 +92,14 @@ class ValidationTests: XCTestCase {
             "isAdmin": "true"
         }
         """
+        let invalidPetBool: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin='true'"
         XCTAssertThrowsError(try User.validate(json: invalidBool)) { error in
             XCTAssertEqual("\(error)",
                            "isAdmin is not a(n) Bool")
+        }
+        XCTAssertThrowsError(try User.validate(invalidPetBool)) { error in
+            XCTAssertEqual("\(error)",
+                       "isAdmin is not a(n) Bool")
         }
 
         let validOptionalFavoritePet = """
@@ -102,7 +122,9 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let validOptionalFavoritePetUrl: URI = "https://tanner.xyz/user?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&favoritePet[name]=Zizek&favoritePet[age]=3&&isAdmin=true"
         XCTAssertNoThrow(try User.validate(json: validOptionalFavoritePet))
+        XCTAssertNoThrow(try User.validate(validOptionalFavoritePetUrl))
 
         let invalidOptionalFavoritePet = """
         {
@@ -124,7 +146,12 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let invalidOptionalFavoritePetUrl: URI = "https://tanner.xyz/model?name=Tanner&age=24&gender=male&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&favoritePet[name]=Zi!ek&favoritePet[age]=3&&isAdmin=true"
         XCTAssertThrowsError(try User.validate(json: invalidOptionalFavoritePet)) { error in
+            XCTAssertEqual("\(error)",
+                           "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
+        }
+        XCTAssertThrowsError(try User.validate(invalidOptionalFavoritePetUrl)) { error in
             XCTAssertEqual("\(error)",
                            "favoritePet name contains '!' (allowed: whitespace, A-Z, a-z, 0-9)")
         }
@@ -147,8 +174,23 @@ class ValidationTests: XCTestCase {
             "isAdmin": true
         }
         """
+        let invalidUserUrl: URI = "https://tanner.xyz/user?name=Tan!ner&age=24&gender=other&email=me@tanner.xyz&luckyNumber=5&profilePictureURL=https://foo.jpg&preferredColors=[blue]&pet[name]=Zizek&pet[age]=3&isAdmin=true"
         do {
             try User.validate(json: invalidUser)
+        } catch let error as ValidationsError {
+            XCTAssertEqual(error.failures.count, 1)
+            let name = error.failures[0]
+            XCTAssertEqual(name.key.stringValue, "name")
+            XCTAssertEqual(name.result.isFailure, true)
+            XCTAssertEqual(name.result.failureDescription, "contains '!' (allowed: A-Z, a-z, 0-9)")
+            let and = name.result as! ValidatorResults.And
+            let count = and.left as! ValidatorResults.Range<Int>
+            XCTAssertEqual(count.result, .greaterThanOrEqualToMin(5))
+            let character = and.right as! ValidatorResults.CharacterSet
+            XCTAssertEqual(character.invalidSlice, "!")
+        }
+        do {
+            try User.validate(invalidUserUrl)
         } catch let error as ValidationsError {
             XCTAssertEqual(error.failures.count, 1)
             let name = error.failures[0]


### PR DESCRIPTION
Adds `validate(query:)` method to `Validatable` protocol for validating decoded query parameters (#2419). 

Previously, you could only validate the content that came from the request body. Now, this addition allows for validating decoded query parameters that conform to the Content protocol.

```swift
struct Hello: Content, Validatable {
    name: String?

    static func validations(_ validations: inout Validations) {
        validations.add("name", as: String.self, is: .alphanumeric)
    }
}
```

And the following URL, `http://localhost:8080/model?name=Vapor`, you can now validate the query parameter "name" as follows:

```swift
try Hello.validate(query: request)
let hello = try req.query.decode(Hello.self)
```

The existing content validation method `validate(_:)` has been renamed to `validate(content:)` to reduce ambiguity. 

```swift
try Hello.validate(content: request)
let hello = try req.content.decode(Hello.self)
```