### PR TITLE
Replace header image with plain markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <a href="https://discord.gg/vapor">
-    <img 
-	 src="https://user-images.githubusercontent.com/1342803/75634175-4876d680-5bd9-11ea-90d6-12c7b6a9ee3f.png" 
-	 height="176" 
-	 alt="Vapor" 
-    >
+	
+![Vapor](https://user-images.githubusercontent.com/1342803/75634175-4876d680-5bd9-11ea-90d6-12c7b6a9ee3f.png)
 </a>
 
 <p align="center">


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

In the original README file, the header image at the top gets stretched when the window is too small (for example, when viewing on mobile).

Normal width | Compact width
--- | ---
<img width="1552" alt="Screen Shot 2020-12-05 at 3 39 37 PM" src="https://user-images.githubusercontent.com/49819455/101267709-9db7b980-3710-11eb-9cb7-0dfd21aea335.png"> | <img width="612" alt="Screen Shot 2020-12-05 at 3 39 43 PM" src="https://user-images.githubusercontent.com/49819455/101267710-a01a1380-3710-11eb-934e-da1db5fef298.png">

That's because `src`s in GitHub-flavored Markdown turn out weird when you supply a `width` or `height`. It's easier just to use Markdown, especially since it looks almost exactly the same in normal width, but a lot better in compact width.

<table>
<tr>
<td>
Old
</td>
</tr>

<tr>
<td>

```html
<img 
    src="https://user-images.githubusercontent.com/1342803/75634175-4876d680-5bd9-11ea-90d6-12c7b6a9ee3f.png" 
    height="176" 
    alt="Vapor" 
>
```

</td>
</tr>

<tr>
<td>
New
</td>
</tr>

<tr>
<td>

```markdown
![Vapor](https://user-images.githubusercontent.com/1342803/75634175-4876d680-5bd9-11ea-90d6-12c7b6a9ee3f.png)
```
</td>
</tr>
</table>

Normal width changes | Compact width changes
--- | ---
<img width="1552" alt="Screen Shot 2020-12-05 at 3 40 52 PM" src="https://user-images.githubusercontent.com/49819455/101267771-6990c880-3711-11eb-91e0-ef1b527a3410.png"> | <img width="612" alt="Screen Shot 2020-12-05 at 3 40 56 PM" src="https://user-images.githubusercontent.com/49819455/101267772-6b5a8c00-3711-11eb-8b84-4e60aa9f087b.png">

The Discord link and alt text are preserved. Here's the final result:

Normal width | Compact width
--- | ---
<img width="1552" alt="Screen Shot 2020-12-05 at 3 41 54 PM" src="https://user-images.githubusercontent.com/49819455/101267834-28e57f00-3712-11eb-9095-62a334f8b80b.png"> | <img width="612" alt="Screen Shot 2020-12-05 at 3 41 59 PM" src="https://user-images.githubusercontent.com/49819455/101267835-2aaf4280-3712-11eb-94df-e6652e2238e7.png">



<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
