### PR TITLE
Allow setting hostname for testable application

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -7,11 +7,13 @@ extension Application: XCTApplicationTester {
 extension Application {
     public enum Method {
         case inMemory
-        case running(port: Int)
-        case runningWith(hostname: String, port: Int)
         public static var running: Method {
-            return .runningWith(hostname:"localhost", port: 8080)
+            return .running(hostname:"localhost", port: 8080)
         }
+        public static func running(port: Int) -> Self {
+            .running(hostname: "localhost", port: port)
+        }
+        case running(hostname: String, port: Int)
     }
 
     public func testable(method: Method = .inMemory) throws -> XCTApplicationTester {
@@ -19,9 +21,7 @@ extension Application {
         switch method {
         case .inMemory:
             return try InMemory(app: self)
-        case .running(let port):
-            return try Live(app: self, port: port)
-        case let .runningWith(hostname, port):
+        case let .running(hostname, port):
             return try Live(app: self, hostname: hostname, port: port)
         }
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -11,20 +11,19 @@ final class RequestTests: XCTestCase {
         }
         
         let ipV4Hostname = "127.0.0.1"
-        try app.testable(method: .runningWith(hostname: ipV4Hostname,
-                                              port: 8080)).test(.GET, "vapor/is/fun") { res in
-                                                XCTAssertContains(res.body.string, ipV4Hostname)
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "vapor/is/fun") { res in
+            XCTAssertEqual(res.body.string, ipV4Hostname)
         }
     }
     
     func testRequestRemoteAddress() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-
+        
         app.get("remote") {
             $0.remoteAddress?.description ?? "n/a"
         }
-
+        
         try app.testable(method: .running).test(.GET, "remote") { res in
             XCTAssertContains(res.body.string, "IP")
         }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -1,6 +1,22 @@
 import XCTVapor
 
 final class RequestTests: XCTestCase {
+    
+    func testCustomHostAdress() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        app.get("vapor", "is", "fun") {
+            return $0.remoteAddress?.hostname ?? "n/a"
+        }
+        
+        let ipV4Hostname = "127.0.0.1"
+        try app.testable(method: .runningWith(hostname: ipV4Hostname,
+                                              port: 8080)).test(.GET, "vapor/is/fun") { res in
+                                                XCTAssertContains(res.body.string, ipV4Hostname)
+        }
+    }
+    
     func testRequestRemoteAddress() throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
Adds `.running(hostname: String, port: Int)` method to allow configure testable application hostname (#2448). 

```swift

try app.testable(method: .running(hostname: "127.0.0.1", port: 8080))

```