### PR TITLE
Fix tests when running in parallel

### DIFF
--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -8,6 +8,7 @@ final class ApplicationTests: XCTestCase {
         let test = Environment(name: "testing", arguments: ["vapor"])
         let app = Application(test)
         defer { app.shutdown() }
+        app.environment.arguments = ["serve"]
         try app.start()
         guard let running = app.running else {
             XCTFail("app started without setting 'running'")
@@ -100,6 +101,7 @@ final class ApplicationTests: XCTestCase {
             "Hello, world!"
         }
 
+        app.environment.arguments = ["serve"]
         try app.start()
 
         let res = try app.client.get("http://localhost:8080/hello").wait()

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -85,6 +85,7 @@ final class ClientTests: XCTestCase {
             }
         }
 
+        app.environment.arguments = ["serve"]
         try app.boot()
         try app.start()
 

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -436,6 +436,7 @@ final class ServerTests: XCTestCase {
 
         let port = 1337
         app.http.server.configuration.port = port
+        app.environment.arguments = ["serve"]
         try app.start()
 
         let request = try HTTPClient.Request(
@@ -493,6 +494,7 @@ final class ServerTests: XCTestCase {
 
         let port = 1337
         app.http.server.configuration.port = port
+        app.environment.arguments = ["serve"]
         try app.start()
 
         let request = try HTTPClient.Request(
@@ -524,7 +526,7 @@ final class ServerTests: XCTestCase {
         defer {
             app.shutdown()
         }
-
+        app.environment.arguments = ["serve"]
         XCTAssertNoThrow(try app.start())
     }
 
@@ -548,6 +550,7 @@ final class ServerTests: XCTestCase {
         let app = Application(.testing)
         app.http.server.configuration.address = .hostname(nil, port: nil)
         defer { app.shutdown() }
+        app.environment.arguments = ["serve"]
 
         XCTAssertNoThrow(try app.start())
     }
@@ -556,6 +559,7 @@ final class ServerTests: XCTestCase {
         let app = Application(.testing)
         app.http.server.configuration.address = .hostname(nil, port: 8008)
         defer { app.shutdown() }
+        app.environment.arguments = ["serve"]
 
         XCTAssertNoThrow(try app.start())
     }
@@ -564,6 +568,7 @@ final class ServerTests: XCTestCase {
         let app = Application(.testing)
         app.http.server.configuration.address = .hostname("0.0.0.0", port: nil)
         defer { app.shutdown() }
+        app.environment.arguments = ["serve"]
         
         XCTAssertNoThrow(try app.start())
     }
@@ -641,6 +646,7 @@ final class ServerTests: XCTestCase {
 
         let port = 1337
         app.http.server.configuration.port = port
+        app.environment.arguments = ["serve"]
         try app.start()
 
         let request = try HTTPClient.Request(

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -28,6 +28,7 @@ final class ServiceTests: XCTestCase {
         defer { app.shutdown() }
 
         app.lifecycle.use(Hello())
+        app.environment.arguments = ["serve"]
         try app.start()
         app.running?.stop()
     }

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -40,6 +40,8 @@ final class WebSocketTests: XCTestCase {
             ws.close(promise: nil)
         }
 
+        app.environment.arguments = ["serve"]
+
         try app.start()
 
         do {
@@ -61,6 +63,7 @@ final class WebSocketTests: XCTestCase {
             ws.send("foo")
             ws.close(promise: nil)
         }
+        app.environment.arguments = ["serve"]
 
         try app.start()
         let promise = app.eventLoopGroup.next().makePromise(of: String.self)
@@ -128,6 +131,8 @@ final class WebSocketTests: XCTestCase {
             webSockets.track(ws)
             ws.send("hello")
         }
+
+        app.environment.arguments = ["serve"]
 
         try app.start()
 


### PR DESCRIPTION
Override the argument when actually running the server to stop it picking up swift test commands. Resolves #2568﻿
