### PR TITLE
Make thread pool configurable and set default size to 64 threads.

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -8,7 +8,7 @@ public final class Application {
     public var storage: Storage
     public private(set) var didShutdown: Bool
     public var logger: Logger
-    private var isBooted: Bool
+    var isBooted: Bool
 
     public struct Lifecycle {
         var handlers: [LifecycleHandler]

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -18,10 +18,16 @@ extension Application {
     /// ```
     ///
     /// If overriden, Vapor will take ownership of the thread pool and automatically start it and shut it down when needed.
-    /// - Warning: Should only be set during application setup/initialization.
+    ///
+    /// - Warning: Can only be set during application setup/initialization.
     public var threadPool: NIOThreadPool {
         get { self.core.storage.threadPool }
         set {
+            guard !self.isBooted else {
+                self.logger.warning("Cannot replace thread pool after application has booted.")
+                return
+            }
+            
             try! self.core.storage.threadPool.syncShutdownGracefully()
             self.core.storage.threadPool = newValue
             self.core.storage.threadPool.start()

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -24,8 +24,7 @@ extension Application {
         get { self.core.storage.threadPool }
         set {
             guard !self.isBooted else {
-                self.logger.warning("Cannot replace thread pool after application has booted.")
-                return
+                fatalError("Cannot replace thread pool after application has booted")
             }
             
             try! self.core.storage.threadPool.syncShutdownGracefully()

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -9,15 +9,15 @@ extension Application {
         set { self.core.storage.commands = newValue }
     }
 
-    /// Access to the application threadpool. Vapor provides a threadpool with 64 threads by default.
+    /// The application thread pool. Vapor provides a thread pool with 64 threads by default.
     ///
-    /// It's possible to configure the threadpool size by overriding this value to your own threadpool.
+    /// It's possible to configure the thread pool size by overriding this value with your own thread pool.
     ///
     /// ```
     /// application.threadPool = NIOThreadPool(numberOfThreads: 100)
     /// ```
     ///
-    /// If overriden, Vapor will take ownership of the threadpool and automatically start it and shut it down when needed.
+    /// If overriden, Vapor will take ownership of the thread pool and automatically start it and shut it down when needed.
     /// - Warning: Should only be set during application setup/initialization.
     public var threadPool: NIOThreadPool {
         get { self.core.storage.threadPool }

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -24,6 +24,7 @@ extension Application {
         get { self.core.storage.threadPool }
         set {
             guard !self.isBooted else {
+                self.logger.critical("Cannot replace thread pool after application has booted")
                 fatalError("Cannot replace thread pool after application has booted")
             }
             


### PR DESCRIPTION
Allows the default thread pool to be overriden and updates the default thread pool size to 64 threads. (#2634)

```swift
app.threadPool = NIOThreadPool(numberOfThreads: 100)
```

Fixes: #2308 