### PR TITLE
Honor Configuration for Optional Date Decoding & Encoding

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -384,7 +384,7 @@ private struct _Decoder: Decoder {
         }
         
         func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
-            //Check if we received a date. We need the decode with the appropriate format
+            // Check if we received a date. We need the decode with the appropriate format.
             guard !(T.self is Date.Type) else {
                 return try configuration.decodeDate(from: data, codingPath: codingPath, forKey: nil) as! T
             }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -169,33 +169,9 @@ private struct _Decoder: Decoder {
         }
         
         private func decodeDate(forKey key: Key) throws -> Date {
-            return try decodeDate(forKey: key, as: configuration.dateDecodingStrategy)
-        }
-        
-        private func decodeDate(forKey key: Key, as dateFormat: URLEncodedFormDecoder.Configuration.DateDecodingStrategy) throws -> Date {
             //If we are trying to decode a required array, we might not have decoded a child, but we should still try to decode an empty array
             let child = self.data.children[key.stringValue] ?? []
-            switch dateFormat {
-            case .secondsSince1970:
-                guard let value = child.values.last else {
-                    throw DecodingError.valueNotFound(Date.self, at: self.codingPath + [key])
-                }
-                if let result = Date.init(urlQueryFragmentValue: value) {
-                    return result
-                } else {
-                    throw DecodingError.typeMismatch(Date.self, at: self.codingPath + [key])
-                }
-            case .iso8601:
-                let decoder = _Decoder(data: child, codingPath: self.codingPath + [key], configuration: configuration)
-                if let date = ISO8601DateFormatter.threadSpecific.date(from: try String(from: decoder)) {
-                    return date
-                } else {
-                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath, debugDescription: "Unable to decode date. Expecting ISO8601 formatted date"))
-                }
-            case .custom(let callback):
-                let decoder = _Decoder(data: child, codingPath: self.codingPath + [key], configuration: configuration)
-                return try callback(decoder)
-            }
+            return try configuration.decodeDate(from: child, codingPath: self.codingPath, forKey: key)
         }
         
         func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
@@ -421,6 +397,33 @@ private struct _Decoder: Decoder {
                 let decoder = _Decoder(data: data, codingPath: self.codingPath, configuration: configuration)
                 return try T(from: decoder)
             }
+        }
+    }
+}
+
+private extension URLEncodedFormDecoder.Configuration {
+    func decodeDate(from data: URLEncodedFormData, codingPath: [CodingKey], forKey key: CodingKey?) throws -> Date {
+        let newCodingPath = codingPath + (key.map { [$0] } ?? [])
+        switch dateDecodingStrategy {
+        case .secondsSince1970:
+            guard let value = data.values.last else {
+                throw DecodingError.valueNotFound(Date.self, at: newCodingPath)
+            }
+            if let result = Date.init(urlQueryFragmentValue: value) {
+                return result
+            } else {
+                throw DecodingError.typeMismatch(Date.self, at: newCodingPath)
+            }
+        case .iso8601:
+            let decoder = _Decoder(data: data, codingPath: newCodingPath, configuration: self)
+            if let date = ISO8601DateFormatter.threadSpecific.date(from: try String(from: decoder)) {
+                return date
+            } else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription: "Unable to decode date. Expecting ISO8601 formatted date"))
+            }
+        case .custom(let callback):
+            let decoder = _Decoder(data: data, codingPath: newCodingPath, configuration: self)
+            return try callback(decoder)
         }
     }
 }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -384,6 +384,10 @@ private struct _Decoder: Decoder {
         }
         
         func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+            //Check if we received a date. We need the decode with the appropriate format
+            guard !(T.self is Date.Type) else {
+                return try configuration.decodeDate(from: data, codingPath: codingPath, forKey: nil) as! T
+            }
             if let convertible = T.self as? URLQueryFragmentConvertible.Type {
               guard let value = data.values.last else {
                     throw DecodingError.valueNotFound(T.self, at: self.codingPath)

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -178,27 +178,12 @@ private class _Encoder: Encoder {
             // skip
         }
         
-        private func encodeDate(_ date: Date, forKey key: Key) throws {
-            switch configuration.dateEncodingStrategy {
-            case .secondsSince1970:
-                internalData.children[key.stringValue] = URLEncodedFormData(values: [date.urlQueryFragmentValue])
-            case .iso8601:
-                internalData.children[key.stringValue] = URLEncodedFormData(values: [
-                    ISO8601DateFormatter.threadSpecific.string(from: date).urlQueryFragmentValue
-                ])
-            case .custom(let callback):
-                let encoder = _Encoder(codingPath: self.codingPath + [key], configuration: self.configuration)
-                try callback(date, encoder)
-                self.internalData.children[key.stringValue] = try encoder.getData()
-            }
-        }
-        
         /// See `KeyedEncodingContainerProtocol`
         func encode<T>(_ value: T, forKey key: Key) throws
             where T : Encodable
         {
             if let date = value as? Date {
-                try encodeDate(date, forKey: key)
+                self.internalData.children[key.stringValue] = try configuration.encodeDate(date, codingPath: self.codingPath, forKey: key)
             } else if let convertible = value as? URLQueryFragmentConvertible {
                 internalData.children[key.stringValue] = URLEncodedFormData(values: [convertible.urlQueryFragmentValue])
             } else {
@@ -385,6 +370,24 @@ private class _Encoder: Encoder {
                 try value.encode(to: encoder)
                 self.data = try encoder.getData()
             }
+        }
+    }
+}
+
+private extension URLEncodedFormEncoder.Configuration {
+    func encodeDate(_ date: Date, codingPath: [CodingKey], forKey key: CodingKey?) throws -> URLEncodedFormData {
+        switch dateEncodingStrategy {
+        case .secondsSince1970:
+            return URLEncodedFormData(values: [date.urlQueryFragmentValue])
+        case .iso8601:
+            return URLEncodedFormData(values: [
+                ISO8601DateFormatter.threadSpecific.string(from: date).urlQueryFragmentValue
+            ])
+        case .custom(let callback):
+            let newCodingPath = codingPath + (key.map { [$0] } ?? [])
+            let encoder = _Encoder(codingPath: newCodingPath, configuration: self)
+            try callback(date, encoder)
+            return try encoder.getData()
         }
     }
 }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -363,7 +363,9 @@ private class _Encoder: Encoder {
         
         /// See `SingleValueEncodingContainer`
         func encode<T>(_ value: T) throws where T: Encodable {
-            if let convertible = value as? URLQueryFragmentConvertible {
+            if let date = value as? Date {
+                self.data = try configuration.encodeDate(date, codingPath: self.codingPath, forKey: nil)
+            } else if let convertible = value as? URLQueryFragmentConvertible {
                 self.data.values.append(convertible.urlQueryFragmentValue)
             } else {
                 let encoder = _Encoder(codingPath: self.codingPath, configuration: self.configuration)

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -220,7 +220,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(decodedCustom, toEncode)
     }
 
-    func testGH2518() throws {
+    func testOptionalDateEncodingAndDecoding_GH2518() throws {
         let optionalDate: Date? = Date(timeIntervalSince1970: 0)
         let dateString = "1970-01-01T00:00:00Z"
 

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -220,6 +220,21 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(decodedCustom, toEncode)
     }
 
+    func testGH2518() throws {
+        let optionalDate: Date? = Date(timeIntervalSince1970: 0)
+        let dateString = "1970-01-01T00:00:00Z"
+
+        let resultForDecodedOptionalDate = try URLEncodedFormDecoder(
+            configuration: .init(dateDecodingStrategy: .iso8601)
+        ).decode(Date?.self, from: dateString)
+        XCTAssertEqual(optionalDate, resultForDecodedOptionalDate)
+
+        let resultForEncodedOptionalDate = try URLEncodedFormEncoder(
+            configuration: .init(dateEncodingStrategy: .iso8601)
+        ).encode(optionalDate)
+        XCTAssertEqual(dateString, resultForEncodedOptionalDate)
+    }
+
     func testEncodedArrayValues() throws {
         let user = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [.baz], nums: [3.14], isCool: true)
         let result = try URLEncodedFormEncoder(


### PR DESCRIPTION
Honor the configuration for Date Decoding & Encoding in `URLEncodedFormDecoder` / `URLEncodedFormEncoder` (fixes #2518).

```swift
// Configure a non-default date decoding strategy
let decoder = URLEncodedFormDecoder(configuration: .init(dateDecodingStrategy: .iso8601))
ContentConfiguration.global.use(urlDecoder: decoder)

// allow to use optional date-parameters in a request 
let after = try req.query.get(Date?.self, at: "after") ?? .distantPast

// => dates with the expected format (e.g. "...?after=2020-10-28T10:31:14Z") are correctly parsed
```