### PR TITLE
Fix Swift 5.3 trailing closure warnings

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -74,9 +74,9 @@ final class ApplicationTests: XCTestCase {
             throw Foo()
         }
 
-        try app.testable().test(.GET, "/error") { res in
+        try app.testable().test(.GET, "/error", afterResponse: { res in
             XCTAssertEqual(res.status, .internalServerError)
-        }
+        })
     }
 
     func testAsyncKitExport() throws {

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -29,13 +29,13 @@ final class AuthenticationTests: XCTestCase {
             return try req.auth.require(Test.self).name
         }
 
-        try app.testable().test(.GET, "/test") { res in
+        try app.testable().test(.GET, "/test", afterResponse: { res in
             XCTAssertEqual(res.status, .unauthorized)
-        }
-        .test(.GET, "/test", headers: ["Authorization": "Bearer test"]) { res in
+        })
+        .test(.GET, "/test", headers: ["Authorization": "Bearer test"], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
-        }
+        })
     }
 
     func testBasicAuthenticator() throws {
@@ -69,12 +69,12 @@ final class AuthenticationTests: XCTestCase {
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-        try app.testable().test(.GET, "/test") { res in
+        try app.testable().test(.GET, "/test", afterResponse: { res in
             XCTAssertEqual(res.status, .unauthorized)
-        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+        }).test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
-        }
+        })
     }
     
     func testBasicAuthenticatorWithRedirect() throws {
@@ -112,13 +112,13 @@ final class AuthenticationTests: XCTestCase {
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-        try app.testable().test(.GET, "/test") { res in
+        try app.testable().test(.GET, "/test", afterResponse: { res in
             XCTAssertEqual(res.status, .seeOther)
             XCTAssertEqual(res.headers["Location"].first, "/redirect?orig=/test")
-        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+        }).test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
-        }
+        })
     }
 
     func testSessionAuthentication() throws {
@@ -170,10 +170,10 @@ final class AuthenticationTests: XCTestCase {
         }
 
         var sessionCookie: HTTPCookies.Value?
-        try app.testable().test(.GET, "/test") { res in
+        try app.testable().test(.GET, "/test", afterResponse: { res in
             XCTAssertEqual(res.status, .unauthorized)
             XCTAssertNil(res.headers.first(name: .setCookie))
-        }.test(.GET, "/test", headers: ["Authorization": "Bearer test"]) { res in
+        }).test(.GET, "/test", headers: ["Authorization": "Bearer test"], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
             if let cookie = res.headers.setCookie?["vapor-session"] {
@@ -181,12 +181,12 @@ final class AuthenticationTests: XCTestCase {
             } else {
                 XCTFail("No set cookie header")
             }
-        }
-        .test(.GET, "/test", headers: ["Cookie": sessionCookie!.serialize(name: "vapor-session")]) { res in
+        })
+        .test(.GET, "/test", headers: ["Cookie": sessionCookie!.serialize(name: "vapor-session")], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
             XCTAssertNotNil(res.headers.first(name: .setCookie))
-        }
+        })
     }
 
     func testMiddlewareConfigExistential() {
@@ -248,11 +248,11 @@ final class AuthenticationTests: XCTestCase {
         }
 
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-        try app.testable().test(.GET, "/test") { res in
+        try app.testable().test(.GET, "/test", afterResponse: { res in
             XCTAssertEqual(res.status, .unauthorized)
-        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+        }).test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"], afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
-        }
+        })
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -73,10 +73,10 @@ final class ContentTests: XCTestCase {
             return foo.name
         }
 
-        try app.testable().test(.GET, "/decode_error") { res in
+        try app.testable().test(.GET, "/decode_error", afterResponse: { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "Value of type 'Int' required for key 'bar'")
-        }
+        })
     }
 
     func testContentContainer() throws {
@@ -98,10 +98,10 @@ final class ContentTests: XCTestCase {
             return res
         }
 
-        try app.testable().test(.GET, "/encode") { res in
+        try app.testable().test(.GET, "/encode", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertContains(res.body.string, "hi")
-        }
+        })
     }
 
     func testMultipartDecode() throws {
@@ -144,10 +144,10 @@ final class ContentTests: XCTestCase {
 
         try app.testable().test(.GET, "/multipart", headers: [
             "Content-Type": "multipart/form-data; boundary=123"
-        ], body: .init(string: data)) { res in
+        ], body: .init(string: data), afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqualJSON(res.body.string, expected)
-        }
+        })
     }
 
     func testMultipartEncode() throws {
@@ -168,14 +168,14 @@ final class ContentTests: XCTestCase {
                 image: File(data: "<contents of image>", filename: "droplet.png")
             )
         }
-        try app.testable().test(.GET, "/multipart") { res in
+        try app.testable().test(.GET, "/multipart", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             let boundary = res.headers.contentType?.parameters["boundary"] ?? "none"
             XCTAssertContains(res.body.string, "Content-Disposition: form-data; name=\"name\"")
             XCTAssertContains(res.body.string, "--\(boundary)")
             XCTAssertContains(res.body.string, "filename=droplet.png")
             XCTAssertContains(res.body.string, "name=\"image\"")
-        }
+        })
     }
 
     func testURLEncodedFormDecode() throws {
@@ -201,9 +201,9 @@ final class ContentTests: XCTestCase {
         var body = ByteBufferAllocator().buffer(capacity: 0)
         body.writeString("name=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]=7")
 
-        try app.testable().test(.GET, "/urlencodedform", headers: headers, body: body) { res in
+        try app.testable().test(.GET, "/urlencodedform", headers: headers, body: body, afterResponse: { res in
             XCTAssertEqual(res.status.code, 200)
-        }
+        })
     }
 
     func testURLEncodedFormEncode() throws {
@@ -220,7 +220,7 @@ final class ContentTests: XCTestCase {
         app.get("urlencodedform") { req -> User in
             return User(name: "Vapor", age: 3, luckyNumbers: [5, 7])
         }
-        try app.testable().test(.GET, "/urlencodedform") { res in
+        try app.testable().test(.GET, "/urlencodedform", afterResponse: { res in
             debugPrint(res)
             XCTAssertEqual(res.status.code, 200)
             XCTAssertEqual(res.headers.contentType, .urlEncodedForm)
@@ -228,7 +228,7 @@ final class ContentTests: XCTestCase {
             XCTAssertContains(res.body.string, "luckyNumbers[]=7")
             XCTAssertContains(res.body.string, "age=3")
             XCTAssertContains(res.body.string, "name=Vapor")
-        }
+        })
     }
 
     func testJSONPreservesHTTPHeaders() throws {

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -114,11 +114,11 @@ final class ErrorTests: XCTestCase {
             var reason: String
         }
 
-        try app.test(.GET, "foo") { res in
+        try app.test(.GET, "foo", afterResponse: { res in
             XCTAssertEqual(res.status, .internalServerError)
             let abort = try res.content.decode(AbortResponse.self)
             XCTAssertEqual(abort.reason, "Foo")
-        }.test(.POST, "foo", beforeRequest: { req in
+        }).test(.POST, "foo", beforeRequest: { req in
             try req.content.encode(Foo(bar: 42))
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .internalServerError)

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -9,11 +9,11 @@ final class FileTests: XCTestCase {
             return req.fileio.streamFile(at: #file)
         }
 
-        try app.testable(method: .running).test(.GET, "/file-stream") { res in
+        try app.testable(method: .running).test(.GET, "/file-stream", afterResponse: { res in
             let test = "the quick brown fox"
             XCTAssertNotNil(res.headers.first(name: .eTag))
             XCTAssertContains(res.body.string, test)
-        }
+        })
     }
 
     func testStreamFileConnectionClose() throws {
@@ -26,11 +26,11 @@ final class FileTests: XCTestCase {
 
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .connection, value: "close")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers, afterResponse: { res in
             let test = "the quick brown fox"
             XCTAssertNotNil(res.headers.first(name: .eTag))
             XCTAssertContains(res.body.string, test)
-        }
+        })
     }
     
     func testFileWrite() throws {
@@ -56,9 +56,9 @@ final class FileTests: XCTestCase {
         let path = #file.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
-        try app.test(.GET, "/Utilities/foo%20bar.html") { res in
+        try app.test(.GET, "/Utilities/foo%20bar.html", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "<h1>Hello</h1>\n")
-        }
+        })
     }
 }

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -11,9 +11,9 @@ final class LoggingTests: XCTestCase {
             return "done"
         }
 
-        try app.testable().test(.GET, "trace") { res in
+        try app.testable().test(.GET, "trace", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "done")
-        }
+        })
     }
 }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -23,10 +23,10 @@ final class MiddlewareTests: XCTestCase {
             return "done"
         }
 
-        try app.testable().test(.GET, "/order") { res in
+        try app.testable().test(.GET, "/order", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(OrderMiddleware.order, ["a", "b", "c"])
             XCTAssertEqual(res.body.string, "done")
-        }
+        })
     }
 }

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -118,10 +118,10 @@ final class QueryTests: XCTestCase {
             return "hi"
         }
 
-        try app.testable().test(.GET, "/todos?a=b") { res in
+        try app.testable().test(.GET, "/todos?a=b", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "hi")
-        }
+        })
     }
 
     func testURLEncodedFormDecodeQuery() throws {
@@ -151,9 +151,9 @@ final class QueryTests: XCTestCase {
         }
 
         let data = "name=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]=7&pet[name]=Fido&pet[age]=3"
-        try app.testable().test(.GET, "/urlencodedform?\(data)") { res in
+        try app.testable().test(.GET, "/urlencodedform?\(data)", afterResponse: { res in
             XCTAssertEqual(res.status.code, 200)
-        }
+        })
     }
 
     func testURLPercentEncodedFormDecodeQuery() throws {
@@ -184,9 +184,9 @@ final class QueryTests: XCTestCase {
         }
 
         let data = "name=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]=7&pet[name]=Fido&pet[age]=3".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        try app.testable().test(.GET, "/urlencodedform?\(data)") { res in
+        try app.testable().test(.GET, "/urlencodedform?\(data)", afterResponse: { res in
             XCTAssertEqual(res.status.code, 200)
-        }
+        })
     }
 
     func testCustomEncode() throws {
@@ -201,13 +201,13 @@ final class QueryTests: XCTestCase {
             return res
         }
 
-        try app.testable().test(.GET, "/custom-encode") { res in
+        try app.testable().test(.GET, "/custom-encode", afterResponse: { res in
             XCTAssertEqual(res.body.string, """
             {
               "hello" : "world"
             }
             """)
-        }
+        })
     }
 
     // https://github.com/vapor/vapor/issues/1609
@@ -231,10 +231,10 @@ final class QueryTests: XCTestCase {
         headers.replaceOrAdd(name: .contentLength, value: body.readableBytes.description)
         headers.contentType = .json
 
-        try app.testable().test(.POST, "/decode-fail", headers: headers, body: body) { res in
+        try app.testable().test(.POST, "/decode-fail", headers: headers, body: body, afterResponse: { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "missing")
-        }
+        })
     }
 
     // https://github.com/vapor/vapor/issues/1687

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -11,9 +11,9 @@ final class RequestTests: XCTestCase {
         }
         
         let ipV4Hostname = "127.0.0.1"
-        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "vapor/is/fun") { res in
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "vapor/is/fun", afterResponse: { res in
             XCTAssertEqual(res.body.string, ipV4Hostname)
-        }
+        })
     }
     
     func testRequestRemoteAddress() throws {
@@ -24,9 +24,9 @@ final class RequestTests: XCTestCase {
             $0.remoteAddress?.description ?? "n/a"
         }
         
-        try app.testable(method: .running).test(.GET, "remote") { res in
+        try app.testable(method: .running).test(.GET, "remote", afterResponse: { res in
             XCTAssertContains(res.body.string, "IP")
-        }
+        })
     }
 
     func testURI() throws {

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -11,15 +11,15 @@ final class RouteTests: XCTestCase {
         app.routes.get("hello", ":a", ":b") { req in
             return [req.parameters.get("a") ?? "", req.parameters.get("b") ?? ""]
         }
-        try app.testable().test(.GET, "/hello/vapor") { res in
+        try app.testable().test(.GET, "/hello/vapor", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertContains(res.body.string, "vapor")
-        }.test(.POST, "/hello/vapor") { res in
+        }).test(.POST, "/hello/vapor", afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
-        }.test(.GET, "/hello/vapor/development") { res in
+        }).test(.GET, "/hello/vapor/development", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, #"["vapor","development"]"#)
-        }
+        })
     }
 
     func testRequiredParameter() throws {
@@ -39,17 +39,17 @@ final class RouteTests: XCTestCase {
             return try req.parameters.require("value")
         }
 
-        try app.testable().test(.GET, "/string/test") { res in
+        try app.testable().test(.GET, "/string/test", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertContains(res.body.string, "test")
-        }.test(.GET, "/int/123") { res in
+        }).test(.GET, "/int/123", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "123")
-        }.test(.GET, "/int/not-int") { res in
+        }).test(.GET, "/int/not-int", afterResponse: { res in
             XCTAssertEqual(res.status, .unprocessableEntity)
-        }.test(.GET, "/missing") { res in
+        }).test(.GET, "/missing", afterResponse: { res in
             XCTAssertEqual(res.status, .internalServerError)
-        }
+        })
     }
 
     func testJSON() throws {
@@ -61,10 +61,10 @@ final class RouteTests: XCTestCase {
             return ["foo": "bar"]
         }
 
-        try app.testable().test(.GET, "/json") { res in
+        try app.testable().test(.GET, "/json", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, #"{"foo":"bar"}"#)
-        }
+        })
     }
 
     func testRootGet() throws {
@@ -78,13 +78,13 @@ final class RouteTests: XCTestCase {
             return "foo"
         }
 
-        try app.testable().test(.GET, "/") { res in
+        try app.testable().test(.GET, "/", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "root")
-        }.test(.GET, "/foo") { res in
+        }).test(.GET, "/foo", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "foo")
-        }
+        })
     }
     
     func testInsensitiveRoutes() throws {
@@ -97,13 +97,13 @@ final class RouteTests: XCTestCase {
             return "foo"
         }
 
-        try app.testable().test(.GET, "/foo") { res in
+        try app.testable().test(.GET, "/foo", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "foo")
-        }.test(.GET, "/FOO") { res in
+        }).test(.GET, "/FOO", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "foo")
-        }
+        })
     }
 
     func testAnyResponse() throws {
@@ -157,13 +157,13 @@ final class RouteTests: XCTestCase {
             }
         }
 
-        try app.testable().test(.GET, "/foo?number=true") { res in
+        try app.testable().test(.GET, "/foo?number=true", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "42")
-        }.test(.GET, "/foo?number=false") { res in
+        }).test(.GET, "/foo?number=false", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "string")
-        }
+        })
     }
 
     func testValidationError() throws {
@@ -229,11 +229,11 @@ final class RouteTests: XCTestCase {
             return "hi"
         }
 
-        try app.testable(method: .running).test(.HEAD, "/hello") { res in
+        try app.testable(method: .running).test(.HEAD, "/hello", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.headers.first(name: .contentLength), "2")
             XCTAssertEqual(res.body.readableBytes, 0)
-        }
+        })
     }
 
     func testInvalidCookie() throws {
@@ -249,11 +249,11 @@ final class RouteTests: XCTestCase {
         var cookies = HTTPCookies()
         cookies["vapor-session"] = "asdf"
         headers.cookie = cookies
-        try app.testable().test(.GET, "/get", headers: headers) { res in
+        try app.testable().test(.GET, "/get", headers: headers, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertNotNil(res.headers[.setCookie])
             XCTAssertEqual(res.body.string, "n/a")
-        }
+        })
     }
 
     // https://github.com/vapor/vapor/issues/1787
@@ -265,10 +265,10 @@ final class RouteTests: XCTestCase {
             throw Abort(.noContent)
         }
 
-        try app.testable(method: .running).test(.GET, "/no-content") { res in
+        try app.testable(method: .running).test(.GET, "/no-content", afterResponse: { res in
             XCTAssertEqual(res.status.code, 204)
             XCTAssertEqual(res.body.readableBytes, 0)
-        }
+        })
     }
 
     func testSimilarRoutingPath() throws {
@@ -282,15 +282,15 @@ final class RouteTests: XCTestCase {
             "b"
         }
 
-        try app.testable(method: .running).test(.GET, "/api/addresses/") { res in
+        try app.testable(method: .running).test(.GET, "/api/addresses/", afterResponse: { res in
             XCTAssertEqual(res.body.string, "a")
-        }.test(.GET, "/api/addresses/search/test") { res in
+        }).test(.GET, "/api/addresses/search/test", afterResponse: { res in
             XCTAssertEqual(res.body.string, "b")
-        }.test(.GET, "/api/addresses/search/") { res in
+        }).test(.GET, "/api/addresses/search/", afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
-        }.test(.GET, "/api/addresses/search") { res in
+        }).test(.GET, "/api/addresses/search", afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
-        }
+        })
     }
 
     func testThrowingGroup() throws {
@@ -313,9 +313,9 @@ final class RouteTests: XCTestCase {
         defer { app.shutdown() }
         try app.register(collection: Foo())
 
-        try app.test(.GET, "foo") { res in
+        try app.test(.GET, "foo", afterResponse: { res in
             XCTAssertEqual(res.body.string, "bar")
-        }
+        })
     }
 
     func testConfigurableMaxBodySize() throws {
@@ -341,14 +341,14 @@ final class RouteTests: XCTestCase {
 
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeBytes(Array(repeating: 0, count: 500_000))
-        try app.testable(method: .running).test(.POST, "/default", body: buffer) { res in
+        try app.testable(method: .running).test(.POST, "/default", body: buffer, afterResponse: { res in
             XCTAssertEqual(res.status, .payloadTooLarge)
-        }.test(.POST, "/1kb", body: buffer) { res in
+        }).test(.POST, "/1kb", body: buffer, afterResponse: { res in
             XCTAssertEqual(res.status, .payloadTooLarge)
-        }.test(.POST, "/1mb", body: buffer) { res in
+        }).test(.POST, "/1mb", body: buffer, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-        }.test(.POST, "/1gb", body: buffer) { res in
+        }).test(.POST, "/1gb", body: buffer, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-        }
+        })
     }
 }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -268,10 +268,10 @@ final class ServerTests: XCTestCase {
             return "123"
         }
 
-        try app.testable().test(.GET, "/ping") { res in
+        try app.testable().test(.GET, "/ping", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "123")
-        }
+        })
     }
 
     func testCustomServer() throws {
@@ -308,9 +308,9 @@ final class ServerTests: XCTestCase {
 
         var buffer = ByteBufferAllocator().buffer(capacity: payload.count)
         buffer.writeBytes(payload)
-        try app.testable(method: .running).test(.POST, "payload", body: buffer) { res in
+        try app.testable(method: .running).test(.POST, "payload", body: buffer, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-        }
+        })
     }
 
     func testCollectedResponseBodyEnd() throws {
@@ -350,9 +350,9 @@ final class ServerTests: XCTestCase {
             return try req.content.decode(User.self)
         }
 
-        try app.testable().test(.GET, "/user") { res in
+        try app.testable().test(.GET, "/user", afterResponse: { res in
             XCTAssertEqual(res.status, .unsupportedMediaType)
-        }
+        })
     }
 
     // https://github.com/vapor/vapor/issues/2245

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -9,10 +9,10 @@ final class ServiceTests: XCTestCase {
             req.readOnly.foos()
         }
 
-        try app.test(.GET, "test") { res in
+        try app.test(.GET, "test", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             try XCTAssertEqual(res.content.decode([String].self), ["foo"])
-        }
+        })
     }
 
     func testWritable() throws {

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -45,7 +45,7 @@ final class SessionTests: XCTestCase {
             return "del"
         }
 
-        try app.testable().test(.GET, "/set") { res in
+        try app.testable().test(.GET, "/set", afterResponse: { res in
             XCTAssertEqual(res.body.string, "set")
             cookie = res.headers.setCookie?["vapor-session"]
             XCTAssertNotNil(cookie)
@@ -53,7 +53,7 @@ final class SessionTests: XCTestCase {
                 #"create SessionData(storage: ["foo": "bar"])"#,
             ])
             MockKeyedCache.ops = []
-        }
+        })
 
         XCTAssertEqual(cookie?.string, "a")
 
@@ -61,13 +61,13 @@ final class SessionTests: XCTestCase {
         var cookies = HTTPCookies()
         cookies["vapor-session"] = cookie
         headers.cookie = cookies
-        try app.testable().test(.GET, "/del", headers: headers) { res in
+        try app.testable().test(.GET, "/del", headers: headers, afterResponse: { res in
             XCTAssertEqual(res.body.string, "del")
             XCTAssertEqual(MockKeyedCache.ops, [
                 #"read SessionID(string: "a")"#,
                 #"delete SessionID(string: "a")"#
             ])
-        }
+        })
     }
 
     func testInvalidCookie() throws {
@@ -94,9 +94,9 @@ final class SessionTests: XCTestCase {
 
 
         // Test accessing session with no cookie.
-        try app.test(.GET, "get") { res in
+        try app.test(.GET, "get", afterResponse: { res in
             XCTAssertEqual(res.status, .badRequest)
-        }
+        })
 
         // Test setting session with invalid cookie.
         var newCookie: HTTPCookies.Value?

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -11,10 +11,10 @@ final class ViewTests: XCTestCase {
             return View(data: data)
         }
 
-        try app.testable().test(.GET, "/view") { res in
+        try app.testable().test(.GET, "/view", afterResponse: { res in
             XCTAssertEqual(res.status.code, 200)
             XCTAssertEqual(res.headers.contentType, .html)
             XCTAssertEqual(res.body.string, "<h1>hello</h1>")
-        }
+        })
     }
 }

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -22,10 +22,10 @@ final class WebSocketTests: XCTestCase {
             }
         }
 
-        try app.testable().test(.GET, "/ws") { res in
+        try app.testable().test(.GET, "/ws", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Hello, world!")
-        }
+        })
     }
 
 


### PR DESCRIPTION
Fixes warnings about trailing closure matching behavior changes in Swift 5.3.

The main offender is `app.test` which has two trailing closures `beforeRequest` and `afterResponse`. Given that Swift is switching to forward matching for trailing closures, the previously used syntax would match `beforeRequest` instead of `afterResponse`. To remedy this, the label is now used explicitly. 