### PR TITLE
Add a new test method to XCTApplicationTester returns a response directly

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -154,7 +154,7 @@ extension XCTApplicationTester {
         return self
     }
 
-    public func performTest(
+    public func sendRequest(
         _ method: HTTPMethod,
         _ path: String,
         headers: HTTPHeaders = [:],

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -153,4 +153,28 @@ extension XCTApplicationTester {
         }
         return self
     }
+
+    public func performTest(
+        _ method: HTTPMethod,
+        _ path: String,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        beforeRequest: (inout XCTHTTPRequest) throws -> () = { _ in }
+    ) throws -> XCTHTTPResponse {
+        var request = XCTHTTPRequest(
+            method: method,
+            url: .init(path: path),
+            headers: headers,
+            body: body ?? ByteBufferAllocator().buffer(capacity: 0)
+        )
+        try beforeRequest(&request)
+        do {
+            return try self.performTest(request: request)
+        } catch {
+            XCTFail("\(error)", file: (file), line: line)
+            throw error
+        }
+    }
 }


### PR DESCRIPTION
I'm finding that there are a few places where having my tests return an XCTHTTPResponse directly — rather than via a closure — feels more ergonomic in use (especially inline with async/await code). 

This PR proposes to add a method that does that.

I'm not sold on the name I've given this method (`performTest(…)`), so please feel free to suggest alternatives. 