### PR TITLE
Handle null key correctly in validation when not required

### DIFF
--- a/Sources/Vapor/Validation/Validation.swift
+++ b/Sources/Vapor/Validation/Validation.swift
@@ -5,7 +5,7 @@ public struct Validation {
         self.init { container in
             let result: ValidatorResult
             do {
-                if container.contains(key) {
+                if container.contains(key), try !container.decodeNil(forKey: key) {
                     result = try validator.validate(container.decode(T.self, forKey: key))
                 } else if required {
                     result = ValidatorResults.Missing()

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -589,6 +589,12 @@ class ValidationTests: XCTestCase {
         }
         """
         XCTAssertNoThrow(try Site.validate(json: valid))
+
+        let valid2 = """
+        {
+        }
+        """
+        XCTAssertNoThrow(try Site.validate(json: valid2))
     }
 
     override class func setUp() {

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -574,6 +574,23 @@ class ValidationTests: XCTestCase {
         })
     }
 
+    func testValidateNullWhenNotRequired() throws {
+        struct Site: Validatable, Codable {
+            var url: String?
+
+            static func validations(_ v: inout Validations) {
+                v.add("url", as: String.self, is: .url, required: false)
+            }
+        }
+
+        let valid = """
+        {
+            "url": null
+        }
+        """
+        XCTAssertNoThrow(try Site.validate(json: valid))
+    }
+
     override class func setUp() {
         XCTAssert(isLoggingConfigured)
     }


### PR DESCRIPTION
Fixes an issue where a key was marked as not required but passing the value `null` in JSON would cause the validation to fail. 

E.g.

```json
{
  "number": null
}
```
would not pass

```swift
validations.add("number", as: Int.self, required: false)
```

