### PR TITLE
TOTP range now gives correct results (#2561)

### DIFF
--- a/Sources/Vapor/Security/OTP.swift
+++ b/Sources/Vapor/Security/OTP.swift
@@ -103,8 +103,7 @@ internal extension OTP {
     /// - Returns: All the generated OTP's in an array.
     func _generate(
         counter: UInt64,
-        range: Int,
-        size: Int = 1
+        range: Int
     ) -> [String] {
         switch self.digest {
         case .sha1: return generateOTPs(Insecure.SHA1(), counter: counter, range: range)

--- a/Sources/Vapor/Security/OTP.swift
+++ b/Sources/Vapor/Security/OTP.swift
@@ -68,16 +68,14 @@ internal extension OTP {
     ///   - counter: The 'main' counter.
     ///   - range: The number of codes to generate in both the forward and backward direction. This number must be bigger than 0.
     ///   For example, if `range` is `2`, a total of `5` codes will be returned: The main code, the two codes prior to the main code and the two codes after the main code.
-    ///   - size: The size of the offset. This is particularly useful for TOTP's, as it allows to specify the interval as size.
     /// - Returns: All the generated OTP's in an array.
     func generateOTPs<H: HashFunction>(
         _ h: H, counter: UInt64,
-        range: Int,
-        size: Int = 1
+        range: Int
     ) -> [String] {
         precondition(range > 0, "Cannot generate range of OTP's for range \(range). Range must be greater than 0")
         
-        return (-range ... range).map { $0 * size }.map {
+        return (-range ... range).map {
             let offset = $0 >= 0 ? counter &+ UInt64($0) : counter &- UInt64(-$0)
             return generate(h, counter: offset)
         }
@@ -101,7 +99,6 @@ internal extension OTP {
     /// - Parameters:
     ///   - counter: The 'main' counter.
     ///   - range: The number of codes to generate in both the forward and backward direction. This number must be bigger than 0.
-    ///   - size: The size of the offset. This is particularly useful for TOTP's, as it allows to specify the interval as size.
     ///   For example, if `range` is `2`, a total of `5` codes will be returned: The main code, the two codes prior to the main code and the two codes after the main code.
     /// - Returns: All the generated OTP's in an array.
     func _generate(
@@ -110,9 +107,9 @@ internal extension OTP {
         size: Int = 1
     ) -> [String] {
         switch self.digest {
-        case .sha1: return generateOTPs(Insecure.SHA1(), counter: counter, range: range, size: size)
-        case .sha256: return generateOTPs(SHA256(), counter: counter, range: range, size: size)
-        case .sha512: return generateOTPs(SHA512(), counter: counter, range: range, size: size)
+        case .sha1: return generateOTPs(Insecure.SHA1(), counter: counter, range: range)
+        case .sha256: return generateOTPs(SHA256(), counter: counter, range: range)
+        case .sha512: return generateOTPs(SHA512(), counter: counter, range: range)
         }
     }
 }
@@ -243,7 +240,7 @@ public struct TOTP: OTP {
     ) -> [String] {
         let secondsPast1970 = Int(floor(time.timeIntervalSince1970))
         let counter = Int(floor(Double(secondsPast1970) / Double(self.interval)))
-        return _generate(counter: UInt64(counter), range: range, size: self.interval)
+        return _generate(counter: UInt64(counter), range: range)
     }
     
     /// Compute the TOTP for the key, time interval and time.

--- a/Tests/VaporTests/SecurityTests.swift
+++ b/Tests/VaporTests/SecurityTests.swift
@@ -27,10 +27,26 @@ final class OTPTests: XCTestCase {
     
     /// Basic TOTP test using the range, copied from Vapor 3.
     /// https://github.com/vapor/open-crypto/blob/38487c8eb13d689d0ed6b3808a9a9bc00cd621f6/Tests/CryptoTests/OTPTests.swift
+    ///
+    /// Test amended due to https://github.com/vapor/vapor/pull/2561
     func testTOTPRange() {
-        let key = SymmetricKey(size: .bits128)
-        let codes = TOTP(key: key, digest: .sha1).generate(time: Date(), range: 1)
+        let time = Date(timeIntervalSince1970: 60)
+        let preTime = Date(timeIntervalSince1970: 30)
+        let postTime = Date(timeIntervalSince1970: 90)
+        
+        let key = SymmetricKey(data: "12345678901234567890".data(using: .ascii)!)
+        let totp = TOTP(key: key, digest: .sha1, digits: .eight, interval: 30)
+        let codes = totp.generate(time: time, range: 1)
         XCTAssertEqual(codes.count, 3)
+        
+        let cur = totp.generate(time: time)
+        let pre = totp.generate(time: preTime)
+        let post = totp.generate(time: postTime)
+        
+        XCTAssert(cur != pre && cur != post && pre != post)
+        XCTAssert(codes.contains(totp.generate(time: time)))
+        XCTAssert(codes.contains(totp.generate(time: preTime)))
+        XCTAssert(codes.contains(totp.generate(time: postTime)))
     }
     
     /// A HOTP test vector.

--- a/Tests/VaporTests/SecurityTests.swift
+++ b/Tests/VaporTests/SecurityTests.swift
@@ -43,7 +43,7 @@ final class OTPTests: XCTestCase {
         let pre = totp.generate(time: preTime)
         let post = totp.generate(time: postTime)
         
-        XCTAssert(cur != pre && cur != post && pre != post)
+        XCTAssert(Set([cur, pre, post]).count == 3)
         XCTAssert(codes.contains(totp.generate(time: time)))
         XCTAssert(codes.contains(totp.generate(time: preTime)))
         XCTAssert(codes.contains(totp.generate(time: postTime)))


### PR DESCRIPTION
Generating multiple TOTPs using the `range` now creates consecutive codes instead of ranges with big gaps (TOTP interval ^ 2) between codes.