### PR TITLE
Removing redundant call to beforeEncode() hook.

### DIFF
--- a/Sources/Vapor/Content/ContentContainer.swift
+++ b/Sources/Vapor/Content/ContentContainer.swift
@@ -34,8 +34,6 @@ extension ContentContainer {
     public mutating func encode<C>(_ encodable: C) throws
         where C: Content
     {
-        var encodable = encodable
-        try encodable.beforeEncode()
         try self.encode(encodable, as: C.defaultContentType)
     }
 


### PR DESCRIPTION
When encoding content with the default content type, there was a redundant call to the `beforeEncode()` hook. This removes that unnecessary call.