### PR TITLE
Fix Xcode 13 RC build failure

### DIFF
--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -35,7 +35,9 @@ public struct DirectoryConfiguration {
         // get actual working directory
         let cwd = getcwd(nil, Int(PATH_MAX))
         defer {
-            free(cwd)
+            if let cwd = cwd {
+                free(cwd)
+            }
         }
 
         let workingDirectory: String


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Using the SDK in Xcode 13 RC, `free()` expects a non-optional parameter. This change unwraps the optional `cwd` before passing it.

Resolves #2686