### PR TITLE
Fix empty password in basic authorization parsing

### DIFF
--- a/Sources/Vapor/Authentication/BasicAuthorization.swift
+++ b/Sources/Vapor/Authentication/BasicAuthorization.swift
@@ -31,7 +31,7 @@ extension HTTPHeaders {
             guard let decodedToken = Data(base64Encoded: .init(headerParts[1])) else {
                 return nil
             }
-            let parts = String.init(decoding: decodedToken, as: UTF8.self).split(separator: ":", maxSplits: 1)
+            let parts = String.init(decoding: decodedToken, as: UTF8.self).split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
 
             guard parts.count == 2 else {
                 return nil

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -116,6 +116,45 @@ final class AuthenticationTests: XCTestCase {
         }
     }
     
+    func testBasicAuthenticatorWithEmptyPassword() throws {
+        struct Test: Authenticatable {
+            static func authenticator() -> Authenticator {
+                TestAuthenticator()
+            }
+
+            var name: String
+        }
+
+        struct TestAuthenticator: BasicAuthenticator {
+            typealias User = Test
+
+            func authenticate(basic: BasicAuthorization, for request: Request) -> EventLoopFuture<Void> {
+                if basic.username == "test" && basic.password == "" {
+                    let test = Test(name: "Vapor")
+                    request.auth.login(test)
+                }
+                return request.eventLoop.makeSucceededFuture(())
+            }
+        }
+        
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.grouped([
+            Test.authenticator(), Test.guardMiddleware()
+        ]).get("test") { req -> String in
+            return try req.auth.require(Test.self).name
+        }
+        
+        let basic = Data("test:".utf8).base64EncodedString()
+        try app.testable().test(.GET, "/test") { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }
+    }
+    
     func testBasicAuthenticatorWithRedirect() throws {
         struct Test: Authenticatable {
             static func authenticator() -> Authenticator {


### PR DESCRIPTION
Currently if the password is empty in a Basic Authorization (the decoded base64 string ends with a semicolon), Vapor will fail to parse it.
It should succeed with an empty password.

This case happens often when dealing with OAuth2: client authentication should be done via Basic auth, and most OAuth clients do not have an app secret, which is represented with an empty password in Basic auth.