### PR TITLE
Add webSocket route overload with array path

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -17,6 +17,15 @@ extension RoutesBuilder {
         maxFrameSize: WebSocketMaxFrameSize = .`default`,
         onUpgrade: @escaping (Request, WebSocket) -> ()
     ) -> Route {
+        return self.webSocket(path, maxFrameSize: maxFrameSize, onUpgrade: onUpgrade)
+    }
+
+    @discardableResult
+    public func webSocket(
+        _ path: [PathComponent],
+        maxFrameSize: WebSocketMaxFrameSize = .`default`,
+        onUpgrade: @escaping (Request, WebSocket) -> ()
+    ) -> Route {
         return self.on(.GET, path) { request -> Response in
             let res = Response(status: .switchingProtocols)
             res.upgrader = .webSocket(maxFrameSize: maxFrameSize, onUpgrade: { ws in


### PR DESCRIPTION
Adds a `webSocket` route overload that accepts an array instead of variadic path (#2445, #2434).

```swift
app.webSocket(["foo", "bar"]) { req, ws in 
    // Handle WebSocket client.
}
```
