### PR TITLE
Update body stream route example with error propagation

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -200,28 +200,23 @@ public func routes(_ app: Application) throws {
                         eventLoop: req.eventLoop
                     )
                 case .error(let drainError):
-                    var fileHandleError: Error?
                     do {
                         try fileHandle.close()
+                        promise.fail(BodyStreamWritingToDiskError.streamFailure(drainError))
                     } catch {
-                        fileHandleError = error
-                    }
-                    if let fileHandleError = fileHandleError {
                         promise.fail(BodyStreamWritingToDiskError.multipleFailures([
-                            .fileHandleClosedFailure(fileHandleError),
+                            .fileHandleClosedFailure(error),
                             .streamFailure(drainError)
                         ]))
-                    } else {
-                        promise.fail(BodyStreamWritingToDiskError.streamFailure(drainError))
                     }
                     return req.eventLoop.makeSucceededFuture(())
                 case .end:
                     do {
                         try fileHandle.close()
+                        promise.succeed(.ok)
                     } catch {
                         promise.fail(BodyStreamWritingToDiskError.fileHandleClosedFailure(error))
                     }
-                    promise.succeed(.ok)
                     return req.eventLoop.makeSucceededFuture(())
                 }
             }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -59,11 +59,11 @@ public struct FileIO {
     ///     print(data) // file data
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     /// - returns: `Future` containing the file data.
-    public func collectFile(at file: String) -> EventLoopFuture<ByteBuffer> {
+    public func collectFile(at path: String) -> EventLoopFuture<ByteBuffer> {
         var data = self.allocator.buffer(capacity: 0)
-        return self.readFile(at: file) { new in
+        return self.readFile(at: path) { new in
             var new = new
             data.writeBuffer(&new)
             return self.request.eventLoop.makeSucceededFuture(())
@@ -77,7 +77,7 @@ public struct FileIO {
     ///     }.wait()
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     ///     - chunkSize: Maximum size for the file data chunks.
     ///     - onRead: Closure to be called sequentially for each file data chunk.
     /// - returns: `Future` that will complete when the file read is finished.
@@ -105,7 +105,7 @@ public struct FileIO {
     ///     }
     ///
     /// - parameters:
-    ///     - file: Path to file on the disk.
+    ///     - path: Path to file on the disk.
     ///     - req: `HTTPRequest` to parse `"If-None-Match"` header from.
     ///     - chunkSize: Maximum size for the file data chunks.
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.


### PR DESCRIPTION
No loss of error information afforded by [recursive enumeration](https://docs.swift.org/swift-book/LanguageGuide/Enumerations.html#ID536) (see [line 185](https://github.com/vapor/vapor/compare/master...sja26:update-example-route-body-stream-fileio-write?expand=1#diff-5bb5bb8ce025ce58dca7f7fa77d3753eR185) and [lines 210-213](https://github.com/vapor/vapor/compare/master...sja26:update-example-route-body-stream-fileio-write?expand=1#diff-5bb5bb8ce025ce58dca7f7fa77d3753eR210-R213)).
