### PR TITLE
Add a built in `PlaintextDecoder`

### DIFF
--- a/Sources/Vapor/Content/ContentConfiguration.swift
+++ b/Sources/Vapor/Content/ContentConfiguration.swift
@@ -29,6 +29,7 @@ public struct ContentConfiguration {
         
         // data
         config.use(encoder: PlaintextEncoder(), for: .plainText)
+        config.use(decoder: PlaintextDecoder(), for: .plainText)
         config.use(encoder: PlaintextEncoder(.html), for: .html)
         
         // form-urlencoded

--- a/Sources/Vapor/Content/PlaintextDecoder.swift
+++ b/Sources/Vapor/Content/PlaintextDecoder.swift
@@ -1,0 +1,88 @@
+/// Decodes data as plaintext, utf8.
+public struct PlaintextDecoder: ContentDecoder {
+
+    public init() { }
+
+    /// `ContentDecoder` conformance.
+    public func decode<D>(_ decodable: D.Type, from body: ByteBuffer, headers: HTTPHeaders) throws -> D
+        where D : Decodable
+    {
+        let string = body.getString(at: body.readerIndex, length: body.readableBytes)
+        return try D(from: _PlaintextDecoder(plaintext: string))
+    }
+}
+
+// MARK: Private
+
+private final class _PlaintextDecoder: Decoder {
+
+    let codingPath: [CodingKey]
+    let userInfo: [CodingUserInfoKey: Any]
+    let plaintext: String?
+
+    init(plaintext: String?) {
+        self.codingPath = []
+        self.userInfo = [:]
+        self.plaintext = plaintext
+    }
+
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
+        fatalError("Plaintext decoding does not support dictionaries.")
+    }
+
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        fatalError("Plaintext decoding does not support arrays.")
+    }
+
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        DataDecodingContainer(decoder: self)
+    }
+}
+
+private final class DataDecodingContainer: SingleValueDecodingContainer {
+
+    var codingPath: [CodingKey] { decoder.codingPath }
+
+    let decoder: _PlaintextDecoder
+    init(decoder: _PlaintextDecoder) {
+        self.decoder = decoder
+    }
+
+    func decodeNil() -> Bool {
+        if let plaintext = decoder.plaintext {
+            return plaintext.isEmpty
+        }
+        return true
+    }
+
+    func losslessDecode<L: LosslessStringConvertible>(_ type: L.Type) throws -> L {
+        if let plaintext = decoder.plaintext, let decoded = L(plaintext) {
+            return decoded
+        }
+        throw DecodingError.dataCorruptedError(
+            in: self,
+            debugDescription: "Failed to get \(type) from \"\(decoder.plaintext ?? "")\""
+        )
+    }
+
+    func decode(_ type: Bool.Type) throws -> Bool { try losslessDecode(type) }
+    func decode(_ type: String.Type) throws -> String { decoder.plaintext ?? "" }
+    func decode(_ type: Double.Type) throws -> Double { try losslessDecode(type) }
+    func decode(_ type: Float.Type) throws -> Float { try losslessDecode(type) }
+    func decode(_ type: Int.Type) throws -> Int { try losslessDecode(type) }
+    func decode(_ type: Int8.Type) throws -> Int8 { try losslessDecode(type) }
+    func decode(_ type: Int16.Type) throws -> Int16 { try losslessDecode(type) }
+    func decode(_ type: Int32.Type) throws -> Int32 { try losslessDecode(type) }
+    func decode(_ type: Int64.Type) throws -> Int64 { try losslessDecode(type) }
+    func decode(_ type: UInt.Type) throws -> UInt { try losslessDecode(type) }
+    func decode(_ type: UInt8.Type) throws -> UInt8 { try losslessDecode(type) }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { try losslessDecode(type) }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { try losslessDecode(type) }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { try losslessDecode(type) }
+    func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+        throw DecodingError.typeMismatch(type, DecodingError.Context(
+            codingPath: codingPath,
+            debugDescription: "Plaintext decoding does not support nested types."
+        ))
+    }
+}

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -369,9 +369,21 @@ final class ContentTests: XCTestCase {
             return res
         }
 
+        app.routes.get("empty-plaintext") { (req) -> Response in
+            let res = Response()
+            try res.content.encode("", as: .plainText)
+            return res
+        }
+
         try app.testable().test(.GET, "/plaintext") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(try res.content.decode(UInt8.self), 255)
+            XCTAssertEqual(try res.content.decode(String.self), "255")
+        }
+
+        try app.testable().test(.GET, "/empty-plaintext") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(try res.content.decode(String.self), "")
         }
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -357,6 +357,23 @@ final class ContentTests: XCTestCase {
             )
         }
     }
+
+    func testPlaintextDecode() throws {
+        let data = "255"
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.get("plaintext") { (req) -> Response in
+            let res = Response()
+            try res.content.encode(data, as: .plainText)
+            return res
+        }
+
+        try app.testable().test(.GET, "/plaintext") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(try res.content.decode(UInt8.self), 255)
+        }
+    }
 }
 
 private struct SampleContent: Content {


### PR DESCRIPTION
Adds a new `PlaintextDecoder` to easily decode strings in requests and responses. `PlaintextDecoder` is the default decoder for `Content-Type: plain/text`. Resolves #2607 
