### PR TITLE
Forward arguments from DotEnvFile.load

### DIFF
--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -43,8 +43,8 @@ public struct DotEnvFile {
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
         // Load specific .env first since values are not overridden.
-        DotEnvFile.load(path: ".env.\(environment.name)")
-        DotEnvFile.load(path: ".env")
+        DotEnvFile.load(path: ".env.\(environment.name)", on: eventLoopGroupProvider, logger: logger)
+        DotEnvFile.load(path: ".env", on: eventLoopGroupProvider, logger: logger)
     }
     
     /// Reads the dotenv files relevant to the environment and loads them into the process.


### PR DESCRIPTION
Forward the arguments passed to `DotEnvFile.load(for:on:logger)` to `DotEnvFile.load(path:on:logger)`.

This ensures that the passed in `EventLoopGroupProvider` and `Logger` actually get used instead of default ones.