### PR TITLE
Support automatic port picking

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -286,6 +286,10 @@ public final class HTTPServer: Server {
         self.configuration.logger.debug("HTTP server shutting down")
         self.didShutdown = true
     }
+
+    public var localAddress: SocketAddress? {
+        return self.connection?.channel.localAddress
+    }
     
     deinit {
         assert(!self.didStart || self.didShutdown, "HTTPServer did not shutdown before deinitializing")

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -107,4 +107,33 @@ final class ApplicationTests: XCTestCase {
         let res = try app.client.get("http://localhost:8080/hello").wait()
         XCTAssertEqual(res.body?.string, "Hello, world!")
     }
+
+    func testAutomaticPortPickingWorks() {
+        let app = Application(.testing)
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+        defer { app.shutdown() }
+
+        app.get("hello") { req in
+            "Hello, world!"
+        }
+
+        XCTAssertNil(app.http.server.shared.localAddress)
+
+        XCTAssertNoThrow(try app.start())
+
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let ip = localAddress.ipAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        XCTAssertEqual("127.0.0.1", ip)
+        XCTAssertGreaterThan(port, 0)
+
+        XCTAssertEqual("Hello, world!",
+                       try app.client.get("http://localhost:\(port)/hello").wait().body?.string)
+    }
 }


### PR DESCRIPTION
- Allow automatic port picking by configuring port 0 and interrogating `app.http.server.shared.localAddress` about the chosen port (fixes #2409).

> Note: Previously, automatic port picking was supported but it was impossible to retrieve the selected port back from Vapor.