### PR TITLE
Enable compiling on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "vapor",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_15),
+       .iOS(.v13),
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),


### PR DESCRIPTION
Enable experimental support of iOS. We need to expand testing and potentially move to `NIOTransportServices` but this allows Vapor to compile on iOS.
