### PR TITLE
Fix array out of bounds error in StackTrace

### DIFF
--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -84,7 +84,7 @@ public struct StackTrace {
     let rawFrames: [RawFrame]
 
     public func description(max: Int = 16) -> String {
-        return self.frames[...min(self.frames.count, max)].readable
+        return self.frames[..<min(self.frames.count, max)].readable
     }
 }
 


### PR DESCRIPTION
Fixes an array out of bounds error in `StackTrace.description(max:)` (#2447). 