### PR TITLE
Fix Array `beforeEncode`/`afterDecode` for `Content`

### DIFF
--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -123,6 +123,18 @@ extension Array: Content, ResponseEncodable, RequestDecodable where Element: Con
     public static var defaultContentType: HTTPMediaType {
         return .json
     }
+
+    public mutating func beforeEncode() throws {
+        for var element in self {
+            try element.beforeEncode()
+        }
+    }
+
+    public mutating func afterDecode() throws {
+        for var element in self {
+            try element.afterDecode()
+        }
+    }
 }
 extension Dictionary: Content, ResponseEncodable, RequestDecodable where Key == String, Value: Content {
     public static var defaultContentType: HTTPMediaType {

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -125,14 +125,20 @@ extension Array: Content, ResponseEncodable, RequestDecodable where Element: Con
     }
 
     public mutating func beforeEncode() throws {
-        for var element in self {
+        for index in 0..<self.count {
+            var element = self[index]
             try element.beforeEncode()
+            self.remove(at: index)
+            self.insert(element, at: index)
         }
     }
 
     public mutating func afterDecode() throws {
-        for var element in self {
+        for index in 0..<self.count {
+            var element = self[index]
             try element.afterDecode()
+            self.remove(at: index)
+            self.insert(element, at: index)
         }
     }
 }

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -82,7 +82,9 @@ extension Content {
         return request.eventLoop.makeSucceededFuture(response)
     }
 
+    @_disfavoredOverload
     public mutating func beforeEncode() throws { }
+    @_disfavoredOverload
     public mutating func afterDecode() throws { }
 }
 
@@ -124,17 +126,17 @@ extension Array: Content, ResponseEncodable, RequestDecodable where Element: Con
         return .json
     }
 
-    public mutating func beforeEncode() throws {
-        for index in 0..<self.count {
-            try self[index].beforeEncode()
-        }
-    }
-
-    public mutating func afterDecode() throws {
-        for index in 0..<self.count {
-            try self[index].afterDecode()
-        }
-    }
+//    public mutating func beforeEncode() throws {
+//        for index in 0..<self.count {
+//            try self[index].beforeEncode()
+//        }
+//    }
+//
+//    public mutating func afterDecode() throws {
+//        for index in 0..<self.count {
+//            try self[index].afterDecode()
+//        }
+//    }
 }
 extension Dictionary: Content, ResponseEncodable, RequestDecodable where Key == String, Value: Content {
     public static var defaultContentType: HTTPMediaType {

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -126,19 +126,13 @@ extension Array: Content, ResponseEncodable, RequestDecodable where Element: Con
 
     public mutating func beforeEncode() throws {
         for index in 0..<self.count {
-            var element = self[index]
-            try element.beforeEncode()
-            self.remove(at: index)
-            self.insert(element, at: index)
+            try self[index].beforeEncode()
         }
     }
 
     public mutating func afterDecode() throws {
         for index in 0..<self.count {
-            var element = self[index]
-            try element.afterDecode()
-            self.remove(at: index)
-            self.insert(element, at: index)
+            try self[index].afterDecode()
         }
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -392,14 +392,14 @@ final class ContentTests: XCTestCase {
     }
 }
 
-private final class SampleContent: Content {
+private struct SampleContent: Content {
     var name = "old name"
 
-    func beforeEncode() throws {
+    mutating func beforeEncode() throws {
         name = "new name"
     }
 
-    func afterDecode() throws {
+    mutating func afterDecode() throws {
         name = "new name after decode"
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -404,6 +404,34 @@ private struct SampleContent: Content {
     }
 }
 
+extension Array where Element: Content {
+    mutating func beforeEncode() throws {
+        for index in 0..<self.count {
+            try self[index].beforeEncode()
+        }
+    }
+
+    mutating func afterDecode() throws {
+        for index in 0..<self.count {
+            try self[index].afterDecode()
+        }
+    }
+}
+
+extension Array where Element == SampleContent {
+    mutating func beforeEncode() throws {
+        for index in 0..<self.count {
+            try self[index].beforeEncode()
+        }
+    }
+
+    mutating func afterDecode() throws {
+        for index in 0..<self.count {
+            try self[index].afterDecode()
+        }
+    }
+}
+
 private struct JsonApiContent: Content {
     struct Meta: Codable {}
     

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -306,7 +306,7 @@ final class ContentTests: XCTestCase {
         try response.content.encode([content1, content2])
 
         let body = try XCTUnwrap(response.body.string)
-        XCTAssertEqual(body, #"[{"name":"new name"},{"name": "new name"}]"#)
+        XCTAssertEqual(body, #"[{"name":"new name"},{"name":"new name"}]"#)
     }
 
     func testAfterDecodeContentWithArray() throws {
@@ -392,14 +392,14 @@ final class ContentTests: XCTestCase {
     }
 }
 
-private struct SampleContent: Content {
+private final class SampleContent: Content {
     var name = "old name"
 
-    mutating func beforeEncode() throws {
+    func beforeEncode() throws {
         name = "new name"
     }
 
-    mutating func afterDecode() throws {
+    func afterDecode() throws {
         name = "new name after decode"
     }
 }


### PR DESCRIPTION
This fixes a bug where `beforeEncode` or `afterDecode` wouldn't be called on an array of `Content`.

However to make this work for value types, it requires replacing each element in the array which could be a significant slow down. Thoughts?