### PR TITLE
Permit disabling automatic logging of all requests

### DIFF
--- a/Sources/Vapor/Middleware/Application+Middleware.swift
+++ b/Sources/Vapor/Middleware/Application+Middleware.swift
@@ -5,6 +5,7 @@ extension Application {
                 return existing
             } else {
                 var new = Middlewares()
+                new.use(RouteLoggingMiddleware(logLevel: .info))
                 new.use(ErrorMiddleware.default(environment: self.environment))
                 self.storage[MiddlewaresKey.self] = new
                 return new

--- a/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
+++ b/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
@@ -1,0 +1,16 @@
+import Logging
+
+/// Emits a log message containing the request method and path to a `Request`'s logger.
+/// The log level of the message is configurable.
+public final class RouteLoggingMiddleware: Middleware {
+    public let logLevel: Logger.Level
+    
+    public init(logLevel: Logger.Level = .info) {
+        self.logLevel = logLevel
+    }
+    
+    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        request.logger.log(level: self.logLevel, "\(request.method) \(request.url.path.removingPercentEncoding ?? request.url.path)")
+        return next.respond(to: request)
+    }
+}

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -53,7 +53,7 @@ extension Application {
 
         var storage: Storage {
             guard let storage = self.application.storage[Key.self] else {
-                fatalError("Sessions not configured. Configure with app.sessions.initialize()")
+                fatalError("Responder not configured. Configure with app.responder.initialize()")
             }
             return storage
         }

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -39,7 +39,6 @@ internal struct DefaultResponder: Responder {
 
     /// See `Responder`
     public func respond(to request: Request) -> EventLoopFuture<Response> {
-        request.logger.info("\(request.method) \(request.url.path.removingPercentEncoding ?? request.url.path)")
         let startTime = DispatchTime.now().uptimeNanoseconds
         let response: EventLoopFuture<Response>
         let path: String
@@ -51,7 +50,7 @@ internal struct DefaultResponder: Responder {
             path = request.url.path
             response = self.notFoundResponder.respond(to: request)
         }
-        response.whenComplete { result in
+        return response.always { result in
             let status: HTTPStatus
             switch result {
             case .success(let response):
@@ -66,7 +65,6 @@ internal struct DefaultResponder: Responder {
                 statusCode: status.code
             )
         }
-        return response
     }
     
     /// Gets a `Route` from the underlying `TrieRouter`.


### PR DESCRIPTION
Previously, all requests received by Vapor would always be logged unconditionally at the `.info` log level, with no means available to control or disable it.

This logging has been moved to an enabled-by-default middleware. Users can remove the `RouteLoggingMiddleware` from `Application.middleware` to prevent any route logging from taking place.