### PR TITLE
Add cache protocol

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -77,6 +77,7 @@ public final class Application {
         self.lifecycle = .init()
         self.isBooted = false
         self.core.initialize()
+        self.caches.initialize()
         self.views.initialize()
         self.passwords.use(.bcrypt)
         self.sessions.initialize()

--- a/Sources/Vapor/Cache/Application+Cache.swift
+++ b/Sources/Vapor/Cache/Application+Cache.swift
@@ -33,7 +33,7 @@ extension Application {
             typealias Value = Storage
         }
 
-        let application: Application
+        public let application: Application
 
         public func use(_ provider: Provider) {
             provider.run(self.application)

--- a/Sources/Vapor/Cache/Application+Cache.swift
+++ b/Sources/Vapor/Cache/Application+Cache.swift
@@ -1,0 +1,58 @@
+extension Application {
+    /// Controls application's configured caches.
+    ///
+    ///     app.caches.use(.memory)
+    ///
+    public var caches: Caches {
+        .init(application: self)
+    }
+
+    /// Current application cache. See `Request.cache` for caching in request handlers.
+    public var cache: Cache {
+        guard let makeCache = self.caches.storage.makeCache else {
+            fatalError("No cache configured. Configure with app.caches.use(...)")
+        }
+        return makeCache(self)
+    }
+
+    public struct Caches {
+        public struct Provider {
+            let run: (Application) -> ()
+
+            public init(_ run: @escaping (Application) -> ()) {
+                self.run = run
+            }
+        }
+        
+        final class Storage {
+            var makeCache: ((Application) -> Cache)?
+            init() { }
+        }
+
+        struct Key: StorageKey {
+            typealias Value = Storage
+        }
+
+        let application: Application
+
+        public func use(_ provider: Provider) {
+            provider.run(self.application)
+        }
+
+        public func use(_ makeCache: @escaping (Application) -> (Cache)) {
+            self.storage.makeCache = makeCache
+        }
+
+        func initialize() {
+            self.application.storage[Key.self] = .init()
+            self.use(.memory)
+        }
+
+        var storage: Storage {
+            guard let storage = self.application.storage[Key.self] else {
+                fatalError("Caches not configured. Configure with app.caches.initialize()")
+            }
+            return storage
+        }
+    }
+}

--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -1,0 +1,22 @@
+/// Codable key-value pair cache.
+public protocol Cache {
+    /// Gets a decodable value from the cache. Returns `nil` if not found.
+    func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
+        where T: Decodable
+    
+    /// Sets an encodable value into the cache. Existing values are replaced. If `nil`, removes value.
+    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
+        where T: Encodable
+    
+    /// Creates a request-specific cache instance.
+    func `for`(_ request: Request) -> Self
+}
+
+extension Cache {
+    /// Gets a decodable value from the cache. Returns `nil` if not found.
+    public func get<T>(_ key: String) -> EventLoopFuture<T?>
+        where T: Decodable
+    {
+        return self.get(key, as: T.self)
+    }
+}

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -1,0 +1,92 @@
+extension Application.Caches {
+    /// In-memory cache. Thread safe.
+    /// Not shared between multiple instances of your application.
+    public var memory: Cache {
+        MemoryCache(storage: self.memoryStorage, on: self.application.eventLoopGroup.next())
+    }
+
+    private var memoryStorage: MemoryCacheStorage {
+        let lock = self.application.locks.lock(for: MemoryCacheKey.self)
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = self.application.storage.get(MemoryCacheKey.self) {
+            return existing
+        } else {
+            let new = MemoryCacheStorage()
+            self.application.storage.set(MemoryCacheKey.self, to: new)
+            return new
+        }
+    }
+}
+
+extension Application.Caches.Provider {
+    /// In-memory cache. Thread safe.
+    /// Not shared between multiple instances of your application.
+    public static var memory: Self {
+        .init {
+            $0.caches.use { $0.caches.memory }
+        }
+    }
+}
+
+private struct MemoryCacheKey: LockKey, StorageKey {
+    typealias Value = MemoryCacheStorage
+}
+
+private final class MemoryCacheStorage {
+    private var storage: [String: Any]
+    private var lock: Lock
+    
+    init() {
+        self.storage = [:]
+        self.lock = .init()
+    }
+    
+    func get<T>(_ key: String) -> T?
+        where T: Decodable
+    {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage[key] as? T
+    }
+    
+    func set<T>(_ key: String, to value: T?)
+        where T: Encodable
+    {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        if let value = value {
+            self.storage[key] = value
+        } else {
+            self.storage.removeValue(forKey: key)
+        }
+    }
+}
+
+private struct MemoryCache: Cache {
+    let storage: MemoryCacheStorage
+    let eventLoop: EventLoop
+    
+    init(storage: MemoryCacheStorage, on eventLoop: EventLoop) {
+        self.storage = storage
+        self.eventLoop = eventLoop
+    }
+    
+    func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
+        where T: Decodable
+    {
+        self.eventLoop.makeSucceededFuture(self.storage.get(key))
+    }
+    
+    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
+        where T: Encodable
+    
+    {
+        self.storage.set(key, to: value)
+        return self.eventLoop.makeSucceededFuture(())
+    }
+    
+    func `for`(_ request: Request) -> MemoryCache {
+        .init(storage: self.storage, on: request.eventLoop)
+    }
+}

--- a/Sources/Vapor/Cache/Request+Cache.swift
+++ b/Sources/Vapor/Cache/Request+Cache.swift
@@ -1,0 +1,5 @@
+extension Request {
+    public var cache: Cache {
+        self.application.cache.for(self)
+    }
+}

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -1,130 +1,54 @@
-import Vapor
-import XCTest
+import XCTVapor
 
-class CacheTests: XCTestCase {
-    func testNoStoreWithExpires() {
-        let requested = Date()
-        var headers = HTTPHeaders()
-        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
-        headers.add(name: .cacheControl, value: "no-store, max-age=12")
-
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+final class CacheTests: XCTestCase {
+    func testDefaultCache() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
+        try app.cache.set("foo", to: "bar").wait()
+        try XCTAssertEqual(app.cache.get("foo").wait(), "bar")
     }
-
-    func testNoStore() {
-        let requested = Date()
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    
+    func testCustomCache() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        app.caches.use(.foo)
+        try XCTAssertEqual(app.cache.get("foo").wait(), "bar")
     }
+}
 
-    func testMaxAge() {
-        let seconds = Int.random(in: 1...3_000_333)
-        let requested = Date()
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-age=\(seconds)"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        let required = requested.addingTimeInterval(TimeInterval(seconds))
-
-        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
+extension Application.Caches.Provider {
+    static var foo: Self {
+        .init { $0.caches.use { FooCache(on: $0.eventLoopGroup.next()) } }
     }
+}
 
-    func testNoMatching() {
-        let requested = Date()
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+// Always returns "bar" for key "foo".
+// That's all...
+struct FooCache: Cache {
+    let eventLoop: EventLoop
+    init(on eventLoop: EventLoop) {
+        self.eventLoop = eventLoop
     }
-
-    func testMissingHeader() {
-        let response = ClientResponse(status: .ok)
-        XCTAssertNil(response.headers.expirationDate(requestSentAt: Date()))
+    
+    func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
+        where T : Decodable
+    {
+        let value: T?
+        if key == "foo" {
+            value = "bar" as? T
+        } else {
+            value = nil
+        }
+        return self.eventLoop.makeSucceededFuture(value)
     }
-
-    private func dateFromFormat(format: String, dateStr: String) -> Date {
-        let fmt = DateFormatter()
-        fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone(secondsFromGMT: 0)
-        fmt.dateFormat = format
-
-        return fmt.date(from: dateStr)!
+    
+    func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void> where T : Encodable {
+        return self.eventLoop.makeSucceededFuture(())
     }
-
-    func testPreferredFormat() {
-        let expires = "Sun, 06 Nov 1994 08:49:37 GMT"
-        let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
-        let required = dateFromFormat(format: format, dateStr: expires)
-        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
-    }
-
-    func testObsoleteFormatOne() {
-        let expires = "Sunday, 06-Nov-94 08:49:37 GMT"
-        let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
-        let required = dateFromFormat(format: format, dateStr: expires)
-        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
-    }
-
-    func testObsoleteFormatTwo() {
-        let expires = "Sun Nov  6 08:49:37 1994"
-        let format = "EEE MMM d hh:mm:s yyyy"
-        let required = dateFromFormat(format: format, dateStr: expires)
-        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
-    }
-
-    func testMaxAgeOverridesExpires() {
-        let requested = Date()
-        let seconds = Int.random(in: 1...3_000_333)
-        let required = requested.addingTimeInterval(TimeInterval(seconds))
-
-        var headers = HTTPHeaders()
-        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
-        headers.add(name: .cacheControl, value: "max-age=\(seconds)")
-
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
-    }
-
-    func testFlags() {
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        XCTAssertTrue(response.headers.cacheControl!.noStore)
-        XCTAssertFalse(response.headers.cacheControl!.immutable)
-        XCTAssertEqual(response.headers.cacheControl!.maxAge, 12)
-    }
-
-    func textMaxStaleNoValue() {
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        let cache = response.headers.cacheControl!
-
-        XCTAssertNotNil(cache.maxStale)
-        XCTAssertNil(cache.maxStale?.seconds)
-    }
-
-    func textMaxStaleNoWithValue() {
-        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale=12"))
-        let response = ClientResponse(status: .ok, headers: headers)
-
-        let cache = response.headers.cacheControl!
-
-        XCTAssertNotNil(cache.maxStale)
-        XCTAssertNotNil(cache.maxStale?.seconds)
-        XCTAssertEqual(cache.maxStale?.seconds, 12)
+    
+    func `for`(_ request: Request) -> FooCache {
+        return self
     }
 }

--- a/Tests/VaporTests/HTTPCacheTests.swift
+++ b/Tests/VaporTests/HTTPCacheTests.swift
@@ -1,0 +1,130 @@
+import Vapor
+import XCTest
+
+class HTTPCacheTests: XCTestCase {
+    func testNoStoreWithExpires() {
+        let requested = Date()
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "no-store, max-age=12")
+
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testNoStore() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testMaxAge() {
+        let seconds = Int.random(in: 1...3_000_333)
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-age=\(seconds)"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
+    }
+
+    func testNoMatching() {
+        let requested = Date()
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "random garbage"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: requested))
+    }
+
+    func testMissingHeader() {
+        let response = ClientResponse(status: .ok)
+        XCTAssertNil(response.headers.expirationDate(requestSentAt: Date()))
+    }
+
+    private func dateFromFormat(format: String, dateStr: String) -> Date {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(secondsFromGMT: 0)
+        fmt.dateFormat = format
+
+        return fmt.date(from: dateStr)!
+    }
+
+    func testPreferredFormat() {
+        let expires = "Sun, 06 Nov 1994 08:49:37 GMT"
+        let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatOne() {
+        let expires = "Sunday, 06-Nov-94 08:49:37 GMT"
+        let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testObsoleteFormatTwo() {
+        let expires = "Sun Nov  6 08:49:37 1994"
+        let format = "EEE MMM d hh:mm:s yyyy"
+        let required = dateFromFormat(format: format, dateStr: expires)
+        let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: Date()), required)
+    }
+
+    func testMaxAgeOverridesExpires() {
+        let requested = Date()
+        let seconds = Int.random(in: 1...3_000_333)
+        let required = requested.addingTimeInterval(TimeInterval(seconds))
+
+        var headers = HTTPHeaders()
+        headers.add(name: .expires, value: "Sun, 06 Nov 1994 08:49:37 GMT")
+        headers.add(name: .cacheControl, value: "max-age=\(seconds)")
+
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertEqual(response.headers.expirationDate(requestSentAt: requested), required)
+    }
+
+    func testFlags() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "no-store, max-age=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        XCTAssertTrue(response.headers.cacheControl!.noStore)
+        XCTAssertFalse(response.headers.cacheControl!.immutable)
+        XCTAssertEqual(response.headers.cacheControl!.maxAge, 12)
+    }
+
+    func textMaxStaleNoValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNil(cache.maxStale?.seconds)
+    }
+
+    func textMaxStaleNoWithValue() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "max-stale=12"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+
+        XCTAssertNotNil(cache.maxStale)
+        XCTAssertNotNil(cache.maxStale?.seconds)
+        XCTAssertEqual(cache.maxStale?.seconds, 12)
+    }
+}


### PR DESCRIPTION
Adds `Cache` protocol and application helpers. 

```swift
// Configure application cache
app.caches.use(.memory)

// Use cache
app.cache.get("foo", as: String.self)

// Use in request handler
req.cache.get("foo", as: String.self)
```

Includes `.memory` cache which stores values in a thread-safe dictionary. 