### PR TITLE
Reuse the application's event loop group and thread pool when loading .env files

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -89,7 +89,7 @@ public final class Application {
         self.clients.use(.http)
         self.commands.use(self.servers.command, as: "serve", isDefault: true)
         self.commands.use(RoutesCommand(), as: "routes")
-        DotEnvFile.load(for: environment, on: eventLoopGroupProvider, logger: self.logger)
+        DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: fileio, logger: self.logger)
     }
     
     public func run() throws {

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -89,7 +89,7 @@ public final class Application {
         self.clients.use(.http)
         self.commands.use(self.servers.command, as: "serve", isDefault: true)
         self.commands.use(RoutesCommand(), as: "routes")
-        DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: fileio, logger: self.logger)
+        DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
     }
     
     public func run() throws {

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -133,7 +133,7 @@ public final class Application {
 
         switch self.eventLoopGroupProvider {
         case .shared:
-            self.logger.trace("Running on shared EventLoopGroup. Not shutting down EventLoopGroup")
+            self.logger.trace("Running on shared EventLoopGroup. Not shutting down EventLoopGroup.")
         case .createNew:
             self.logger.trace("Shutting down EventLoopGroup")
             do {

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -1,0 +1,65 @@
+extension DotEnvFile {
+    /// Reads the dotenv files relevant to the environment and loads them into the process.
+    ///
+    ///     let environment: Environment
+    ///     let elgp: EventLoopGroupProvider
+    ///     let logger: Logger
+    ///     try DotEnvFile.load(for: .development, on: elgp, logger: logger)
+    ///     print(Environment.process.FOO) // BAR
+    ///
+    /// - parameters:
+    ///     - environment: current environment, selects which .env file to use.
+    ///     - eventLoopGroupProvider: Either provides an EventLoopGroup or tells the function to create a new one.
+    ///     - logger: Optionally provide an existing logger.
+    @available(*, deprecated, message: "use `load(for:on:fileio:logger)`")
+    public static func load(
+        for environment: Environment = .development,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        logger: Logger = Logger(label: "dot-env-loggger")
+    ) {
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
+        threadPool.start()
+        defer {
+            do {
+                try threadPool.syncShutdownGracefully()
+            } catch {
+                logger.error("Shutting down threadPool failed: \(error)")
+            }
+        }
+        let fileio = NonBlockingFileIO(threadPool: threadPool)
+
+        self.load(for: environment, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
+    }
+
+    /// Reads the dotenv files relevant to the environment and loads them into the process.
+    ///
+    ///     let path: String
+    ///     let elgp: EventLoopGroupProvider
+    ///     let logger: Logger
+    ///     try DotEnvFile.load(path: path, on: elgp, logger: logger)
+    ///     print(Environment.process.FOO) // BAR
+    ///
+    /// - parameters:
+    ///     - path: Absolute or relative path of the dotenv file.
+    ///     - eventLoopGroupProvider: Either provides an EventLoopGroup or tells the function to create a new one.
+    ///     - logger: Optionally provide an existing logger.
+    @available(*, deprecated, message: "use `load(path:on:fileio:logger)`")
+    public static func load(
+        path: String,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        logger: Logger = Logger(label: "dot-env-loggger")
+    ) {
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
+        threadPool.start()
+        defer {
+            do {
+                try threadPool.syncShutdownGracefully()
+            } catch {
+                logger.error("Shutting down threadPool failed: \(error)")
+            }
+        }
+        let fileio = NonBlockingFileIO(threadPool: threadPool)
+
+        self.load(path: path, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
+    }
+}

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -75,7 +75,7 @@ public struct DotEnvFile {
         defer {
             switch eventLoopGroupProvider {
             case .shared:
-                logger.trace("Running on shared EventLoopGroup. Not shutting down EventLoopGroup")
+                logger.trace("Running on shared EventLoopGroup. Not shutting down EventLoopGroup.")
             case .createNew:
                 logger.trace("Shutting down EventLoopGroup")
                 do {

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -51,7 +51,7 @@ public struct DotEnvFile {
                 logger.error("Shutting down threadPool failed: \(error)")
             }
         }
-        let fileIO = NonBlockingFileIO(threadPool: threadPool)
+        let fileio = NonBlockingFileIO(threadPool: threadPool)
 
         self.load(for: environment, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
     }
@@ -107,7 +107,7 @@ public struct DotEnvFile {
                 logger.error("Shutting down threadPool failed: \(error)")
             }
         }
-        let fileIO = NonBlockingFileIO(threadPool: threadPool)
+        let fileio = NonBlockingFileIO(threadPool: threadPool)
 
         self.load(path: path, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
     }
@@ -155,7 +155,7 @@ public struct DotEnvFile {
         }
 
         do {
-            try load(path: path, fileio: fileIO, on: eventLoopGroup.next()).wait()
+            try load(path: path, fileio: fileio, on: eventLoopGroup.next()).wait()
         } catch {
             logger.debug("Could not load \(path) file: \(error)")
         }

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -29,37 +29,6 @@ public struct DotEnvFile {
     ///
     ///     let environment: Environment
     ///     let elgp: EventLoopGroupProvider
-    ///     let logger: Logger
-    ///     try DotEnvFile.load(for: .development, on: elgp, logger: logger)
-    ///     print(Environment.process.FOO) // BAR
-    ///
-    /// - parameters:
-    ///     - environment: current environment, selects which .env file to use.
-    ///     - eventLoopGroupProvider: Either provides an EventLoopGroup or tells the function to create a new one.
-    ///     - logger: Optionally provide an existing logger.
-    public static func load(
-        for environment: Environment = .development,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
-        logger: Logger = Logger(label: "dot-env-loggger")
-    ) {
-        let threadPool = NIOThreadPool(numberOfThreads: 1)
-        threadPool.start()
-        defer {
-            do {
-                try threadPool.syncShutdownGracefully()
-            } catch {
-                logger.error("Shutting down threadPool failed: \(error)")
-            }
-        }
-        let fileio = NonBlockingFileIO(threadPool: threadPool)
-
-        self.load(for: environment, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
-    }
-
-    /// Reads the dotenv files relevant to the environment and loads them into the process.
-    ///
-    ///     let environment: Environment
-    ///     let elgp: EventLoopGroupProvider
     ///     let fileio: NonBlockingFileIO
     ///     let logger: Logger
     ///     try DotEnvFile.load(for: .development, on: elgp, fileio: fileio, logger: logger)
@@ -101,37 +70,6 @@ public struct DotEnvFile {
         // Load specific .env first since values are not overridden.
         DotEnvFile.load(path: ".env.\(environment.name)", on: .shared(eventLoopGroup), fileio: fileio, logger: logger)
         DotEnvFile.load(path: ".env", on: .shared(eventLoopGroup), fileio: fileio, logger: logger)
-    }
-
-    /// Reads the dotenv files relevant to the environment and loads them into the process.
-    ///
-    ///     let path: String
-    ///     let elgp: EventLoopGroupProvider
-    ///     let logger: Logger
-    ///     try DotEnvFile.load(path: path, on: elgp, logger: logger)
-    ///     print(Environment.process.FOO) // BAR
-    ///
-    /// - parameters:
-    ///     - path: Absolute or relative path of the dotenv file.
-    ///     - eventLoopGroupProvider: Either provides an EventLoopGroup or tells the function to create a new one.
-    ///     - logger: Optionally provide an existing logger.
-    public static func load(
-        path: String,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
-        logger: Logger = Logger(label: "dot-env-loggger")
-    ) {
-        let threadPool = NIOThreadPool(numberOfThreads: 1)
-        threadPool.start()
-        defer {
-            do {
-                try threadPool.syncShutdownGracefully()
-            } catch {
-                logger.error("Shutting down threadPool failed: \(error)")
-            }
-        }
-        let fileio = NonBlockingFileIO(threadPool: threadPool)
-
-        self.load(path: path, on: eventLoopGroupProvider, fileio: fileio, logger: logger)
     }
 
     /// Reads the dotenv files relevant to the environment and loads them into the process.

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -60,7 +60,7 @@ public struct DotEnvFile {
     ///
     ///     let environment: Environment
     ///     let elgp: EventLoopGroupProvider
-    ///     let fileio: FileIO
+    ///     let fileio: NonBlockingFileIO
     ///     let logger: Logger
     ///     try DotEnvFile.load(for: .development, on: elgp, fileio: fileio, logger: logger)
     ///     print(Environment.process.FOO) // BAR
@@ -116,9 +116,9 @@ public struct DotEnvFile {
     ///
     ///     let path: String
     ///     let elgp: EventLoopGroupProvider
-    ///     let fileio: FileIO
+    ///     let fileio: NonBlockingFileIO
     ///     let logger: Logger
-    ///     try DotEnvFile.load(path: path, on: elgp, logger: logger)
+    ///     try DotEnvFile.load(path: path, on: elgp, fileio: filio, logger: logger)
     ///     print(Environment.process.FOO) // BAR
     ///
     /// - parameters:


### PR DESCRIPTION
- Prevents a separate `EventLoopGroup` from being created unnecessarily for loading .env files.
- Deprecates overloads for `DotEnvFile.load` in favor of version that accept a `NonBlockingFileIO` so existing resources can be reused.
- Prevents multiple `EventLoopGroup`s from being created when calling the `load` methods that take an `Environment` when provided without a shared `EventLoopGroupProvider`.