### PR TITLE
Conform MultipartError to AbortError

### DIFF
--- a/Sources/Vapor/Multipart/AbortError+MultipartError.swift
+++ b/Sources/Vapor/Multipart/AbortError+MultipartError.swift
@@ -1,0 +1,12 @@
+import MultipartKit
+
+extension MultipartError: AbortError {
+    public var status: HTTPResponseStatus {
+        switch self {
+        case .nesting:
+            return .notImplemented
+        default:
+            return .badRequest
+        }
+    }
+}

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -145,6 +145,28 @@ final class ErrorTests: XCTestCase {
             XCTAssertContains(error.stackTrace?.frames[2].function, "foo")
         }
     }
+
+    func testMultipartErrorReturnsBadRequest() {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.get("multipart") { req -> String in
+            throw MultipartError.missingFilename
+        }
+
+        app.post("mulitpartNesting") { req -> String in
+            throw MultipartError.nesting
+        }
+
+
+        XCTAssertNoThrow(try app.test(.GET, "multipart") { res in
+            XCTAssertEqual(res.status, .badRequest)
+        })
+
+        XCTAssertNoThrow(try app.test(.GET, "multipartNesting") { res in
+            XCTAssertEqual(res.status, .notImplemented)
+        })
+    }
 }
 
 func XCTAssertContains(

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -154,7 +154,7 @@ final class ErrorTests: XCTestCase {
             throw MultipartError.missingFilename
         }
 
-        app.post("mulitpartNesting") { req -> String in
+        app.get("mulitpartNesting") { req -> String in
             throw MultipartError.nesting
         }
 
@@ -163,7 +163,7 @@ final class ErrorTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         })
 
-        XCTAssertNoThrow(try app.test(.GET, "multipartNesting") { res in
+        XCTAssertNoThrow(try app.test(.GET, "mulitpartNesting") { res in
             XCTAssertEqual(res.status, .notImplemented)
         })
     }


### PR DESCRIPTION
Conform MultipartError to AbortError so that failing requests return a sensible status code to the client, instead of an internal server error.

Resolves #2573 