### PR TITLE
Completely redefine how the CI for all Vapor repos works

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action) }}
+        uses: maxim-lobanov/setup-xcode@v1.2.1
         with:
           xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}
@@ -60,7 +60,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action) }}
+        uses: maxim-lobanov/setup-xcode@v1.2.1
         with:
           xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::$(envblob)"
-          echo "::set-output name=xcode_action::$(actblob)"
+          printf '::set-output name=xcode_action::{"act":"%s"}\n' "${actblob}"
     
   test-providers:
     needs: getcidata
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJson(needs.getcidata.outputs.environments) }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
         provider:
           - vapor/jwt
           - vapor/fluent
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -52,13 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJson(needs.getcidata.outputs.environments) }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
     runs-on: ${{ matrix.env.os }}
     container: ${{ matrix.env.image }}
-    steps:
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
+        uses: 'maxim-lobanov/setup-xcode@v1.2.1'
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -57,7 +57,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
+        uses: 'maxim-lobanov/setup-xcode@v1.2.1'
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - id: output
         run: |
-          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
+          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::$(envblob)"
           echo "::set-output name=xcode_action::${actblob}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,77 +1,68 @@
 name: test
-on:
-  pull_request:
-  push:
-    branches:
-    - master
+on: { pull_request: {} }
+
 jobs:
-  providers:
+  getcidata:
     runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.output.outputs.environments }}
+      xcode_action: ${{ steps.output.outputs.xcode_action }}
+    steps:
+      - id: output
+        run: |
+          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
+          actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
+          echo "::set-output name=environments::$(envblob)"
+          echo "::set-output name=xcode_action::$(actblob)"
+    
+  test-providers:
+    needs: getcidata
     strategy:
       fail-fast: false
       matrix:
+        env: ${{ fromJson(needs.getcidata.outputs.environments) }}
         provider:
-          - jwt
-          - fluent
-          - leaf
-          - queues
-          - apns
-    container: swift:5.2-focal
+          - vapor/jwt
+          - vapor/fluent
+          - vapor/leaf
+          - vapor/queues
+          - vapor/apns
+          #- vapor/redis
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     steps: 
+      - name: Select toolchain
+        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
+        if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
-        with:
-          path: vapor
+        with: { path: 'vapor' }
       - name: Check out provider
         uses: actions/checkout@v2
-        with:
-          repository: vapor/${{ matrix.provider }}
-          path: provider
+        with: { repository: ${{ matrix.provider }}, path: 'provider' }
       - name: Use local Vapor
-        run: swift package edit vapor --path ../vapor
-        working-directory: provider
+        run: swift package --package-path ./provider edit vapor --path ./vapor
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --skip-update --disable-index-store --enable-test-discovery --sanitize=thread
         working-directory: provider
-  linux:
-    runs-on: ubuntu-latest
+        
+  test-vapor:
+    needs: getcidata
     strategy:
       fail-fast: false
       matrix:
-        image:
-          # 5.2 Stable
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          - swift:5.2-focal
-          - swift:5.2-centos8
-          - swift:5.2-amazonlinux2
-          # 5.2 Unstable
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          # 5.3 Unstable
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          # Master Unstable
-          # - swiftlang/swift:nightly-master-xenial
-          # - swiftlang/swift:nightly-master-bionic
-          # - swiftlang/swift:nightly-master-focal
-          # - swiftlang/swift:nightly-master-centos8
-          # - swiftlang/swift:nightly-master-amazonlinux2
-    container: ${{ matrix.image }}
+        env: ${{ fromJson(needs.getcidata.outputs.environments) }}
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     steps:
-      - name: Check out code
+    steps: 
+      - name: Select toolchain
+        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
+        if: ${{ matrix.env.toolchain != '' }}
+      - name: Check out Vapor
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        timeout-minutes: 10
-        run: swift test --enable-test-discovery --sanitize=thread
-  macOS:
-    runs-on: macos-latest
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
-        with:
-          xcode-version: latest
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
+        timeout-minutes: 20
+        run: swift test --disable-index-store --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@v1.2
         with:
           xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
+        env:
+          - { os: 'ubuntu-latest', image: 'swift:5.2-focal', toolchain: '' }
+          - { os: 'ubuntu-latest', image: 'swift:5.3-focal', toolchain: '' }
+          - { os: 'macos-latest', image: '', toolchain: 'latest-stable' }
+          - { os: 'macos-latest', image: '', toolchain: 'latest' }
         provider:
           - vapor/jwt
           - vapor/fluent
           - vapor/leaf
           - vapor/queues
           - vapor/apns
-          #- vapor/redis
     runs-on: ${{ matrix.env.os }}
     container: ${{ matrix.env.image }}
     steps: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::$(envblob)"
-          printf '::set-output name=xcode_action::{"act":"%s"}\n' "${actblob}"
+          echo "::set-output name=xcode_action::${actblob}"
     
   test-providers:
     needs: getcidata
@@ -31,7 +31,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
+        uses: ${{ needs.getcidata.outputs.xcode_action }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -56,7 +56,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
+        uses: ${{ needs.getcidata.outputs.xcode_action }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: 'maxim-lobanov/setup-xcode@v1.2.1'
+        uses: 'maxim-lobanov/setup-xcode@v1.2'
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -57,7 +57,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: 'maxim-lobanov/setup-xcode@v1.2.1'
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,21 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
         provider:
           - vapor/jwt
           - vapor/fluent
           - vapor/leaf
           - vapor/queues
           - vapor/apns
-    runs-on: ${{ matrix.env.os }}
-    container: ${{ matrix.env.image }}
+    runs-on: ubuntu-latest
+    container: swift:5.3-focal
     steps: 
-      - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
-        with:
-          xcode-version: ${{ matrix.env.toolchain }}
-        if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env:
-          - { os: 'ubuntu-latest', image: 'swift:5.2-focal', toolchain: '' }
-          - { os: 'ubuntu-latest', image: 'swift:5.3-focal', toolchain: '' }
-          - { os: 'macos-latest', image: '', toolchain: 'latest-stable' }
-          - { os: 'macos-latest', image: '', toolchain: 'latest' }
+        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
         provider:
           - vapor/jwt
           - vapor/fluent
@@ -35,19 +31,15 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2
-        with:
-          xcode-version: ${{ matrix.env.toolchain }}
+        uses: maxim-lobanov/setup-xcode@v1.2.1
+        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
-        with: 
-          path: vapor
+        with: { path: 'vapor' }
       - name: Check out provider
         uses: actions/checkout@v2
-        with: 
-          repository: ${{ matrix.provider }}
-          path: provider
+        with: { repository: ${{ matrix.provider }}, path: 'provider' }
       - name: Use local Vapor
         run: swift package --package-path ./provider edit vapor --path ./vapor
       - name: Run tests with Thread Sanitizer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
         provider:
           - vapor/jwt
           - vapor/fluent
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: 'maxim-lobanov/setup-xcode@v1.2'
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
     runs-on: ${{ matrix.env.os }}
     container: ${{ matrix.env.image }}
     steps: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       environments: ${{ steps.output.outputs.environments }}
-      xcode_action: ${{ steps.output.outputs.xcode_action }}
     steps:
       - id: output
         run: |
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
-          actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::${envblob}"
-          echo "::set-output name=xcode_action::${actblob}"
     
   test-providers:
     needs: getcidata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Use local Vapor
         run: swift package --package-path ./provider edit vapor --path ./vapor
       - name: Run tests with Thread Sanitizer
-        run: swift test --skip-update --disable-index-store --enable-test-discovery --sanitize=thread
+        run: swift test --enable-test-discovery --sanitize=thread
         working-directory: provider
         
   test-vapor:
@@ -68,4 +68,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         timeout-minutes: 20
-        run: swift test --disable-index-store --enable-test-discovery --sanitize=thread
+        run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::$(envblob)"
-          printf '::set-output name=xcode_action::{"act":"%s"}\n' "${actblob}"
+          echo "::set-output name=xcode_action::${actblob}"
     
   test-providers:
     needs: getcidata
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
         provider:
           - vapor/jwt
           - vapor/fluent
@@ -31,16 +31,19 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action) }}
         with:
           xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
-        with: { path: 'vapor' }
+        with:
+          path: vapor
       - name: Check out provider
         uses: actions/checkout@v2
-        with: { repository: ${{ matrix.provider }}, path: 'provider' }
+        with: 
+          repository: ${{ matrix.provider }}
+          path: provider
       - name: Use local Vapor
         run: swift package --package-path ./provider edit vapor --path ./vapor
       - name: Run tests with Thread Sanitizer
@@ -52,12 +55,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments)[0] }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
     runs-on: ${{ matrix.env.os }}
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action) }}
         with:
           xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,8 @@ jobs:
     steps: 
       - name: Select toolchain
         uses: maxim-lobanov/setup-xcode@v1.2
-        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
@@ -57,7 +58,8 @@ jobs:
     steps: 
       - name: Select toolchain
         uses: maxim-lobanov/setup-xcode@v1.2
-        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
+        uses: maxim-lobanov/setup-xcode@v1.2
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -56,7 +56,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
+        uses: maxim-lobanov/setup-xcode@v1.2
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,15 +35,19 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
-        with: { 'xcode-version': ${{ matrix.env.toolchain }} }
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
         uses: actions/checkout@v2
-        with: { path: 'vapor' }
+        with: 
+          path: vapor
       - name: Check out provider
         uses: actions/checkout@v2
-        with: { repository: ${{ matrix.provider }}, path: 'provider' }
+        with: 
+          repository: ${{ matrix.provider }}
+          path: provider
       - name: Use local Vapor
         run: swift package --package-path ./provider edit vapor --path ./vapor
       - name: Run tests with Thread Sanitizer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        uses: maxim-lobanov/setup-xcode@v1.2.1
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -58,7 +58,7 @@ jobs:
     steps:
     steps: 
       - name: Select toolchain
-        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        uses: maxim-lobanov/setup-xcode@v1.2.1
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
-          echo "::set-output name=environments::$(envblob)"
+          echo "::set-output name=environments::${envblob}"
           echo "::set-output name=xcode_action::${actblob}"
     
   test-providers:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj)"
           actblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/setup-xcode-action.txt)"
           echo "::set-output name=environments::$(envblob)"
-          echo "::set-output name=xcode_action::${actblob}"
+          printf '::set-output name=xcode_action::{"act":"%s"}\n' "${actblob}"
     
   test-providers:
     needs: getcidata
@@ -31,7 +31,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor
@@ -56,7 +56,7 @@ jobs:
     container: ${{ matrix.env.image }}
     steps: 
       - name: Select toolchain
-        uses: ${{ needs.getcidata.outputs.xcode_action }}
+        uses: ${{ fromJSON(needs.getcidata.outputs.xcode_action).act }}
         with: { 'xcode-version': ${{ matrix.env.toolchain }} }
         if: ${{ matrix.env.toolchain != '' }}
       - name: Check out Vapor


### PR DESCRIPTION
This is the test case, since GH actions can't be tested without pushing the workflow somewhere.