### PR TITLE
Fix flaky Websocket tests

### DIFF
--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -32,6 +32,9 @@ final class WebSocketTests: XCTestCase {
                 }
             }.flatMap {
                 return promise.futureResult
+            }.flatMapError { error in
+                promise.fail(error)
+                return promise.futureResult
             }
         }
 

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -13,41 +13,34 @@ final class WebSocketTests: XCTestCase {
         server.environment.arguments = ["serve"]
         try server.start()
 
-        let app = Application(.testing)
         defer {
-            app.shutdown()
             server.shutdown()
         }
 
-        guard let localAddress = server.http.server.shared.localAddress,
-              let port = localAddress.port else {
-                  XCTFail("couldn't get port from \(app.http.server.shared.localAddress.debugDescription)")
-                  return
-              }
+        guard let localAddress = server.http.server.shared.localAddress, let port = localAddress.port else {
+            XCTFail("couldn't get port from \(server.http.server.shared.localAddress.debugDescription)")
+            return
+        }
 
-        app.get("ws") { req -> EventLoopFuture<String> in
-            let promise = req.eventLoop.makePromise(of: String.self)
-            return WebSocket.connect(
-                to: "ws://localhost:\(port)/echo",
-                on: req.eventLoop
-            ) { ws in
-                ws.send("Hello, world!")
-                ws.onText { ws, text in
-                    promise.succeed(text)
-                    ws.close().cascadeFailure(to: promise)
-                }
-            }.flatMap {
-                return promise.futureResult
-            }.flatMapError { error in
-                promise.fail(error)
-                return promise.futureResult
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        let promise = elg.next().makePromise(of: String.self)
+        let string = try WebSocket.connect(
+            to: "ws://localhost:\(port)/echo",
+            on: elg.next()
+        ) { ws in
+            ws.send("Hello, world!")
+            ws.onText { ws, text in
+                promise.succeed(text)
+                ws.close().cascadeFailure(to: promise)
             }
-        }
-
-        try app.testable().test(.GET, "/ws") { res in
-            XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "Hello, world!")
-        }
+        }.flatMap {
+            return promise.futureResult
+        }.flatMapError { error in
+            promise.fail(error)
+            return promise.futureResult
+        }.wait()
+        XCTAssertEqual(string, "Hello, world!")
     }
 
 


### PR DESCRIPTION
This PR fixes the flaky websocket tests by bringing it all in house.

The websocket server we were using failed frequently causing issues with testing and has now been shutdown. By running a local server we should fix these issues.

Resolves #2669 
Resolves #2618 
Resolves #2610
