### PR TITLE
Rework 'SessionData' to be more friendly to 2nd party devs

### DIFF
--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -1,13 +1,44 @@
-/// Codable session data.
-public struct SessionData: Codable {
-    /// Session codable object storage.
-    internal var storage: [String: String]
+/// A container for storing data associated with a given `SessionID`.
+///
+/// You can add data to an instance of `SessionData` by subscripting:
+///
+///     let data = SessionData()
+///     data["login_date"] = "\(Date())"
+///
+/// If you need a snapshot of the data stored in the container, such as for custom serialization to storage drivers, you can get a copy with `.snapshot`.
+///
+///     let data: SessionData = ["name": "Vapor"]
+///     // creates a copy of the data as of this point
+///     let snapshot = data.snapshot
+///     client.storeUsingDictionary(snapshot)
+public struct SessionData {
+    /// A copy of the current data in the container.
+    public var snapshot: [String: String] { self.storage }
 
-    /// Create a new, empty session data.
-    public init(_ data: [String: String] = [:]) {
-        self.storage = data
+    private var storage: [String: String]
+    
+    /// Creates a new empty session data container.
+    public init() { self.storage = [:] }
+
+    /// Creates a session data container for the given data.
+    /// - Parameter data: The data to store in the container.
+    public init(initialData data: [String: String]) { self.storage = data }
+
+    public subscript(_ key: String) -> String? {
+        get { return self.storage[key] }
+        set(newValue) { self.storage[key] = newValue }
     }
+}
 
+// MARK: Equatable
+extension SessionData {
+    public static func ==(lhs: SessionData, rhs: SessionData) -> Bool {
+        return lhs.storage == rhs.storage
+    }
+}
+
+// MARK: Codable
+extension SessionData: Codable {
     public init(from decoder: Decoder) throws {
         self.storage = try .init(from: decoder)
     }
@@ -15,10 +46,12 @@ public struct SessionData: Codable {
     public func encode(to encoder: Encoder) throws {
         try self.storage.encode(to: encoder)
     }
-    
-    /// Convenience `[String: String]` accessor.
-    public subscript(_ key: String) -> String? {
-        get { return self.storage[key] }
-        set { self.storage[key] = newValue }
+}
+
+// MARK: ExpressibleByDictionaryLiteral
+extension SessionData: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, String)...) {
+        let storage: [String: String] = elements.reduce(into: [:]) { $0[$1.0] = $1.1 }
+        self.init(initialData: storage)
     }
 }

--- a/Sources/Vapor/_Deprecations.swift
+++ b/Sources/Vapor/_Deprecations.swift
@@ -1,0 +1,7 @@
+
+// MARK: - Sessions
+
+extension SessionData {
+    @available(*, deprecated, message: "use SessionData.init(initialData:)")
+    public init(_ data: [String: String]) { self.init(initialData: data) }
+}


### PR DESCRIPTION
As reported by #2480, right now `SessionData` is a public type without much use to developers to write middleware, algorithms, etc. on top of due to how strongly the storage is encapsulated.

`SessionData` has been changed as follows:

- Now conforms to `Equatable` and `ExpressibleByDictionaryLiteral`
- A new `snapshot` computed property is available to get a copy of its storage
- `init(_:)` is now deprecated in favor of `init(initialData:)`

```swift
let data: SessionData = ["name": "Vapor"]
// creates a copy of the data as of this point
let snapshot = data.snapshot
client.storeUsingDictionary(snapshot)
```