### PR TITLE
Fix building Vapor for tvOS and watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,10 @@ import PackageDescription
 let package = Package(
     name: "vapor",
     platforms: [
-       .macOS(.v10_15),
-       .iOS(.v13),
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "Vapor", targets: ["Vapor"]),


### PR DESCRIPTION
Fixes building Vapor for tvOS and watchOS by setting the minimum platform versions to match Swift Crypto (#2624)