### PR TITLE
Change `AbortError` 5xx logging to always be `warning`

### DIFF
--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -24,12 +24,7 @@ extension Logger {
         case let abort as AbortError:
             reason = abort.reason
             source = nil
-            
-            if (500...599).contains(abort.status.code) {
-                level = .error
-            } else {
-                level = .warning
-            }
+            level = .warning
         case let localized as LocalizedError:
             reason = localized.localizedDescription
             source = nil


### PR DESCRIPTION
Changes logging level for `AbortError` to always be `warning` regardless of status code. (#2600)