### PR TITLE
BUG FIX: Multipart/form-data crashed if data was missing

### DIFF
--- a/Sources/Vapor/Multipart/FormDataDecoder.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder.swift
@@ -74,10 +74,10 @@ private final class FormDataDecoderContext {
             part = p
         case 2:
             let name = codingPath[0].stringValue + "[]"
-            guard let offset = codingPath[1].intValue else {
-                throw MultipartError.nesting
+            guard let p = parts.allParts(named: name)[safe: offset] else {
+              throw MultipartError.missingPart("\(codingPath[1].stringValue)")
             }
-            part = parts.allParts(named: name)[offset]
+            part = p
         default:
             throw MultipartError.nesting
         }

--- a/Sources/Vapor/Multipart/FormDataDecoder.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder.swift
@@ -75,10 +75,10 @@ private final class FormDataDecoderContext {
         case 2:
             let name = codingPath[0].stringValue + "[]"
             guard let offset = codingPath[1].intValue else {
-              throw MultipartError.nesting
+                throw MultipartError.nesting
             }
             guard let p = parts.allParts(named: name)[safe: offset] else {
-              throw MultipartError.missingPart("\(codingPath[1].stringValue)")
+                throw MultipartError.missingPart("\(codingPath[1].stringValue)")
             }
             part = p
         default:

--- a/Sources/Vapor/Multipart/FormDataDecoder.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder.swift
@@ -74,6 +74,9 @@ private final class FormDataDecoderContext {
             part = p
         case 2:
             let name = codingPath[0].stringValue + "[]"
+            guard let offset = codingPath[1].intValue else {
+              throw MultipartError.nesting
+            }
             guard let p = parts.allParts(named: name)[safe: offset] else {
               throw MultipartError.missingPart("\(codingPath[1].stringValue)")
             }

--- a/Tests/VaporTests/MultipartTests.swift
+++ b/Tests/VaporTests/MultipartTests.swift
@@ -295,6 +295,30 @@ class MultipartTests: XCTestCase {
         XCTAssertEqual(foo.bool, true)
     }
 
+    func testFormDataDecoderMultipleWithMissingData() {
+      /// Content-Type: multipart/form-data; boundary=hello
+      let data = """
+        --hello\r\n\
+        Content-Disposition: form-data; name="link"\r\n\
+        \r\n\
+        https://google.com\r\n\
+        --hello--\r\n
+        """
+
+      struct Foo: Decodable {
+        var link: URL
+      }
+
+      XCTAssertThrowsError(try FormDataDecoder().decode(Foo.self, from: data, boundary: "hello")) { error in
+        guard case let MultipartError.missingPart(array) = error else {
+          XCTFail("Was expecting an error of type MultipartError.missingPart")
+          return
+        }
+
+        XCTAssertEqual(array, "relative")
+      }
+    }
+
     func testDocBlocks() throws {
         do {
             /// Content-Type: multipart/form-data; boundary=123


### PR DESCRIPTION
Fix a crash in `FormDataDecoderContext` when the offset doesn't exist when parsing multipart form data (#2548)