### PR TITLE
Default cookie's SameSite attribute to lax

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -171,7 +171,8 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral {
             self.maxAge = maxAge
             self.domain = domain
             self.path = path
-            //samesite none requires secure attribute to be set
+            // SameSite=None requires Secure attribute to be set
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
             let forceSecure = sameSite == SameSitePolicy.none
             self.isSecure = isSecure || forceSecure
             self.isHTTPOnly = isHTTPOnly

--- a/Sources/Vapor/Sessions/SessionsConfiguration.swift
+++ b/Sources/Vapor/Sessions/SessionsConfiguration.swift
@@ -33,7 +33,7 @@ public struct SessionsConfiguration {
                 path: "/",
                 isSecure: false,
                 isHTTPOnly: false,
-                sameSite: nil
+                sameSite: .lax
             )
         }
     }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -161,6 +161,7 @@ final class HTTPHeaderTests: XCTestCase {
             ("cookie", "vapor-session=0FuTYcHmGw7Bz1G4HiF+EA==; _ga=GA1.1.500315824.1585154561; _gid=GA1.1.500224287.1585154561")
         ])
         XCTAssertEqual(headers.cookie?["vapor-session"]?.string, "0FuTYcHmGw7Bz1G4HiF+EA==")
+        XCTAssertEqual(headers.cookie?["vapor-session"]?.sameSite, .lax)
         XCTAssertEqual(headers.cookie?["_ga"]?.string, "GA1.1.500315824.1585154561")
         XCTAssertEqual(headers.cookie?["_gid"]?.string, "GA1.1.500224287.1585154561")
     }


### PR DESCRIPTION
Set a cookie's default `SameSite` attribute to `lax`.

This prevents warnings in browsers and stops functionality working when following redirects, cross site link or when browsers assume the attribute to be `None`, which requires `Secure` attribute(HTTPS only).

#2495 