### PR TITLE
Improve documentation of ResponseCodable

### DIFF
--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -10,7 +10,15 @@ public protocol ResponseEncodable {
     func encodeResponse(for request: Request) -> EventLoopFuture<Response>
 }
 
+/// Can convert `Request` to a `Self`.
+///
+/// Types that conform to this protocol can be returned in route closures.
 public protocol RequestDecodable {
+    /// Decodes an instance of `HTTPRequest` to a `Self`.
+    ///
+    /// - parameters:
+    ///     - request: The `HTTPRequest` to be decoded.
+    /// - returns: An asynchronous `Self`.
     static func decodeRequest(_ request: Request) -> EventLoopFuture<Self>
 }
 

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -12,7 +12,7 @@ public protocol ResponseEncodable {
 
 /// Can convert `Request` to a `Self`.
 ///
-/// Types that conform to this protocol can be returned in route closures.
+/// Types that conform to this protocol can decode requests to their type.
 public protocol RequestDecodable {
     /// Decodes an instance of `HTTPRequest` to a `Self`.
     ///


### PR DESCRIPTION
This PR further improves the documentation of Vapor's `ResponseCodable` to make it more convenient to see inline docs with `ResponseCodable` and the Vapor types that conform to it.

This PR includes:
- Added documentation comments to `ResponseCodable` protocol and its static function `decodeRequest`.
