### PR TITLE
Fix Swift 5.3 trailing closure warnings

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -120,6 +120,7 @@ extension XCTApplicationTester {
             body: body,
             file: file,
             line: line,
+            beforeRequest: { _ in },
             afterResponse: afterResponse
         )
     }

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -111,6 +111,28 @@ extension XCTApplicationTester {
         body: ByteBuffer? = nil,
         file: StaticString = #file,
         line: UInt = #line,
+        afterResponse: (XCTHTTPResponse) throws -> ()
+    ) throws -> XCTApplicationTester {
+        try self.test(
+            method,
+            path,
+            headers: headers,
+            body: body,
+            file: file,
+            line: line,
+            afterResponse: afterResponse
+        )
+    }
+
+
+    @discardableResult
+    public func test(
+        _ method: HTTPMethod,
+        _ path: String,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) throws -> () = { _ in },
         afterResponse: (XCTHTTPResponse) throws -> () = { _ in }
     ) throws -> XCTApplicationTester {


### PR DESCRIPTION
Fixes warnings about trailing closure matching behavior changes in Swift 5.3 (#2485, #2484).