### PR TITLE
Add basic docstrings for `Application` and `Request`

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,5 +1,6 @@
 import Backtrace
 
+/// Core type representing a Vapor application.
 public final class Application {
     public var environment: Environment
     public let eventLoopGroupProvider: EventLoopGroupProvider

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -1,5 +1,6 @@
 import NIO
 
+/// Represents an HTTP request in an application.
 public final class Request: CustomStringConvertible {
     public let application: Application
 


### PR DESCRIPTION
This adds inline documentation for `Application` and `Request`. This helps when trying to integrate Jazzy (https://github.com/realm/jazzy/issues/936)