### PR TITLE
Update dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.2.0"),
     
         // Sugary extensions for the SwiftNIO library
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.11.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.13.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
         
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
@@ -64,13 +64,13 @@ final class HTTPServerRequestDecoder: ChannelInboundHandler, RemovableChannelHan
                 } else {
                     let stream = Request.BodyStream(on: context.eventLoop)
                     request.bodyStorage = .stream(stream)
+                    self.requestState = .streamingBody(stream)
                     context.fireChannelRead(self.wrapInboundOut(request))
                     self.handleBodyStreamStateResult(
                         context: context,
                         self.bodyStreamState.didReadBytes(buffer),
                         stream: stream
                     )
-                    self.requestState = .streamingBody(stream)
                 }
             case .streamingBody(let stream):
                 self.handleBodyStreamStateResult(
@@ -196,6 +196,23 @@ final class HTTPServerRequestDecoder: ChannelInboundHandler, RemovableChannelHan
             case .ready, .skipping:
                 // Response ended after request had been read.
                 break
+            }
+        }
+    }
+}
+
+extension HTTPPart: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .head(let head):
+            return "head: \(head)"
+        case .body(let body):
+            return "body: \(body)"
+        case .end(let headers):
+            if let headers = headers {
+                return "end: \(headers)"
+            } else {
+                return "end"
             }
         }
     }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -269,7 +269,7 @@ final class ServerTests: XCTestCase {
             }
 
             func didFinishRequest(task: HTTPClient.Task<HTTPClient.Response>) throws -> HTTPClient.Response {
-                .init(host: "", status: .ok, headers: [:], body: nil)
+                .init(host: "", status: .ok, version: .init(major: 1, minor: 1), headers: [:], body: nil)
             }
         }
         let response = ResponseDelegate(context: context)


### PR DESCRIPTION
Updates to swift-nio 2.18, async-http-client 1.2, and swift-nio-http2 1.13 (#2470, #2467, fixes #2466). 

- Fixes any usages of deprecated methods. 
- Fixes a reentrancy bug causing "body stream deinit before closing" assertion that popped up in tests with latest dependencies. 
- Makes trace logs from the HTTP decoder more concise.