### PR TITLE
Use new concurrency verbage

### DIFF
--- a/Sources/Vapor/Concurrency/AsyncMiddleware.swift
+++ b/Sources/Vapor/Concurrency/AsyncMiddleware.swift
@@ -21,7 +21,7 @@ public protocol AsyncMiddleware: Middleware {
 extension AsyncMiddleware {
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         let promise = request.eventLoop.makePromise(of: Response.self)
-        promise.completeWithAsync {
+        promise.completeWithTask {
             try await respond(to: request, chainingTo: next)
         }
         return promise.futureResult

--- a/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
@@ -132,14 +132,14 @@ extension RoutesBuilder {
                     max: max?.value ?? request.application.routes.defaultMaxBodySize.value
                 ).flatMap { _ -> EventLoopFuture<Response> in
                     let promise = request.eventLoop.makePromise(of: Response.self)
-                    promise.completeWithAsync {
+                    promise.completeWithTask {
                         try await closure(request)
                     }
                     return promise.futureResult
                 }.encodeResponse(for: request)
             } else {
                 let promise = request.eventLoop.makePromise(of: Response.self)
-                promise.completeWithAsync {
+                promise.completeWithTask {
                     try await closure(request)
                 }
                 return promise.futureResult.encodeResponse(for: request)

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -14,7 +14,7 @@ extension Request {
             maxFrameSize: maxFrameSize,
             shouldUpgrade: { request in
                 let promise = request.eventLoop.makePromise(of: HTTPHeaders?.self)
-                promise.completeWithAsync {
+                promise.completeWithTask {
                     try await shouldUpgrade(request)
                 }
                 return promise.futureResult


### PR DESCRIPTION
This just updates the `async-await` branch to use the new name `completeWithTask` rather than the old `completeWithAsync`.