### PR TITLE
Fixes #2683 `HTTPHeaders+ContentDisposition` init

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -54,7 +54,7 @@ extension HTTPHeaders {
                 case "filename":
                     self.filename = .init(parameter)
                 default:
-                    return nil
+                    continue
                 }
             }
         }


### PR DESCRIPTION
Multipart won't parse `File` if there are additional directives in `Content-Disposition` header.

Postman app adds `filename*` directive and it fails `File` parsing.

<img width="604" alt="Screenshot 2021-09-15 at 23 08 10" src="https://user-images.githubusercontent.com/1272610/133495277-1274781c-9ab1-45c8-a92a-2abfd0e70e4d.png">

This fix allows to init `ContentDisposition` with additional directives in `Content-Disposition` header.
