### PR TITLE
Avoid a `try!` and an IUO in `XCTVaporTests`

### DIFF
--- a/Sources/XCTVapor/XCTVaporTests.swift
+++ b/Sources/XCTVapor/XCTVaporTests.swift
@@ -5,13 +5,14 @@ public var app: (() throws -> Application) = {
 open class XCTVaporTests: XCTestCase {
     open var app: Application!
     
-    open override func setUp() {
+    open override func setUpWithError() throws {
         super.setUp()
-        self.app = try! XCTVapor.app()
+        self.app = try XCTVapor.app()
     }
     
     open override func tearDown() {
         super.tearDown()
-        self.app.shutdown()
+        self.app?.shutdown()
+        app = nil
     }
 }


### PR DESCRIPTION
Improves `XCTVaporTests` by removing `try!` and an implicitly unwrapped optional. (#2585)

Resolves #2582