### PR TITLE
Fix crash in DotEnv parser

### DIFF
--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -258,10 +258,13 @@ extension DotEnvFile {
         }
 
         private mutating func skipComment() {
-            guard let commentLength = self.countDistance(to: .newLine) else {
-                return
+            let commentLength: Int
+            if let toNewLine = self.countDistance(to: .newLine) {
+                commentLength = toNewLine + 1 // include newline
+            } else {
+                commentLength = self.source.readableBytes
             }
-            self.source.moveReaderIndex(forwardBy: commentLength + 1) // include newline
+            self.source.moveReaderIndex(forwardBy: commentLength)
         }
 
         private mutating func parseLine() -> Line? {

--- a/Tests/VaporTests/DotEnvTests.swift
+++ b/Tests/VaporTests/DotEnvTests.swift
@@ -43,4 +43,14 @@ final class DotEnvTests: XCTestCase {
             .init(key: "BAR", value: "baz"),
         ])
     }
+    func testCommentWithNoTrailingNewline() throws {
+        let env = "FOO=bar\n#BAR=baz"
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeString(env)
+        var parser = DotEnvFile.Parser(source: buffer)
+        let lines = parser.parse()
+        XCTAssertEqual(lines, [
+            .init(key: "FOO", value: "bar")
+        ])
+    }
 }


### PR DESCRIPTION
Previously, when .env file with a comment as the last line was parsed, an infinite recursive loop crashed the application.
The comment is now properly skipped.