### PR TITLE
Add test timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        timeout-minutes: 15
+        timeout-minutes: 10
         run: swift test --enable-test-discovery --sanitize=thread
   macOS:
     runs-on: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
+        timeout-minutes: 15
         run: swift test --enable-test-discovery --sanitize=thread
   macOS:
     runs-on: macos-latest


### PR DESCRIPTION
Adds a 15 minute timeout to the Linux builds due to the `nightly` images sometimes failing.

Not sure if we could make this so only the nightly builds have the timeouts? CC @gwynne 