### PR TITLE
Add application/wasm HTTPMediaType

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -367,6 +367,7 @@ let fileExtensionMediaTypeMapping: [String: HTTPMediaType] = [
     "wmlsc": HTTPMediaType(type: "application", subType: "vnd.wap.wmlscriptc"),
     "wpd": HTTPMediaType(type: "application", subType: "vnd.wordperfect"),
     "wp5": HTTPMediaType(type: "application", subType: "vnd.wordperfect5.1"),
+    "wasm": HTTPMediaType(type: "application", subType: "wasm"),
     "wk": HTTPMediaType(type: "application", subType: "x-123"),
     "7z": HTTPMediaType(type: "application", subType: "x-7z-compressed"),
     "abw": HTTPMediaType(type: "application", subType: "x-abiword"),


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

Adds the application/wasm HTTP media type for .wasm files. Especially now with SwiftWasm gearing up this is relevant as WebAssembly.instantiateStreaming(…) requires the correct MIME type to be set.

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
