### PR TITLE
Add missing async `send` version to `Client`

### DIFF
--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -33,6 +33,10 @@ extension Client {
         try beforeSend(&request)
         return try await self.send(request).get()
     }
+    
+    public func send(_ request: ClientRequest) async throws -> ClientResponse {
+        return try await self.send(request).get()
+    }
 }
 
 #endif


### PR DESCRIPTION
Adds a async alternative for sending a `ClientRequest` with `Client`
```swift
send(_ request: ClientRequest) async throws
```