### PR TITLE
Add ability to prepend middleware

### DIFF
--- a/Sources/Vapor/Middleware/MiddlewareConfiguration.swift
+++ b/Sources/Vapor/Middleware/MiddlewareConfiguration.swift
@@ -4,6 +4,12 @@ public struct Middlewares {
     /// The configured middleware.
     private var storage: [Middleware]
 
+  
+    public enum Position {
+      case beginning
+      case end
+    }
+  
     /// Create a new, empty `MiddlewareConfig`.
     public init() {
         self.storage = []
@@ -18,8 +24,13 @@ public struct Middlewares {
     /// - warning: Ensure the `Middleware` is thread-safe when using this method.
     ///            Otherwise, use the type-based method and register the `Middleware`
     ///            using factory method to `Services`.
-    public mutating func use(_ middleware: Middleware) {
+    public mutating func use(_ middleware: Middleware, at position: Position = .end) {
+      switch position {
+      case .end:
         self.storage.append(middleware)
+      case .beginning:
+        self.storage.insert(middleware, at: 0)
+      }
     }
 
     /// Resolves the configured middleware for a given container


### PR DESCRIPTION
Allows middleware to be inserted at the start of the responder chain. This is useful when working with things like the `CORSMiddleware`.

Usage: 

```swift
app.middleware.use(corsMiddleware, at: .beginning)
```

The default behaviour remains appending:

```swift
app.middleware.use(someOtherMiddleware)
```