### PR TITLE
Remove async content protocols pre-concurrency

### DIFF
--- a/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
@@ -1,3 +1,4 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
 /// Can convert `self` to a `Response`.
@@ -11,10 +12,8 @@ public protocol AsyncResponseEncodable {
     /// - parameters:
     ///     - for: The `HTTPRequest` associated with this `HTTPResponse`.
     /// - returns: An `HTTPResponse`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     func encodeResponse(for request: Request) async throws -> Response
-    #endif
 }
 
 /// Can convert `Request` to a `Self`.
@@ -28,23 +27,18 @@ public protocol AsyncRequestDecodable {
     /// - parameters:
     ///     - request: The `HTTPRequest` to be decoded.
     /// - returns: An asynchronous `Self`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     static func decodeRequest(_ request: Request) async throws -> Self
-    #endif
 }
 
 extension Request: AsyncRequestDecodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public static func decodeRequest(_ request: Request) async throws -> Request {
         return request
     }
-    #endif
 }
 
 // MARK: Convenience
-#if compiler(>=5.5) && canImport(_Concurrency)
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncResponseEncodable {
     /// Asynchronously encodes `Self` into a `Response`, setting the supplied status and headers.
@@ -69,43 +63,35 @@ extension AsyncResponseEncodable {
         return response
     }
 }
-#endif
 
 // MARK: Default Conformances
 
 extension Response: AsyncResponseEncodable {
     // See `AsyncResponseCodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return self
     }
-    #endif
 }
 
 extension StaticString: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(staticString: self))
         return res
     }
-    #endif
 }
 
 extension String: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(string: self))
         return res
     }
-    #endif
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Content {
     public func encodeResponse(for request: Request) async throws -> Response {
@@ -119,10 +105,8 @@ extension Content {
         return content
     }
 }
-#endif
 
 extension ClientResponse: AsyncResponseEncodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let body: Response.Body
@@ -138,14 +122,13 @@ extension ClientResponse: AsyncResponseEncodable {
         )
         return response
     }
-    #endif
 }
 
 extension HTTPStatus: AsyncResponseEncodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return Response(status: self)
     }
-    #endif
 }
+
+#endif


### PR DESCRIPTION
This change attempts to correct a breaking change from Vapor 4.50.0 where changing the definition of `Content` broke existing code.

To illustrate:
```swift
struct S<T> {
  let t: T
}
extension S: Codable where T: Codable {}
extension S: Content, RequestDecodable, ResponseEncodable where T: Content {}
```
Started failing to compile with 4.50.0 because conformance to `AsyncRequestDecodable` and `AsyncResponseEncodable` could not be implied.

With this proposed change, the above problem is at least resolved when the condition `#if compiler(>=5.5) && canImport(_Concurrency)` is not met. For Swift 5.5+ with concurrency, the redefinition of `Content` is still a breaking change that will need to be dealt with.