### PR TITLE
Fix issues with date parsing in HTTP headers

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -37,8 +37,6 @@ extension HTTPHeaders {
 
     private func getSeparatorCharacters(for headerName: Name) -> [Character] {
         switch headerName {
-        case .accept, .acceptLanguage, .acceptEncoding, .forwarded, .range:
-            return [.comma, .semicolon]
         case .setCookie, .setCookie2, .ifModifiedSince, .date:
             return [.semicolon]
         default: return [.comma, .semicolon]

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -38,7 +38,7 @@ extension HTTPHeaders {
     private func getSeparatorCharacters(for headerName: Name) -> [Character] {
         switch headerName {
         // Headers with dates can't have comma as a separator
-        case .setCookie, .setCookie2, .ifModifiedSince, .date:
+        case .setCookie, .ifModifiedSince, .date, .lastModified, .lastModified, .expires:
             return [.semicolon]
         default: return [.comma, .semicolon]
         }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -37,6 +37,7 @@ extension HTTPHeaders {
 
     private func getSeparatorCharacters(for headerName: Name) -> [Character] {
         switch headerName {
+        // Headers with dates can't have comma as a separator
         case .setCookie, .setCookie2, .ifModifiedSince, .date:
             return [.semicolon]
         default: return [.comma, .semicolon]

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -132,6 +132,20 @@ final class HTTPHeaderTests: XCTestCase {
         }
     }
 
+    func testComplexCookieParsing() throws {
+        var headers = HTTPHeaders()
+        do {
+            headers.add(name: .setCookie, value: "SIWA_STATE=CJKxa71djx6CaZ0MwRjtvtJ5Zub+kfaoIEZGoY3wXKA=; Path=/; SameSite=None")
+            headers.add(name: .setCookie, value: "vapor-session=TL7r+TS3RNhpEC6HoCfukq+7edNHKF2elF6WiKV4JCg=; Expires=Wed, 02 Jun 2021 14:57:57 GMT; Path=/; SameSite=None")
+            XCTAssertEqual(headers.setCookie?.all.count, 2)
+            let siwaState = try XCTUnwrap(headers.setCookie?["SIWA_STATE"])
+            XCTAssertEqual(siwaState.sameSite, HTTPCookies.SameSitePolicy.none)
+
+            let vaporSession = try XCTUnwrap(headers.setCookie?["vapor-session"])
+            XCTAssertEqual(vaporSession.sameSite, HTTPCookies.SameSitePolicy.none)
+        }
+    }
+
     func testForwarded_quote() throws {
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .forwarded, value: #"For="[2001:db8:cafe::17]:4711""#)

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -135,14 +135,20 @@ final class HTTPHeaderTests: XCTestCase {
     func testComplexCookieParsing() throws {
         var headers = HTTPHeaders()
         do {
-            headers.add(name: .setCookie, value: "SIWA_STATE=CJKxa71djx6CaZ0MwRjtvtJ5Zub+kfaoIEZGoY3wXKA=; Path=/; SameSite=None")
-            headers.add(name: .setCookie, value: "vapor-session=TL7r+TS3RNhpEC6HoCfukq+7edNHKF2elF6WiKV4JCg=; Expires=Wed, 02 Jun 2021 14:57:57 GMT; Path=/; SameSite=None")
+            headers.add(name: .setCookie, value: "SIWA_STATE=CJKxa71djx6CaZ0MwRjtvtJ5Zub+kfaoIEZGoY3wXKA=; Path=/; SameSite=None; HttpOnly; Secure")
+            headers.add(name: .setCookie, value: "vapor-session=TL7r+TS3RNhpEC6HoCfukq+7edNHKF2elF6WiKV4JCg=; Expires=Wed, 02 Jun 2021 14:57:57 GMT; Path=/; SameSite=None; HttpOnly; Secure")
             XCTAssertEqual(headers.setCookie?.all.count, 2)
             let siwaState = try XCTUnwrap(headers.setCookie?["SIWA_STATE"])
             XCTAssertEqual(siwaState.sameSite, HTTPCookies.SameSitePolicy.none)
+            XCTAssertEqual(siwaState.expires, nil)
+            XCTAssertTrue(siwaState.isHTTPOnly)
+            XCTAssertTrue(siwaState.isSecure)
 
             let vaporSession = try XCTUnwrap(headers.setCookie?["vapor-session"])
             XCTAssertEqual(vaporSession.sameSite, HTTPCookies.SameSitePolicy.none)
+            XCTAssertEqual(vaporSession.expires, Date(timeIntervalSince1970: 1622645877))
+            XCTAssertTrue(siwaState.isHTTPOnly)
+            XCTAssertTrue(siwaState.isSecure)
         }
     }
 


### PR DESCRIPTION
This fixes an issue introduced by #2603 where dates in HTTP headers would break the parsing logic. Any field that has a date would not get parsed correctly. This includes breaking the `set-cookie` header as HTTP header dates are in the format `Date: <day-name>, <day> <month> <year> <hour>:<minute>:<second> GMT`.