### PR TITLE
CORS: add "vary: origin" header if allowed origin is .originBased (#2539)

### DIFF
--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -135,7 +135,8 @@ public final class CORSMiddleware: Middleware {
         
         return response.map { response in
             // Modify response headers based on CORS settings
-            response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: self.configuration.allowedOrigin.header(forRequest: request))
+            let originBasedAccessControlAllowHeader = self.configuration.allowedOrigin.header(forRequest: request)
+            response.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: originBasedAccessControlAllowHeader)
             response.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: self.configuration.allowedHeaders)
             response.headers.replaceOrAdd(name: .accessControlAllowMethods, value: self.configuration.allowedMethods)
             
@@ -149,6 +150,10 @@ public final class CORSMiddleware: Middleware {
             
             if self.configuration.allowCredentials {
                 response.headers.replaceOrAdd(name: .accessControlAllowCredentials, value: "true")
+            }
+
+            if case .originBased = self.configuration.allowedOrigin, !originBasedAccessControlAllowHeader.isEmpty {
+                response.headers.add(name: .vary, value: "origin")
             }
             
             return response


### PR DESCRIPTION
- Set the "vary: origin" header when using the request's "origin" header. (fixes #2539).

> Note: Previously, the "Vary: Origin" header would not be set. 
