### PR TITLE
reversed shutdown order of LifecycleHandlers

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -125,7 +125,7 @@ public final class Application {
         self.logger.debug("Application shutting down")
 
         self.logger.trace("Shutting down providers")
-        self.lifecycle.handlers.forEach { $0.shutdown(self) }
+        self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
         self.lifecycle.handlers = []
         
         self.logger.trace("Clearing Application storage")


### PR DESCRIPTION
I want my vapor backend to count the requests to allow each user only a certain number of requests.
Since there are a lot of requests, I don't want to query the database for each request just to check and decrease a counter.
Therefore I want to download the data from the database once at the beginning and then cache them locally.
This cache is then regularly synchronized with the database.
To write the data on shutdown into the database I implemented a LifecycleHandler.
The problem is, that the LifecycleHandler has to be registered after the database, because it needs the data from the database.
Because of this the LifecycleHandler's shutdown function is called when the database connection is already closed.
This leads to the fact that a new connection is created to synchronize the cache.
This connection will not be closed afterwards, because the LifecycleHandler of the database already finished.
This leads to the error "ConnectionPool.shutdown() was not called before deinit."
To solve this I reversed the order of the LifecycleHandlers for the shutdown.