### PR TITLE
Change Vapor's logging levels for errors.

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -140,7 +140,7 @@ public final class Application {
             do {
                 try self.eventLoopGroup.syncShutdownGracefully()
             } catch {
-                self.logger.error("Shutting down EventLoopGroup failed: \(error)")
+                self.logger.warning("Shutting down EventLoopGroup failed: \(error)")
             }
         }
 

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -23,7 +23,7 @@ extension DotEnvFile {
             do {
                 try threadPool.syncShutdownGracefully()
             } catch {
-                logger.error("Shutting down threadPool failed: \(error)")
+                logger.warning("Shutting down threadPool failed: \(error)")
             }
         }
         let fileio = NonBlockingFileIO(threadPool: threadPool)
@@ -55,7 +55,7 @@ extension DotEnvFile {
             do {
                 try threadPool.syncShutdownGracefully()
             } catch {
-                logger.error("Shutting down threadPool failed: \(error)")
+                logger.warning("Shutting down threadPool failed: \(error)")
             }
         }
         let fileio = NonBlockingFileIO(threadPool: threadPool)

--- a/Sources/Vapor/Error/DebuggableError.swift
+++ b/Sources/Vapor/Error/DebuggableError.swift
@@ -106,7 +106,7 @@ extension DebuggableError {
     }
 
     public var logLevel: Logger.Level { 
-        .error
+        .warning
     }
 }
 

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -24,20 +24,25 @@ extension Logger {
         case let abort as AbortError:
             reason = abort.reason
             source = nil
-            level = .error
+            
+            if (500...599).contains(abort.status.code) {
+                level = .error
+            } else {
+                level = .warning
+            }
         case let localized as LocalizedError:
             reason = localized.localizedDescription
             source = nil
-            level = .error
+            level = .warning
         case let convertible as CustomStringConvertible:
             reason = convertible.description
             source = nil
-            level = .error
+            level = .warning
         default:
             reason = "\(error)"
             source = nil
-            level = .error
-        }
+            level = .warning
+        
         self.log(
             level: level,
             .init(stringLiteral: reason),

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -42,6 +42,7 @@ extension Logger {
             reason = "\(error)"
             source = nil
             level = .warning
+        }
         
         self.log(
             level: level,
@@ -50,52 +51,5 @@ extension Logger {
             function: source?.function ?? function,
             line: numericCast(source?.line ?? line)
         )
-    }
-}
-
-struct MyError: DebuggableError {
-    enum Value {
-        case userNotLoggedIn
-        case invalidEmail(String)
-    }
-
-    var identifier: String {
-        switch self.value {
-        case .userNotLoggedIn:
-            return "userNotLoggedIn"
-        case .invalidEmail:
-            return "invalidEmail"
-        }
-    }
-
-    var reason: String {
-        switch self.value {
-        case .userNotLoggedIn:
-            return "User is not logged in."
-        case .invalidEmail(let email):
-            return "Email address is not valid: \(email)."
-        }
-    }
-
-    var value: Value
-    var source: ErrorSource?
-    var stackTrace: StackTrace?
-
-    init(
-        _ value: Value,
-        file: String = #file,
-        function: String = #function,
-        line: UInt = #line,
-        column: UInt = #column,
-        stackTrace: StackTrace? = .capture()
-    ) {
-        self.value = value
-        self.source = .init(
-            file: file,
-            function: function,
-            line: line,
-            column: column
-        )
-        self.stackTrace = stackTrace
     }
 }

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -62,7 +62,7 @@ public struct DotEnvFile {
                 do {
                     try eventLoopGroup.syncShutdownGracefully()
                 } catch {
-                    logger.error("Shutting down EventLoopGroup failed: \(error)")
+                    logger.warning("Shutting down EventLoopGroup failed: \(error)")
                 }
             }
         }
@@ -109,7 +109,7 @@ public struct DotEnvFile {
                 do {
                     try eventLoopGroup.syncShutdownGracefully()
                 } catch {
-                    logger.error("Shutting down EventLoopGroup failed: \(error)")
+                    logger.warning("Shutting down EventLoopGroup failed: \(error)")
                 }
             }
         }

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -8,7 +8,7 @@ public struct Storage {
             do {
                 try self.onShutdown?(self.value)
             } catch {
-                logger.error("Could not shutdown \(T.self): \(error)")
+                logger.warning("Could not shutdown \(T.self): \(error)")
             }
         }
     }


### PR DESCRIPTION
> ⚠️ If you're relying on Vapor logging errors at the `.error` level you should review this release to ensure that you don't start losing errors. ⚠️ 

As per the [log level guidelines from the SSWG](https://github.com/swift-server/guides/pull/19) this changes many of the errors logged in Vapor to use the `.warning` level instead of `.error`. (#2598)

Fixes #2586.