### PR TITLE
Add missing public access to HTTPHeaders.Link initializer

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
@@ -91,7 +91,7 @@ extension HTTPHeaders {
         public var relation: Relation
         public var attributes: [String: String]
         
-        init(uri: String, relation: Relation, attributes: [String: String]) {
+        public init(uri: String, relation: Relation, attributes: [String: String]) {
             self.uri = uri
             self.relation = relation
             self.attributes = attributes


### PR DESCRIPTION
Without a public initializer, the Link HTTP header support is effectively read-only, which was not intended.

A bit ridiculously, requires a semver-minor release due to adding a "new" public API.