### PR TITLE
Provide option to implement `shouldUpgrade` on webSockets

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -52,10 +52,7 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
             if res.status == .switchingProtocols, let upgrader = res.upgrader {
                 switch upgrader {
                 case .webSocket(let maxFrameSize, let shouldUpgrade, let onUpgrade):
-                    let webSocketUpgrader = NIOWebSocketServerUpgrader(maxFrameSize: maxFrameSize.value, automaticErrorHandling: false, shouldUpgrade: { channel, _ in
-                        guard let shouldUpgrade = shouldUpgrade else {
-                            return channel.eventLoop.makeSucceededFuture([:])
-                        }
+                    let webSocketUpgrader = NIOWebSocketServerUpgrader(maxFrameSize: maxFrameSize.value, automaticErrorHandling: false, shouldUpgrade: { _, _ in
                         return shouldUpgrade()
                     }, upgradePipelineHandler: { channel, req in
                         return WebSocket.server(on: channel, onUpgrade: onUpgrade)

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -36,7 +36,7 @@ public final class Response: CustomStringConvertible {
     var forHeadRequest: Bool
 
     internal enum Upgrader {
-        case webSocket(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: (() -> EventLoopFuture<HTTPHeaders?>)? = nil, onUpgrade: (WebSocket) -> ())
+        case webSocket(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: (() -> EventLoopFuture<HTTPHeaders?>), onUpgrade: (WebSocket) -> ())
     }
     
     internal var upgrader: Upgrader?

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -36,7 +36,7 @@ public final class Response: CustomStringConvertible {
     var forHeadRequest: Bool
 
     internal enum Upgrader {
-        case webSocket(maxFrameSize: WebSocketMaxFrameSize, onUpgrade: (WebSocket) -> ())
+        case webSocket(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: (() -> EventLoopFuture<HTTPHeaders?>)? = nil, onUpgrade: (WebSocket) -> ())
     }
     
     internal var upgrader: Upgrader?

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -11,6 +11,15 @@ public struct WebSocketMaxFrameSize: ExpressibleByIntegerLiteral {
 }
 
 extension RoutesBuilder {
+    /// Adds a route for opening a web socket connection
+    /// - parameters:
+    ///   - path: Path components separated by commas.
+    ///   - maxFrameSize: The maximum allowed frame size. See `NIOWebSocketServerUpgrader`.
+    ///   - shouldUpgrade: Closure to apply before upgrade to web socket happens.
+    ///       Returns additional `HTTPHeaders` for response, `nil` to deny upgrading.
+    ///       See `NIOWebSocketServerUpgrader`.
+    ///   - onUpgrade: Closure to apply after web socket is upgraded successfully.
+    /// - returns: `Route` instance for newly created web socket endpoint
     @discardableResult
     public func webSocket(
         _ path: PathComponent...,
@@ -23,6 +32,15 @@ extension RoutesBuilder {
         return self.webSocket(path, maxFrameSize: maxFrameSize, shouldUpgrade: shouldUpgrade, onUpgrade: onUpgrade)
     }
 
+    /// Adds a route for opening a web socket connection
+    /// - parameters:
+    ///   - path: Array of path components.
+    ///   - maxFrameSize: The maximum allowed frame size. See `NIOWebSocketServerUpgrader`.
+    ///   - shouldUpgrade: Closure to apply before upgrade to web socket happens.
+    ///       Returns additional `HTTPHeaders` for response, `nil` to deny upgrading.
+    ///       See `NIOWebSocketServerUpgrader`.
+    ///   - onUpgrade: Closure to apply after web socket is upgraded successfully.
+    /// - returns: `Route` instance for newly created web socket endpoint
     @discardableResult
     public func webSocket(
         _ path: [PathComponent],

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -360,7 +360,7 @@ final class RouteTests: XCTestCase {
         let testMarkerHeaderValue = "addedInShouldUpgrade"
         
         app.routes.webSocket("customshouldupgrade", shouldUpgrade: { req in
-            return req.eventLoop.future([testMarkerHeaderKey:testMarkerHeaderValue])
+            return req.eventLoop.future([testMarkerHeaderKey: testMarkerHeaderValue])
         }, onUpgrade: { _, _ in })
         
         try app.testable(method: .running).test(.GET, "customshouldupgrade", beforeRequest: { req in

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -351,4 +351,25 @@ final class RouteTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         }
     }
+    
+    func testWebsocketUpgrade() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        let testMarkerHeaderKey = "TestMarker"
+        let testMarkerHeaderValue = "addedInShouldUpgrade"
+        
+        app.routes.webSocket("customshouldupgrade", shouldUpgrade: { req in
+            return req.eventLoop.future([testMarkerHeaderKey:testMarkerHeaderValue])
+        }, onUpgrade: { _, _ in })
+        
+        try app.testable(method: .running).test(.GET, "customshouldupgrade", beforeRequest: { req in
+            req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketVersion, value: "13")
+            req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketKey, value: "zyFJtLIpI2ASsmMHJ4Cf0A==")
+            req.headers.replaceOrAdd(name: .connection, value: "Upgrade")
+            req.headers.replaceOrAdd(name: .upgrade, value: "websocket")
+        }) { res in
+            XCTAssertEqual(res.headers.first(name: testMarkerHeaderKey), testMarkerHeaderValue)
+        }
+    }
 }


### PR DESCRIPTION
Adds support for a custom implementation of `shouldUpgrade` for websockets. This can be used to switch to specific subprotocols or to deny upgrading by returning `nil`.

```swift
routes.webSocket("authedecho", shouldUpgrade: { req in
    guard req.auth.has(User.self) else {
        return req.eventLoop.future(nil)
    }
    return req.eventLoop.future([:])            
}, onUpgrade: { req, ws in
    print(ws)
})
```