### PR TITLE
Fix issue when using `:` in HTTP Basic Authentication passwords

### DIFF
--- a/Sources/Vapor/Authentication/BasicAuthorization.swift
+++ b/Sources/Vapor/Authentication/BasicAuthorization.swift
@@ -31,7 +31,7 @@ extension HTTPHeaders {
             guard let decodedToken = Data(base64Encoded: .init(headerParts[1])) else {
                 return nil
             }
-            let parts = String.init(decoding: decodedToken, as: UTF8.self).split(separator: ":")
+            let parts = String.init(decoding: decodedToken, as: UTF8.self).split(separator: ":", maxSplits: 1)
 
             guard parts.count == 2 else {
                 return nil


### PR DESCRIPTION
This fixes a bug where using a password with `:` would not be able to authenticate using Vapor's Basic Authorisation. Using colons in a password was previously leading to an edge case as the authentication string was being split on any ":" making it impossible for users who registered with such passwords to ever authenticate. This allows for colons (`:`) to be valid characters in passwords (e.g. "This:is_myPassword123!").
