### PR TITLE
Improve documentation of `Middleware` pt.2

### DIFF
--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -39,11 +39,10 @@ private final class GuardAuthenticationMiddleware<A>: Middleware
         self.error = error
     }
 
-    /// See `Middleware`.
-    public func respond(to req: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        guard req.auth.has(A.self) else {
-            return req.eventLoop.makeFailedFuture(self.error)
+    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        guard request.auth.has(A.self) else {
+            return request.eventLoop.makeFailedFuture(self.error)
         }
-        return next.respond(to: req)
+        return next.respond(to: request)
     }
 }

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -120,7 +120,6 @@ public final class CORSMiddleware: Middleware {
         self.configuration = configuration
     }
 
-    /// See `Middleware`.
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // Check if it's valid CORS request
         guard request.headers[.origin].first != nil else {

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -67,8 +67,7 @@ public final class ErrorMiddleware: Middleware {
     public init(_ closure: @escaping (Request, Error) -> (Response)) {
         self.closure = closure
     }
-
-    /// See `Middleware`.
+    
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         return next.respond(to: request).flatMapErrorThrowing { error in
             return self.closure(request, error)

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -11,7 +11,6 @@ public final class FileMiddleware: Middleware {
         self.publicDirectory = publicDirectory.hasSuffix("/") ? publicDirectory : publicDirectory + "/"
     }
 
-    /// See `Middleware`.
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // make a copy of the percent-decoded path
         guard var path = request.url.path.removingPercentEncoding else {


### PR DESCRIPTION
Following up on [the previously merged PR](https://github.com/vapor/vapor/pull/2662), this PR further improves the documentation of Vapor's `Middleware` to make it easier to see inline docs with both `Middleware` and Vapor types that conform to it.

This PR includes:
- Cleaned up `See Middleware` comments.
- Changed variable name `req` to `request` to make it easier to read `Middleware` inline docs.
