### PR TITLE
Bump SwiftNIO version to 2.18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
         
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),


### PR DESCRIPTION
As noted in #2466  - the docs refer to a ByteBuffer convenience initialiser, which is not implemented in SwiftNIO until version 2.18