### PR TITLE
Change Request.Body drain method's handler parameter closure signature

### DIFF
--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -21,17 +21,17 @@ extension Request {
             }
         }
         
-        public func drain(_ handler: @escaping (BodyStreamResult) -> EventLoopFuture<Void>) {
+        public func drain(_ handler: @escaping (BodyStreamResult, EventLoopPromise<Void>?) -> Void) {
             switch self.request.bodyStorage {
             case .stream(let stream):
                 stream.read { (result, promise) in
-                    handler(result).cascade(to: promise)
+                    handler(result, promise)
                 }
             case .collected(let buffer):
-                _ = handler(.buffer(buffer))
-                _ = handler(.end)
+                _ = handler(.buffer(buffer), nil)
+                _ = handler(.end, nil)
             case .none:
-                _ = handler(.end)
+                _ = handler(.end, nil)
             }
         }
         


### PR DESCRIPTION
Attempt to make code at `Request.Body drain(:)` method call sites clearer by [changing its method signature](https://github.com/vapor/vapor/compare/master...sja26:request-body-drain-handler-signature-change?expand=1#diff-a174fb0755369930fa71cf521b8bfd4aL24-R24).

See the updated [route examples](https://github.com/vapor/vapor/compare/master...sja26:request-body-drain-handler-signature-change?expand=1#diff-5bb5bb8ce025ce58dca7f7fa77d3753eL20-L204), especially the last example that opens a file handle where I enabled error propagation (`try` instead of `try!`) when closing the file handle (lines [197](https://github.com/vapor/vapor/compare/master...sja26:request-body-drain-handler-signature-change?expand=1#diff-5bb5bb8ce025ce58dca7f7fa77d3753eR197) and [200](https://github.com/vapor/vapor/compare/master...sja26:request-body-drain-handler-signature-change?expand=1#diff-5bb5bb8ce025ce58dca7f7fa77d3753eR200)) **before** completing the top-level promise (see this Stack Overflow [answer](https://stackoverflow.com/a/8176030) as to why this is important).