### PR TITLE
Fix misspelled property name of class Routes

### DIFF
--- a/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
+++ b/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
@@ -1,0 +1,12 @@
+extension Routes {
+    @available(*, deprecated, renamed: "caseInsensitive")
+    public var caseInsenstive: Bool {
+        get {
+            caseInsensitive
+        }
+        set {
+            caseInsensitive = newValue
+        }
+    }
+}
+

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -12,7 +12,7 @@ internal struct DefaultResponder: Responder {
 
     /// Creates a new `ApplicationResponder`
     public init(routes: Routes, middleware: [Middleware] = []) {
-        let options = routes.caseInsenstive ?
+        let options = routes.caseInsensitive ?
             Set(arrayLiteral: TrieRouter<CachedRoute>.ConfigurationOption.caseInsensitive) : []
         let router = TrieRouter(CachedRoute.self, options: options)
         

--- a/Sources/Vapor/Routing/Routes.swift
+++ b/Sources/Vapor/Routing/Routes.swift
@@ -5,7 +5,7 @@ public final class Routes: RoutesBuilder, CustomStringConvertible {
     public var defaultMaxBodySize: ByteCount
     /// Default routing behavior of `DefaultResponder` is case-sensitive; configure to `true` prior to
     /// Application start handle `Constant` `PathComponents` in a case-insensitive manner.
-    public var caseInsenstive: Bool
+    public var caseInsensitive: Bool
 
     public var description: String {
         return self.all.description
@@ -14,7 +14,7 @@ public final class Routes: RoutesBuilder, CustomStringConvertible {
     public init() {
         self.all = []
         self.defaultMaxBodySize = "16kb"
-        self.caseInsenstive = false
+        self.caseInsensitive = false
     }
 
     public func add(_ route: Route) {

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -91,7 +91,7 @@ final class RouteTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
         
-        app.routes.caseInsenstive = true
+        app.routes.caseInsensitive = true
         
         app.routes.get("foo") { req -> String in
             return "foo"


### PR DESCRIPTION
Fix misspelled property name of class `Routes`, change from `caseInsenstive` to `caseInsensitive` (#2435, fixes #2426).

The misspelled `caseInsenstive` is now marked as deprecated.