### PR TITLE
Add stack trace to `RouteNotFound` error to improve `DebuggableError` conformance

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -120,7 +120,13 @@ private struct NotFoundResponder: Responder {
     }
 }
 
-struct RouteNotFound: Error { }
+struct RouteNotFound: Error {
+    let stackTrace: StackTrace?
+
+    init() {
+        self.stackTrace = StackTrace.capture(skip: 1)
+    }
+}
 
 extension RouteNotFound: AbortError {
     static var typeIdentifier: String {

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -128,11 +128,7 @@ struct RouteNotFound: Error {
     }
 }
 
-extension RouteNotFound: AbortError {
-    static var typeIdentifier: String {
-        "Abort"
-    }
-    
+extension RouteNotFound: AbortError {    
     var status: HTTPResponseStatus {
         .notFound
     }


### PR DESCRIPTION
Adds a stacktrace to the `RouteNotFound` error so that error reporting tools have access to it.

Resolves #2532﻿
