### PR TITLE
Server shutdown improvements

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
@@ -1,0 +1,29 @@
+extension HTTPHeaders {
+    public struct Connection: ExpressibleByStringLiteral, Equatable {
+        public static let close: Self = "close"
+        public static let keepAlive: Self = "keep-alive"
+
+        public let value: String
+
+        public init(value: String) {
+            self.value = value
+        }
+
+        public init(stringLiteral value: String) {
+            self.init(value: value)
+        }
+    }
+
+    public var connection: Connection? {
+        get {
+            self.first(name: .connection).flatMap(Connection.init(value:))
+        }
+        set {
+            if let value = newValue {
+                self.replaceOrAdd(name: .connection, value: value.value)
+            } else {
+                self.remove(name: .connection)
+            }
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -361,7 +361,7 @@ extension ChannelPipeline {
         handlers.append(serverResEncoder)
         
         // add server request -> response delegate
-        let handler = HTTPServerHandler(responder: responder)
+        let handler = HTTPServerHandler(responder: responder, logger: application.logger)
         handlers.append(handler)
         
         return self.addHandlers(handlers).flatMap {
@@ -426,7 +426,7 @@ extension ChannelPipeline {
         )
         handlers.append(serverReqDecoder)
         // add server request -> response delegate
-        let handler = HTTPServerHandler(responder: responder)
+        let handler = HTTPServerHandler(responder: responder, logger: application.logger)
 
         // add HTTP upgrade handler
         let upgrader = HTTPServerUpgradeHandler(

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -76,4 +76,84 @@ final class WebSocketTests: XCTestCase {
 
         try XCTAssertEqual(promise.futureResult.wait(), "foo")
     }
+
+    func testLifecycleShutdown() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.port = 1337
+
+        final class WebSocketManager: LifecycleHandler {
+            private let lock: Lock
+            private var connections: Set<WebSocket>
+
+            init() {
+                self.lock = .init()
+                self.connections = .init()
+            }
+
+            func track(_ ws: WebSocket) {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                self.connections.insert(ws)
+                ws.onClose.whenComplete { _ in
+                    self.lock.lock()
+                    defer { self.lock.unlock() }
+                    self.connections.remove(ws)
+                }
+            }
+
+            func broadcast(_ message: String) {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                for ws in self.connections {
+                    ws.send(message)
+                }
+            }
+
+            /// Closes all active WebSocket connections
+            func shutdown(_ app: Application) {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                app.logger.debug("Shutting down \(self.connections.count) WebSocket(s)")
+                try! EventLoopFuture<Void>.andAllSucceed(
+                    self.connections.map { $0.close() } ,
+                    on: app.eventLoopGroup.next()
+                ).wait()
+            }
+        }
+
+        let webSockets = WebSocketManager()
+        app.lifecycle.use(webSockets)
+
+        app.webSocket("watcher") { req, ws in
+            webSockets.track(ws)
+            ws.send("hello")
+        }
+
+        try app.start()
+
+        let clientGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try! clientGroup.syncShutdownGracefully() }
+        let connectPromise = app.eventLoopGroup.next().makePromise(of: WebSocket.self)
+        WebSocket.connect(to: "ws://localhost:1337/watcher", on: clientGroup) { ws in
+            connectPromise.succeed(ws)
+        }.cascadeFailure(to: connectPromise)
+
+        let ws = try connectPromise.futureResult.wait()
+        app.shutdown()
+        try ws.onClose.wait()
+    }
+
+    override class func setUp() {
+        XCTAssertTrue(isLoggingConfigured)
+    }
+}
+
+extension WebSocket: Hashable {
+    public static func == (lhs: WebSocket, rhs: WebSocket) -> Bool {
+        lhs === rhs
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        ObjectIdentifier(self).hash(into: &hasher)
+    }
 }


### PR DESCRIPTION
Adds support for gracefully shutting down in-flight requests and idle keep-alive connections (#2472, fixes #2451). 

- In-flight requests will no longer respect `connection: keep-alive` after server shutdown is initiated. 
- Idle keep-alive connections will now be closed once server shutdown is initiated. 
- Adds new `HTTPHeaders` helper for working with [`connection`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection) header.

```swift
// Change to 'connection: close'.
if req.headers.connection == .keepAlive {
    req.headers.connection = .close
}
```