### PR TITLE
Fix repeated match of switch case

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -38,7 +38,7 @@ extension HTTPHeaders {
     private func getSeparatorCharacters(for headerName: Name) -> [Character] {
         switch headerName {
         // Headers with dates can't have comma as a separator
-        case .setCookie, .ifModifiedSince, .date, .lastModified, .lastModified, .expires:
+        case .setCookie, .ifModifiedSince, .date, .lastModified, .expires:
             return [.semicolon]
         default: return [.comma, .semicolon]
         }


### PR DESCRIPTION
Fixed that a switch in HTTPHeaders+Directive.swift tried to match the .lastModified case twice.