### PR TITLE
Correctly pass `SocketAddress` through to `Request` convenience initialiser

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -168,6 +168,7 @@ public final class Request: CustomStringConvertible {
             version: version,
             headersNoUpdate: headers,
             collectedBody: collectedBody,
+            remoteAddress: remoteAddress,
             logger: logger,
             on: eventLoop
         )

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -2,7 +2,7 @@ import XCTVapor
 
 final class RequestTests: XCTestCase {
     
-    func testCustomHostAdress() throws {
+    func testCustomHostAddress() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         


### PR DESCRIPTION
Fixes an issue where the convenience initializer for `Request` has a `remoteAddress: SocketAddress?` parameter that wasn't being forwarded into the main initializer call (#2685)