### PR TITLE
Fix warnings from Swift 5.4 compiler

### DIFF
--- a/Sources/Vapor/Utilities/Extendable.swift
+++ b/Sources/Vapor/Utilities/Extendable.swift
@@ -8,7 +8,7 @@
 ///         }
 ///     }
 ///
-public protocol Extendable: class {
+public protocol Extendable: AnyObject {
     /// Arbitrary property storage. See `Extend` and `Extendable`.
     var extend: Extend { get set }
 }


### PR DESCRIPTION
Fixes the following warnings now produced by the Swift 5.4 compiler:

```
warning: using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead
public protocol Extendable: class {
                            ^~~~~
                            AnyObject
```
