### PR TITLE
Fix decodeNil in URLEncodedFormDecoder's single value decoder

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -404,7 +404,7 @@ private struct _Decoder: Decoder {
         }
         
         func decodeNil() -> Bool {
-            return false
+            self.data.values.isEmpty
         }
         
         func decode<T>(_ type: T.Type) throws -> T where T: Decodable {

--- a/Sources/Vapor/Utilities/BasicCodingKey.swift
+++ b/Sources/Vapor/Utilities/BasicCodingKey.swift
@@ -67,3 +67,25 @@ public enum BasicCodingKey: CodingKey {
         self.init(codingKeyRepresentable.codingKey)
     }
 }
+
+extension BasicCodingKey: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .index(let index):
+            return index.description
+        case .key(let key):
+            return key.description
+        }
+    }
+}
+
+extension BasicCodingKey: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .index(let index):
+            return index.description
+        case .key(let key):
+            return key.debugDescription
+        }
+    }
+}

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -272,4 +272,29 @@ final class QueryTests: XCTestCase {
         let b = try URLEncodedFormDecoder().decode(Test.self, from: query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         XCTAssertEqual(a, b)
     }
+
+    func testOptionalGet() throws {
+        let app = Application()
+        defer { app.shutdown() }
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/"),
+            on: app.eventLoopGroup.next()
+        )
+        do {
+            req.url = .init(path: "/foo?bar=baz")
+            let page = try req.query.get(Int?.self, at: "page")
+            XCTAssertEqual(page, nil)
+        }
+        do {
+            req.url = .init(path: "/foo?bar=baz&page=1")
+            let page = try req.query.get(Int?.self, at: "page")
+            XCTAssertEqual(page, 1)
+        }
+        do {
+            req.url = .init(path: "/foo?bar=baz&page=a")
+            XCTAssertThrowsError(try req.query.get(Int?.self, at: "page"))
+        }
+    }
 }


### PR DESCRIPTION
Fixes an issue causing `URLEncodedFormDecoder`'s single value decoder to not detect `nil` correctly (#2463, fixes #2460). 

This could result in `req.query.get` throwing an error instead of returning `nil` if the key was missing.

```swift
// This code will now return `nil` instead of throwing if the key is missing.
// It will still throw an error if the value cannot be converted to an Int. 
let page = try req.query.get(Int?.self, at: "page")
```