### PR TITLE
Fixes - Restore previous XCTVaporTests behavior if necc.

### DIFF
--- a/Sources/XCTVapor/XCTVaporTests.swift
+++ b/Sources/XCTVapor/XCTVaporTests.swift
@@ -30,6 +30,11 @@ open class XCTVaporTests: XCTestCase {
         }
 
         if self.app == nil {
+            // this was the behavior of this class pre 4.41.5
+            // keeping for compatibility however it will crash if
+            // the function throws. Provided the user assigns to
+            // XCTVapor.app in the class setUp or setUpWithError everything will work
+            // as we intend.
             self.app = try! _app()
         }
     }

--- a/Sources/XCTVapor/XCTVaporTests.swift
+++ b/Sources/XCTVapor/XCTVaporTests.swift
@@ -25,15 +25,12 @@ open class XCTVaporTests: XCTestCase {
 
         super.setUp()
 
-        if self.app == nil, let _app = XCTVapor.app {
-            // this was the behavior of this class pre 4.41.5
-            // keeping for compatability however it will crash obv if
-            // the function throws. Provided the user assigns to
-            // XCTVapor.app in the class setUp everything will work
-            // as we intend.
-            self.app = try! _app()
-        } else {
+        guard let _app = XCTVapor.app else {
             fatalError("implement static app generator")
+        }
+
+        if self.app == nil {
+            self.app = try! _app()
         }
     }
 


### PR DESCRIPTION
Properly restores previous behaviour as described here https://github.com/vapor/vapor/pull/2587#issuecomment-802903118
