### PR TITLE
Fix warning when registering HEAD routes for GET requests

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -44,6 +44,14 @@ public func routes(_ app: Application) throws {
 
         return done.futureResult
     }
+
+    app.get("test", "head") { req -> String in
+        return "OK!"
+    }
+
+    app.post("test", "head") { req -> String in
+        return "OK!"
+    }
     
     app.post("login") { req -> String in
         let creds = try req.content.decode(Creds.self)

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -35,7 +35,7 @@ internal struct DefaultResponder: Responder {
             // If the route isn't explicitly a HEAD route,
             // and it's made up solely of .constant components,
             // register a HEAD route with the same path
-            if route.method != .HEAD &&
+            if route.method == .GET &&
                 route.path.allSatisfy({ component in
                     if case .constant(_) = component { return true }
                     return false


### PR DESCRIPTION
Fixes an issue where the `DefaultResponder` would add HEAD routes for all requests instead of just GET requests, resulting in `[Routing] Warning: Overriding route output at: HEAD/some/route` if you registered routes at the same path with different methods.