### PR TITLE
Add expiration time to `Cache` protocol and in-memory cache.

### DIFF
--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -8,11 +8,22 @@ public protocol Cache {
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
         where T: Encodable
     
+    /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
+    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+        where T: Encodable
+    
     /// Creates a request-specific cache instance.
     func `for`(_ request: Request) -> Self
 }
 
 extension Cache {
+    /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
+    public func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+        where T: Encodable
+    {
+        return self.set(key, to: value)
+    }
+    
     /// Gets a decodable value from the cache. Returns `nil` if not found.
     public func get<T>(_ key: String) -> EventLoopFuture<T?>
         where T: Decodable

--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -9,7 +9,7 @@ public protocol Cache {
         where T: Encodable
     
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
-    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+    func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
         where T: Encodable
     
     /// Creates a request-specific cache instance.
@@ -18,7 +18,7 @@ public protocol Cache {
 
 extension Cache {
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
-    public func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+    public func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
         where T: Encodable
     {
         return self.set(key, to: value)

--- a/Sources/Vapor/Cache/CacheExpirationTime.swift
+++ b/Sources/Vapor/Cache/CacheExpirationTime.swift
@@ -1,0 +1,21 @@
+/// Defines the lifetime of an entry in a cache.
+public enum CacheExpirationTime {
+    case seconds(Int)
+    case minutes(Int)
+    case hours(Int)
+    case days(Int)
+    
+    /// Returns the amount of time in seconds.
+    public var seconds: Int {
+        switch self {
+        case let .seconds(seconds):
+            return seconds
+        case let .minutes(minutes):
+            return minutes * 60
+        case let .hours(hours):
+            return hours * 60 * 60
+        case let .days(days):
+            return days * 24 * 60 * 60
+        }
+    }
+}

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -34,6 +34,16 @@ private struct MemoryCacheKey: LockKey, StorageKey {
 }
 
 private final class MemoryCacheStorage {
+    struct CacheEntryBox<T> {
+        var expiresAt: Date?
+        var value: T
+        
+        init(_ value: T) {
+            self.expiresAt = nil
+            self.value = value
+        }
+    }
+    
     private var storage: [String: Any]
     private var lock: Lock
     
@@ -47,16 +57,27 @@ private final class MemoryCacheStorage {
     {
         self.lock.lock()
         defer { self.lock.unlock() }
-        return self.storage[key] as? T
+        
+        guard let box = self.storage[key] as? CacheEntryBox<T> else { return nil }
+        if let expiresAt = box.expiresAt, expiresAt < Date() {
+            self.storage.removeValue(forKey: key)
+            return nil
+        }
+        
+        return box.value
     }
     
-    func set<T>(_ key: String, to value: T?)
+    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?)
         where T: Encodable
     {
         self.lock.lock()
         defer { self.lock.unlock() }
         if let value = value {
-            self.storage[key] = value
+            var box = CacheEntryBox(value)
+            if let expiresIn = expiresIn {
+                box.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn.seconds))
+            }
+            self.storage[key] = box
         } else {
             self.storage.removeValue(forKey: key)
         }
@@ -79,10 +100,15 @@ private struct MemoryCache: Cache {
     }
     
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
-        where T: Encodable
-    
+        where T : Encodable
     {
-        self.storage.set(key, to: value)
+        self.set(key, to: value, expiresIn: nil)
+    }
+    
+    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+        where T : Encodable
+    {
+        self.storage.set(key, to: value, expiresIn: expiresIn)
         return self.eventLoop.makeSucceededFuture(())
     }
     

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -67,15 +67,15 @@ private final class MemoryCacheStorage {
         return box.value
     }
     
-    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?)
+    func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?)
         where T: Encodable
     {
         self.lock.lock()
         defer { self.lock.unlock() }
         if let value = value {
             var box = CacheEntryBox(value)
-            if let expiresIn = expiresIn {
-                box.expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn.seconds))
+            if let expirationTime = expirationTime {
+                box.expiresAt = Date().addingTimeInterval(TimeInterval(expirationTime.seconds))
             }
             self.storage[key] = box
         } else {
@@ -105,10 +105,10 @@ private struct MemoryCache: Cache {
         self.set(key, to: value, expiresIn: nil)
     }
     
-    func set<T>(_ key: String, to value: T?, expiresIn: CacheExpirationTime?) -> EventLoopFuture<Void>
+    func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
         where T : Encodable
     {
-        self.storage.set(key, to: value, expiresIn: expiresIn)
+        self.storage.set(key, to: value, expiresIn: expirationTime)
         return self.eventLoop.makeSucceededFuture(())
     }
     

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -100,13 +100,13 @@ private struct MemoryCache: Cache {
     }
     
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
-        where T : Encodable
+        where T: Encodable
     {
         self.set(key, to: value, expiresIn: nil)
     }
     
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
-        where T : Encodable
+        where T: Encodable
     {
         self.storage.set(key, to: value, expiresIn: expirationTime)
         return self.eventLoop.makeSucceededFuture(())

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -1,19 +1,26 @@
 import XCTVapor
 
 final class CacheTests: XCTestCase {
-    func testDefaultCache() throws {
+    func testInMemoryCache() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         
         try XCTAssertNil(app.cache.get("foo", as: String.self).wait())
         try app.cache.set("foo", to: "bar").wait()
         try XCTAssertEqual(app.cache.get("foo").wait(), "bar")
+        
+        // Test expiration
+        try app.cache.set("foo2", to: "bar2", expiresIn: .seconds(1)).wait()
+        try XCTAssertEqual(app.cache.get("foo2").wait(), "bar2")
+        sleep(1)
+        try XCTAssertEqual(app.cache.get("foo2", as: String.self).wait(), nil)
     }
     
     func testCustomCache() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         app.caches.use(.foo)
+        try app.cache.set("1", to: "2").wait()
         try XCTAssertEqual(app.cache.get("foo").wait(), "bar")
     }
 }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -13,7 +13,7 @@ final class CacheTests: XCTestCase {
         try app.cache.set("foo2", to: "bar2", expiresIn: .seconds(1)).wait()
         try XCTAssertEqual(app.cache.get("foo2").wait(), "bar2")
         sleep(1)
-        try XCTAssertEqual(app.cache.get("foo2", as: String.self).wait(), nil)
+        try XCTAssertNil(app.cache.get("foo2", as: String.self).wait())
     }
     
     func testCustomCache() throws {


### PR DESCRIPTION
Adds expiration time functionality to the `Cache` protocol and the default in-memory cache.

An expiration time can be set on a cache entry like so:
```swift
app.cache.set("username", to: "mads", expiresIn: .seconds(30))
```