### PR TITLE
Fix potential race condition when accessing Application.http.client.shared

### DIFF
--- a/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
+++ b/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
@@ -17,25 +17,21 @@ extension Application.HTTP {
         let application: Application
 
         public var shared: HTTPClient {
+            let lock = self.application.locks.lock(for: Key.self)
+            lock.lock()
+            defer { lock.unlock() }
             if let existing = self.application.storage[Key.self] {
                 return existing
-            } else {
-                let lock = self.application.locks.lock(for: Key.self)
-                lock.lock()
-                defer { lock.unlock() }
-                if let existing = self.application.storage[Key.self] {
-                    return existing
-                }
-                let new = HTTPClient(
-                    eventLoopGroupProvider: .shared(self.application.eventLoopGroup),
-                    configuration: self.configuration,
-                    backgroundActivityLogger: self.application.logger
-                )
-                self.application.storage.set(Key.self, to: new) {
-                    try $0.syncShutdown()
-                }
-                return new
             }
+            let new = HTTPClient(
+                eventLoopGroupProvider: .shared(self.application.eventLoopGroup),
+                configuration: self.configuration,
+                backgroundActivityLogger: self.application.logger
+            )
+            self.application.storage.set(Key.self, to: new) {
+                try $0.syncShutdown()
+            }
+            return new
         }
 
         public var configuration: HTTPClient.Configuration {


### PR DESCRIPTION
The accessor for `Application.http.client.shared` was performing a lookup in the storage dictionary using double-checked locking, which is not actually thread-safe (despite all appearances to the contrary). It now unconditionally takes the lock before performing the lookup.

Applications making heavy use of `Request.client` or `Application.client` may experience a performance regression from this change.