### PR TITLE
Expand Crypto dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.0.0"),
 
         // 🔑 Hashing (BCrypt, SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
 
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0"),


### PR DESCRIPTION
Expand the versions of Swift Crypto Vapor depends on to allow versions of Swift Crypto beyond 1.0.0.

⚠️ **WARNING:** this release may contain a breaking change if you're relying on Swift Crypto without specifying it as a dependency. If you're switching on `CryptoError` you'll need to account for the new case or specify Swift Crypto as a dependency and choose the version you want ⚠️