### PR TITLE
Fix: URLEncodedFormDecoder ignores empty value when decoding Array

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -286,19 +286,15 @@ private struct _Decoder: Decoder {
                 if let valuesInBracket = data.children[""] {
                     values = values + valuesInBracket.values
                 }
+                
                 // parse out any character separated array values
-                for explodeArraysOn in configuration.arraySeparators {
-                    var explodedValues: [URLQueryFragment] = []
-                    for value in values {
-                        let splitted = try value.asUrlEncoded()
-                            .split(separator: explodeArraysOn, omittingEmptySubsequences: false)
-                        explodedValues = explodedValues + splitted.map { (ss: Substring) in
-                            URLQueryFragment.urlEncoded(String(ss))
-                        }
+                self.values = try values.flatMap { value in
+                    try value.asUrlEncoded().split(omittingEmptySubsequences: false) {
+                        configuration.arraySeparators.contains($0)
+                    }.map { (ss: Substring) in
+                        URLQueryFragment.urlEncoded(String(ss))
                     }
-                    values = explodedValues
                 }
-                self.values = values
             }
         }
         

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -290,9 +290,11 @@ private struct _Decoder: Decoder {
                 for explodeArraysOn in configuration.arraySeparators {
                     var explodedValues: [URLQueryFragment] = []
                     for value in values {
-                        explodedValues = try explodedValues + value.asUrlEncoded().split(separator: explodeArraysOn).map({ (ss: Substring) -> URLQueryFragment in
-                            return .urlEncoded(String(ss))
-                        })
+                        let splitted = try value.asUrlEncoded()
+                            .split(separator: explodeArraysOn, omittingEmptySubsequences: false)
+                        explodedValues = explodedValues + splitted.map { (ss: Substring) in
+                            URLQueryFragment.urlEncoded(String(ss))
+                        }
                     }
                     values = explodedValues
                 }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -289,11 +289,12 @@ private struct _Decoder: Decoder {
                 
                 // parse out any character separated array values
                 self.values = try values.flatMap { value in
-                    try value.asUrlEncoded().split(omittingEmptySubsequences: false) {
-                        configuration.arraySeparators.contains($0)
-                    }.map { (ss: Substring) in
-                        URLQueryFragment.urlEncoded(String(ss))
-                    }
+                    try value.asUrlEncoded()
+                        .split(omittingEmptySubsequences: false,
+                               whereSeparator: configuration.arraySeparators.contains)
+                        .map { (ss: Substring) in
+                            URLQueryFragment.urlEncoded(String(ss))
+                        }
                 }
             }
         }

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -107,11 +107,28 @@ final class URLEncodedFormTests: XCTestCase {
         }
 
         let data = """
-        array[0]=a&array[1]=b
+        array[0]=a&array[1]=&array[2]=b&array[3]=
         """
         let test = try URLEncodedFormDecoder().decode(Test.self, from: data)
         XCTAssertEqual(test.array[0], "a")
-        XCTAssertEqual(test.array[1], "b")
+        XCTAssertEqual(test.array[1], "")
+        XCTAssertEqual(test.array[2], "b")
+        XCTAssertEqual(test.array[3], "")
+    }
+    
+    func testDecodeUnindexedArray() throws {
+        struct Test: Decodable {
+            let array: [String]
+        }
+
+        let data = """
+        array[]=a&array[]=&array[]=b&array[]=
+        """
+        let test = try URLEncodedFormDecoder().decode(Test.self, from: data)
+        XCTAssertEqual(test.array[0], "a")
+        XCTAssertEqual(test.array[1], "")
+        XCTAssertEqual(test.array[2], "b")
+        XCTAssertEqual(test.array[3], "")
     }
 
     func testDecodeIndexedArray_dictionary() throws {


### PR DESCRIPTION
When `URLEncodedFormDecoder` decodes `array[]=a&array[]=&array[]=b&array[]=`, empty values are ignored and we get incorrect result `["a", "b"]`.
After this change the result will be `["a", "", "b", ""]`.