### PR TITLE
Fix `comparePreference` function when only one media type specified

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
@@ -49,10 +49,10 @@ extension Array where Element == HTTPMediaTypePreference {
             }
         case (.none, .some):
             // there is not a value for a, no way it can be preferred
-            return .orderedDescending
+            return .orderedAscending
         case (.some, .none):
             // there is not a value for b, a is preferred by default
-            return .orderedAscending
+            return .orderedDescending
         case (.none, .none):
             // there is no value for either, neither is preferred
             return .orderedSame

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -130,6 +130,15 @@ final class HTTPHeaderTests: XCTestCase {
             XCTAssertEqual(headers.accept.first(where: { $0.mediaType == .png })?.q, 0.8)
             XCTAssertTrue(headers.accept.comparePreference(for: .xml, to: .png) == .orderedDescending)
         }
+
+        // #2668 Preference should be consistent: present types are preferred to missing types
+        do {
+            headers.replaceOrAdd(name: .accept, value: "image/png;q=0.5")
+            XCTAssertEqual(headers.accept.comparePreference(for: .png, to: .gif), .orderedDescending)
+            XCTAssertEqual(headers.accept.comparePreference(for: .gif, to: .png), .orderedAscending)
+            XCTAssertEqual(headers.accept.comparePreference(for: .png, to: .png), .orderedSame)
+            XCTAssertEqual(headers.accept.comparePreference(for: .gif, to: .gif), .orderedSame)
+        }
     }
 
     func testComplexCookieParsing() throws {


### PR DESCRIPTION
This fixes the `comparePreference` function which returns wrong results if only one media type is specified in the accept header.

Resolves #2668 