### PR TITLE
Add reason bodies for Validation

### DIFF
--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -48,7 +48,7 @@ public struct Validations {
             throw Abort(.unprocessableEntity)
         }
         guard let body = request.body.data else {
-            throw Abort(.unprocessableEntity)
+            throw Abort(.unprocessableEntity, reason: "Empty Body")
         }
         let contentDecoder = try ContentConfiguration.global.requireDecoder(for: contentType)
         let decoder = try contentDecoder.decode(DecoderUnwrapper.self, from: body, headers: request.headers)

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -45,7 +45,7 @@ public struct Validations {
     
     public func validate(request: Request) throws -> ValidationsResult {
         guard let contentType = request.headers.contentType else {
-            throw Abort(.unprocessableEntity)
+            throw Abort(.unprocessableEntity, reason: "Missing \"Content-Type\" header")
         }
         guard let body = request.body.data else {
             throw Abort(.unprocessableEntity, reason: "Empty Body")

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -84,7 +84,7 @@ extension Application {
                 method: request.method,
                 url: request.url,
                 headers: headers,
-                collectedBody: request.body,
+                collectedBody: request.body.readableBytes == 0 ? nil : request.body,
                 remoteAddress: nil,
                 on: self.app.eventLoopGroup.next()
             )

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -192,6 +192,9 @@ final class RouteTests: XCTestCase {
         }) { res in
             XCTAssertEqual(res.status, .badRequest)
             XCTAssertContains(res.body.string, "email is not a valid email address")
+        }.test(.POST, "/users") { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertContains(res.body.string.replacingOccurrences(of: "\\", with: ""), "Missing \"Content-Type\" header")
         }
     }
 

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -195,6 +195,9 @@ final class RouteTests: XCTestCase {
         }.test(.POST, "/users") { res in
             XCTAssertEqual(res.status, .unprocessableEntity)
             XCTAssertContains(res.body.string.replacingOccurrences(of: "\\", with: ""), "Missing \"Content-Type\" header")
+        }.test(.POST, "/users", headers: ["Content-Type":"application/json"]) { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertContains(res.body.string, "Empty Body")
         }
     }
 


### PR DESCRIPTION
Adds messages to the errors thrown during validation to make it clearer what the error is. Fixes #2606