### PR TITLE
HTTP Authorization header scheme is case-insensitive

### DIFF
--- a/Sources/Vapor/Authentication/BasicAuthorization.swift
+++ b/Sources/Vapor/Authentication/BasicAuthorization.swift
@@ -25,7 +25,7 @@ extension HTTPHeaders {
             guard headerParts.count == 2 else {
                 return nil
             }
-            guard headerParts[0] == "Basic" else {
+            guard headerParts[0].lowercased() == "basic" else {
                 return nil
             }
             guard let decodedToken = Data(base64Encoded: .init(headerParts[1])) else {

--- a/Sources/Vapor/Authentication/BearerAuthorization.swift
+++ b/Sources/Vapor/Authentication/BearerAuthorization.swift
@@ -21,7 +21,7 @@ extension HTTPHeaders {
             guard headerParts.count == 2 else {
                 return nil
             }
-            guard headerParts[0] == "Bearer" else {
+            guard headerParts[0].lowercased() == "bearer" else {
                 return nil
             }
             return .init(token: String(headerParts[1]))

--- a/Tests/AsyncTests/AsyncAuthTests.swift
+++ b/Tests/AsyncTests/AsyncAuthTests.swift
@@ -37,6 +37,10 @@ final class AsyncAuthenticationTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
         }
+        .test(.GET, "/test", headers: ["Authorization": "bearer test"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }
     }
 
     func testBasicAuthenticator() throws {
@@ -72,6 +76,9 @@ final class AsyncAuthenticationTests: XCTestCase {
         try app.testable().test(.GET, "/test") { res in
             XCTAssertEqual(res.status, .unauthorized)
         }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }.test(.GET, "/test", headers: ["Authorization": "basic \(basic)"]) { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
         }

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -36,6 +36,10 @@ final class AuthenticationTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
         }
+        .test(.GET, "/test", headers: ["Authorization": "bearer test"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }
     }
 
     func testBasicAuthenticator() throws {
@@ -72,6 +76,9 @@ final class AuthenticationTests: XCTestCase {
         try app.testable().test(.GET, "/test") { res in
             XCTAssertEqual(res.status, .unauthorized)
         }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }.test(.GET, "/test", headers: ["Authorization": "basic \(basic)"]) { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "Vapor")
         }


### PR DESCRIPTION
Fixes an issue where Vapor would reject valid requests, if the Authorization token was not cased exactly like Vapor wanted it. The RFC dictates that the token should be case-insensitive.
