### PR TITLE
Fix crash related to setting nil hostname and port

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -20,7 +20,7 @@ public final class HTTPServer: Server {
         public static let defaultHostname = "127.0.0.1"
         public static let defaultPort = 8080
         
-        /// Address the server will bind to.
+        /// Address the server will bind to. Configuring an address using a hostname with a nil host or port will use the default hostname or port respectively.
         public var address: BindAddress
         
         /// Host name the server will bind to.
@@ -255,7 +255,7 @@ public final class HTTPServer: Server {
         let addressDescription: String
         switch configuration.address {
         case .hostname(let hostname, let port):
-            addressDescription = "\(scheme)://\(hostname!):\(port!)" // will never be nil because we set them above to non-optional values
+            addressDescription = "\(scheme)://\(hostname ?? configuration.hostname):\(port ?? configuration.port)"
         case .unixDomainSocket(let socketPath):
             addressDescription = "\(scheme)+unix: \(socketPath)"
         }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -543,6 +543,30 @@ final class ServerTests: XCTestCase {
 
         XCTAssertThrowsError(try app.start())
     }
+
+    func testStartWithDefaultHostnameConfiguration() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.address = .hostname(nil, port: nil)
+        defer { app.shutdown() }
+
+        XCTAssertNoThrow(try app.start())
+    }
+
+    func testStartWithDefaultHostname() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.address = .hostname(nil, port: 8008)
+        defer { app.shutdown() }
+
+        XCTAssertNoThrow(try app.start())
+    }
+
+    func testStartWithDefaultPort() throws {
+        let app = Application(.testing)
+        app.http.server.configuration.address = .hostname("0.0.0.0", port: nil)
+        defer { app.shutdown() }
+        
+        XCTAssertNoThrow(try app.start())
+    }
     
     func testAddressConfigurations() throws {
         var configuration = HTTPServer.Configuration()


### PR DESCRIPTION
Fixes a crash that could occur if the configuration configures a hostname address with a nil host or port, and the server is started according to the default configuration (#2479, fixes #2478).

The doc comment for `HTTPServer.Configuration.address` also clarifies the usage of having a nil host or port when using a `.hostname`-based address.