### PR TITLE
Add non-variadic variants of RoutesBuilder group methods.

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+Group.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Group.swift
@@ -13,9 +13,24 @@ extension RoutesBuilder {
     ///     - path: Group path components separated by commas.
     /// - returns: Newly created `Router` wrapped in the path.
     public func grouped(_ path: PathComponent...) -> RoutesBuilder {
+        return self.grouped(path)
+    }
+
+    /// Creates a new `Router` that will automatically prepend the supplied path components.
+    ///
+    ///     let users = router.grouped("user")
+    ///     // Adding "user/auth/" route to router.
+    ///     users.get("auth") { ... }
+    ///     // adding "user/profile/" route to router
+    ///     users.get("profile") { ... }
+    ///
+    /// - parameters:
+    ///     - path: Array of group path components.
+    /// - returns: Newly created `Router` wrapped in the path.
+    public func grouped(_ path: [PathComponent]) -> RoutesBuilder {
         return HTTPRoutesGroup(root: self, path: path)
     }
-    
+
     /// Creates a new `Router` that will automatically prepend the supplied path components.
     ///
     ///     router.group("user") { users in
@@ -29,6 +44,22 @@ extension RoutesBuilder {
     ///     - path: Group path components separated by commas.
     ///     - configure: Closure to configure the newly created `Router`.
     public func group(_ path: PathComponent..., configure: (RoutesBuilder) throws -> ()) rethrows {
+        return try group(path, configure: configure)
+    }
+
+    /// Creates a new `Router` that will automatically prepend the supplied path components.
+    ///
+    ///     router.group("user") { users in
+    ///         // Adding "user/auth/" route to router.
+    ///         users.get("auth") { ... }
+    ///         // adding "user/profile/" route to router
+    ///         users.get("profile") { ... }
+    ///     }
+    ///
+    /// - parameters:
+    ///     - path: Array of group path components.
+    ///     - configure: Closure to configure the newly created `Router`.
+    public func group(_ path: [PathComponent], configure: (RoutesBuilder) throws -> ()) rethrows {
         try configure(HTTPRoutesGroup(root: self, path: path))
     }
 }

--- a/Sources/Vapor/Routing/RoutesBuilder+Group.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Group.swift
@@ -18,7 +18,7 @@ extension RoutesBuilder {
 
     /// Creates a new `Router` that will automatically prepend the supplied path components.
     ///
-    ///     let users = router.grouped("user")
+    ///     let users = router.grouped(["user"])
     ///     // Adding "user/auth/" route to router.
     ///     users.get("auth") { ... }
     ///     // adding "user/profile/" route to router
@@ -49,7 +49,7 @@ extension RoutesBuilder {
 
     /// Creates a new `Router` that will automatically prepend the supplied path components.
     ///
-    ///     router.group("user") { users in
+    ///     router.group(["user"]) { users in
     ///         // Adding "user/auth/" route to router.
     ///         users.get("auth") { ... }
     ///         // adding "user/profile/" route to router


### PR DESCRIPTION
This allows for route paths to be passed in as an array. (#2420)

```swift
routes.group(["users", ":userID"]) { lists in
    // ...
}
```