### PR TITLE
Add support for string interpolation to URI

### DIFF
--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -1,6 +1,6 @@
 import CURLParser
 
-public struct URI: ExpressibleByStringLiteral, CustomStringConvertible {
+public struct URI: ExpressibleByStringInterpolation, CustomStringConvertible {
     public var string: String
 
     public init(string: String = "/") {

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -49,5 +49,14 @@ final class RequestTests: XCTestCase {
             XCTAssertEqual(uri.host, nil)
             XCTAssertEqual(uri.path, "")
         }
+        do {
+            let uri: URI = "/foo/bar/baz"
+            XCTAssertEqual(uri.path, "/foo/bar/baz")
+        }
+        do {
+            let foo = "foo"
+            let uri: URI = "/\(foo)/bar/baz"
+            XCTAssertEqual(uri.path, "/foo/bar/baz")
+        }
     }
 }


### PR DESCRIPTION
Enables call sites that use URIs to allow for string literals that make use of interpolation (#2442).

```swift
app.get("hello") { req -> EventLoopFuture<String> in
    return req.client.get("\(Constants.basePath)/status")
    .flatMapThrowing { res throws in
        return "Hello, world!"
    }
}
```