### PR TITLE
Percent-encoded brackets in query strings

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormError.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormError.swift
@@ -1,6 +1,6 @@
 /// Errors thrown while encoding/decoding `application/x-www-form-urlencoded` data.
 enum URLEncodedFormError: Error {
-    case malformedKey(key: String)
+    case malformedKey(key: Substring)
 }
 
 extension URLEncodedFormError: AbortError {

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -1,20 +1,13 @@
 /// Parses a URL Query `single=value&arr=1&arr=2&obj[key]=objValue` into
 internal struct URLEncodedFormParser {
-    let splitVariablesOn: Character
-    let splitKeyValueOn: Character
-    
-    /// Create a new form-urlencoded data parser.
-    init(splitVariablesOn: Character = "&", splitKeyValueOn: Character = "=") {
-        self.splitVariablesOn = splitVariablesOn
-        self.splitKeyValueOn = splitKeyValueOn
-    }
+    init() { }
     
     func parse(_ query: String) throws -> URLEncodedFormData {
         let plusDecodedQuery = query.replacingOccurrences(of: "+", with: "%20")
         var result: URLEncodedFormData = []
-        for pair in plusDecodedQuery.split(separator: splitVariablesOn) {
+        for pair in plusDecodedQuery.split(separator: "&") {
             let kv = pair.split(
-                separator: self.splitKeyValueOn,
+                separator: "=",
                 maxSplits: 1, // max 1, `foo=a=b` should be `"foo": "a=b"`
                 omittingEmptySubsequences: false
             )

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -29,19 +29,18 @@ internal struct URLEncodedFormParser {
 
     func parseKey(key: Substring) throws -> [String] {
         guard let percentDecodedKey = key.removingPercentEncoding else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unable to remove percent encoding for \(key)"))
+            throw URLEncodedFormError.malformedKey(key: key)
         }
-        var path = [String]()
-        for var element in percentDecodedKey.split(separator: "[") {
-            if path.count > 0 { //First one is not wrapped with `[]`
-                guard element.last == "]" else {
-                    throw URLEncodedFormError.malformedKey(key: .init(key))
+        return try percentDecodedKey.split(separator: "[").enumerated().map { (i, part) in 
+            switch i {
+            case 0:
+                return String(part)
+            default:
+                guard part.last == "]" else {
+                    throw URLEncodedFormError.malformedKey(key: key)
                 }
-                element = element.prefix(element.count-1) //Remove the `]`
+                return String(part.dropLast())
             }
-            path.append(String(element))
         }
-        return path
     }
 }
-

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormParser.swift
@@ -33,20 +33,20 @@ internal struct URLEncodedFormParser {
         }
         return result
     }
-    
+
     func parseKey(key: Substring) throws -> [String] {
+        guard let percentDecodedKey = key.removingPercentEncoding else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unable to remove percent encoding for \(key)"))
+        }
         var path = [String]()
-        for var element in key.split(separator: "[") {
+        for var element in percentDecodedKey.split(separator: "[") {
             if path.count > 0 { //First one is not wrapped with `[]`
                 guard element.last == "]" else {
                     throw URLEncodedFormError.malformedKey(key: .init(key))
                 }
                 element = element.prefix(element.count-1) //Remove the `]`
             }
-            guard let percentDecodedElement = element.removingPercentEncoding else {
-                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unable to remove percent encoding for \(element)"))
-            }
-            path.append(percentDecodedElement)
+            path.append(String(element))
         }
         return path
     }

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -505,7 +505,7 @@ final class URLEncodedFormTests: XCTestCase {
     func testPercentDecoding() throws {
         let data = "aaa%5B%5D=%2Bbbb%20+ccc&d[]=1&d[]=2"
         let form = try URLEncodedFormParser().parse(data)
-        XCTAssertEqual(form, ["aaa[]": "+bbb  ccc", "d": ["": ["1","2"]]])
+        XCTAssertEqual(form, ["aaa": ["": "+bbb  ccc"], "d": ["": ["1","2"]]])
     }
     
     func testNestedParsing() throws {


### PR DESCRIPTION
Adds support for percent-encoded brackets in query strings (fixes #2383, #2384, #2432). 

Percent-encoded square brackets are now parsed as array or dictionary delimiters in query strings. For example, both of the following query strings are now equivalent:

```
page[offset]=0&page[limit]=50
page%5Boffset%5D=0&page%5Blimit%5D=50
```

Both query strings can now be decoded by the following struct:
 
```swift
struct Info {
    struct Page {
        var offset: Int
        var limit: Int
    }
    let page: Page
}
```

Previously, the percent-encoded brackets were ignored during array and dictionary parsing. 

This change brings Vapor 4's behavior in line with Vapor 3 and [other frameworks](https://github.com/vapor/vapor/issues/2383#issuecomment-656864600). 