### PR TITLE
Header directive parameter quoting

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -177,7 +177,11 @@ extension HTTPHeaders {
                 for directive in directives {
                     let string: String
                     if let parameter = directive.parameter {
-                        string = "\(directive.value)=\(parameter)"
+                        if self.shouldQuote(parameter) {
+                            string = "\(directive.value)=\"\(parameter.escapingDoubleQuotes())\""
+                        } else {
+                            string = "\(directive.value)=\(parameter)"
+                        }
                     } else {
                         string = .init(directive.value)
                     }
@@ -188,19 +192,30 @@ extension HTTPHeaders {
 
             return main.joined(separator: ", ")
         }
+
+        private func shouldQuote(_ parameter: Substring) -> Bool {
+            parameter.contains(where: { 
+                $0 == .space || $0 == .doubleQuote
+            })
+        }
     }
 }
 
 private extension Substring {
     /// Converts all `\"` to `"`.
     func unescapingDoubleQuotes() -> Substring {
-        return self.lazy.split(separator: "\\").reduce(into: "") { (result, part) in
+        self.lazy.split(separator: "\\").reduce(into: "") { (result, part) in
             if result.isEmpty || part.first == "\"" {
                 result += part
             } else {
                 result += "\\" + part
             }
         }
+    }
+
+    /// Converts all `"` to `\"`.
+    func escapingDoubleQuotes() -> String {
+        self.split(separator: "\"").joined(separator: "\\\"")
     }
 }
 
@@ -226,6 +241,9 @@ private extension Character {
     }
     static var period: Self {
         .init(".")
+    }
+    static var space: Self {
+        .init(" ")
     }
 
     var isDirectiveKey: Bool {

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -1,7 +1,7 @@
 @testable import Vapor
 import XCTest
 
-final class HTTPHeaderValueTests: XCTestCase {
+final class HTTPHeaderTests: XCTestCase {
     func testValue() throws {
         var parser = HTTPHeaders.DirectiveParser(string: "foobar")
         XCTAssertEqual(parser.nextDirectives(), [.init(value: "foobar")])
@@ -195,5 +195,16 @@ final class HTTPHeaderValueTests: XCTestCase {
         let lower = HTTPMediaType(type: "foo", subType: "bar")
         let upper = HTTPMediaType(type: "foo", subType: "BAR")
         XCTAssertEqual(lower, upper)
+    }
+
+    // https://github.com/vapor/vapor/issues/2439
+    func testContentDispositionQuotedFilename() throws {
+        var headers = HTTPHeaders()
+        headers.contentDisposition = .init(.formData, filename: "foo")
+        XCTAssertEqual(headers.first(name: .contentDisposition), "form-data; filename=foo")
+        headers.contentDisposition = .init(.formData, filename: "foo bar")
+        XCTAssertEqual(headers.first(name: .contentDisposition), #"form-data; filename="foo bar""#)
+        headers.contentDisposition = .init(.formData, filename: "foo\"bar")
+        XCTAssertEqual(headers.first(name: .contentDisposition), #"form-data; filename="foo\"bar""#)
     }
 }


### PR DESCRIPTION
Adds support for quoting HTTP header value directive parameters containing unsupported characters (#2411, fixes #2439). 

For example:

```diff
- content-disposition: form-data; filename=foo bar
+ content-disposition: form-data; filename="foo bar"
```