### PR TITLE
Improve documentation of `Middleware`

### DIFF
--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -26,13 +26,12 @@ private final class RedirectMiddleware<A>: Middleware
         self.makePath = makePath
     }
 
-    /// See Middleware.respond
-    func respond(to req: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        if req.auth.has(A.self) {
-            return next.respond(to: req)
+    func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        if request.auth.has(A.self) {
+            return next.respond(to: request)
         }
 
-        let redirect = req.redirect(to: self.makePath(req))
-        return req.eventLoop.makeSucceededFuture(redirect)
+        let redirect = request.redirect(to: self.makePath(request))
+        return request.eventLoop.makeSucceededFuture(redirect)
     }
 }

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -39,6 +39,10 @@ private struct HTTPMiddlewareResponder: Responder {
         self.responder = responder
     }
     
+    /// Chains an incoming request to another `Responder` on the router.
+    /// - parameters:
+    ///     - request: The incoming `Request`.
+    /// - returns: An asynchronous `Response`.
     func respond(to request: Request) -> EventLoopFuture<Response> {
         return self.middleware.respond(to: request, chainingTo: self.responder)
     }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -32,7 +32,6 @@ public final class SessionsMiddleware: Middleware {
         self.configuration = configuration
     }
 
-    /// See `Middleware.respond`
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // Signal middleware has been added.
         request._sessionCache.middlewareFlag = true


### PR DESCRIPTION
This improves the documentation of Vapor's `Middleware` to make it easier to see inline docs with both `Middleware` and Vapor types that conform to it.