### PR TITLE
Validation of unrequired key in JSON string with a null value

### DIFF
--- a/Sources/Vapor/Validation/Validation.swift
+++ b/Sources/Vapor/Validation/Validation.swift
@@ -13,7 +13,11 @@ public struct Validation {
                     result = ValidatorResults.Skipped()
                 }
             } catch DecodingError.valueNotFound {
-                result = ValidatorResults.NotFound()
+                if required {
+                    result = ValidatorResults.NotFound()
+                } else {
+                    result = ValidatorResults.Skipped()
+                }
            } catch DecodingError.typeMismatch(let type, _) {
                 result = ValidatorResults.TypeMismatch(type: type)
             } catch DecodingError.dataCorrupted(let context) {


### PR DESCRIPTION
Given this JSON string:
[{ "name": null }](url)

for the validations:
`validations.add("name", as: String.self, is: .count(1...255), required: false)`

Validating this string with the given validation would produce the error "name cannot be null"

even though `required` is `false`.