### PR TITLE
Fix issue where an invalid URL using the Client would crash

### DIFF
--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -16,9 +16,14 @@ private struct EventLoopHTTPClient: Client {
     func send(
         _ client: ClientRequest
     ) -> EventLoopFuture<ClientResponse> {
+        let urlString = client.url.string
+        guard let url = URL(string: urlString) else {
+            self.logger?.debug("\(urlString) is an invalid URL")
+            return self.eventLoop.makeFailedFuture(Abort(.internalServerError, reason: "\(urlString) is an invalid URL"))
+        }
         do {
             let request = try HTTPClient.Request(
-                url: URL(string: client.url.string)!,
+                url: url,
                 method: client.method,
                 headers: client.headers,
                 body: client.body.map { .byteBuffer($0) }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -412,4 +412,18 @@ final class RouteTests: XCTestCase {
             XCTAssertEqual(res.headers.first(name: testMarkerHeaderKey), testMarkerHeaderValue)
         }
     }
+    
+    // https://github.com/vapor/vapor/issues/2716
+    func testGH2716() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.get("client") { req in
+            return req.client.get("http://httpbin.org/status/2 1").map { $0.description }
+        }
+        
+        try app.testable(method: .running).test(.GET, "/client") { res in
+            XCTAssertEqual(res.status.code, 500)
+        }
+    }
 }


### PR DESCRIPTION
This resolves an issue where sending a request with an invalid URL using the Client cause a crash. 
Fixes #2716.
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
