### PR TITLE
Filled in missing documentation in commonly used APIs

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -97,7 +97,7 @@ public final class Application {
     /// Starts the Application using the `start()` command, then waits for any running tasks to complete
     /// If your application is started without arguments, the default argument is used.
     ///
-    /// Under normal circumstances, `run `will start the shut down and wait for the web server to (manually) shut down before exiting the application.
+    /// Under normal circumstances, `run()` begin start the shutdown, then wait for the web server to (manually) shut down before returning.
     public func run() throws {
         do {
             try self.start()

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -94,6 +94,10 @@ public final class Application {
         DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
     }
     
+    /// Starts the Application using the `start()` command, then waits for any running tasks to complete
+    /// If your application is started without arguments, the default argument is used.
+    ///
+    /// Under normal circumstances, `run `will start the shut down and wait for the web server to (manually) shut down before exiting the application.
     public func run() throws {
         do {
             try self.start()
@@ -104,6 +108,11 @@ public final class Application {
         }
     }
     
+    /// When called, this will execute the startup command provided through an argument. If no startup command is provided, the default is used.
+    /// Under normal circumstances, this will start running Vapor's webserver.
+    ///
+    /// If you `start` Vapor through this method, you'll need to prevent your Swift Executable from closing yourself.
+    /// If you want to run your Application indefinitely, or until your code shuts the application down, use `run()` instead.
     public func start() throws {
         try self.boot()
         let command = self.commands.group()

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -94,7 +94,7 @@ public final class Application {
         DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
     }
     
-    /// Starts the Application using the `start()` command, then waits for any running tasks to complete
+    /// Starts the Application using the `start()` method, then waits for any running tasks to complete
     /// If your application is started without arguments, the default argument is used.
     ///
     /// Under normal circumstances, `run()` begin start the shutdown, then wait for the web server to (manually) shut down before returning.

--- a/Sources/Vapor/Bcrypt/Bcrypt.swift
+++ b/Sources/Vapor/Bcrypt/Bcrypt.swift
@@ -29,7 +29,8 @@ public final class BCryptDigest {
     /// Creates a new `BCryptDigest`. Use the global `BCrypt` convenience variable.
     public init() { }
 
-
+    /// Creates a new BCrypt hash with a randomly generated salt.
+    /// The result can be stored in a database.
     public func hash(_ plaintext: String, cost: Int = 12) throws -> String {
         guard cost >= BCRYPT_MINLOGROUNDS && cost <= 31 else {
             throw BcryptError.invalidCost

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -14,7 +14,7 @@ extension Client {
 extension Client {
     public func get(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) -> EventLoopFuture<ClientResponse> {
         return self.send(.GET, headers: headers, to: url, beforeSend: beforeSend)
-    }`
+    }
 
     public func post(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) -> EventLoopFuture<ClientResponse> {
         return self.send(.POST, headers: headers, to: url, beforeSend: beforeSend)

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -14,7 +14,7 @@ extension Client {
 extension Client {
     public func get(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) -> EventLoopFuture<ClientResponse> {
         return self.send(.GET, headers: headers, to: url, beforeSend: beforeSend)
-    }
+    }`
 
     public func post(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) -> EventLoopFuture<ClientResponse> {
         return self.send(.POST, headers: headers, to: url, beforeSend: beforeSend)

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -99,6 +99,8 @@ public final class Request: CustomStringConvertible {
         }
     }
 
+    /// This container is used to read your Decodable type using a ContentDecoder implementation.
+    /// If no ContentDecoder is provided, a supported Decoder will be selected based on the Request's Content-Type header.
     public var content: ContentContainer {
         get {
             return _ContentContainer(request: self)
@@ -108,6 +110,8 @@ public final class Request: CustomStringConvertible {
         }
     }
     
+    /// This Logger from Apple's `swift-log` Package is preferred when logging in the context of handing this Request.
+    /// Vapor alraedy provides metadata to this logger so that multiple logged messages can be traced back to the same request.
     public var logger: Logger
     
     public var body: Body {
@@ -142,12 +146,21 @@ public final class Request: CustomStringConvertible {
         return desc.joined(separator: "\n")
     }
 
+    /// The address from which this HTTP request was received by SwiftNIO.
+    /// This address may not represent the original address of the peer, especially if Vapor receives its requests through a reverse-proxy such as nginx.
     public let remoteAddress: SocketAddress?
     
+    /// The EventLoop upon which Vapor calls the middlewares and route handler for this request.
+    /// While respond to this request asynchronously, you **MUST** ensure the resulting EventLoopFuture is bound to this EventLoop.
+    ///
+    /// If you cannot ensure that a library returns on this EventLoop, you can use `eventLoopFuture.hop(to: request.eventLoop)`
     public let eventLoop: EventLoop
     
+    /// A container containing the route parameters that were captured when receiving this request.
+    /// Use this container to grab any non-static parameters from the URL, such as model IDs in a REST API.
     public var parameters: Parameters
 
+    /// This container is used as arbitrary request-local storage during the request-response lifecycle.Z
     public var storage: Storage
     
     public convenience init(

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -99,8 +99,8 @@ public final class Request: CustomStringConvertible {
         }
     }
 
-    /// This container is used to read your Decodable type using a ContentDecoder implementation.
-    /// If no ContentDecoder is provided, a supported Decoder will be selected based on the Request's Content-Type header.
+    /// This container is used to read your `Decodable` type using a `ContentDecoder` implementation.
+    /// If no `ContentDecoder` is provided, a `Request`'s `Content-Type` header is used to select a registered decoder.
     public var content: ContentContainer {
         get {
             return _ContentContainer(request: self)
@@ -111,7 +111,7 @@ public final class Request: CustomStringConvertible {
     }
     
     /// This Logger from Apple's `swift-log` Package is preferred when logging in the context of handing this Request.
-    /// Vapor alraedy provides metadata to this logger so that multiple logged messages can be traced back to the same request.
+    /// Vapor already provides metadata to this logger so that multiple logged messages can be traced back to the same request.
     public var logger: Logger
     
     public var body: Body {
@@ -150,10 +150,10 @@ public final class Request: CustomStringConvertible {
     /// This address may not represent the original address of the peer, especially if Vapor receives its requests through a reverse-proxy such as nginx.
     public let remoteAddress: SocketAddress?
     
-    /// The EventLoop upon which Vapor calls the middlewares and route handler for this request.
-    /// While respond to this request asynchronously, you **MUST** ensure the resulting EventLoopFuture is bound to this EventLoop.
+    /// The `EventLoop` which is handling this `Request`. The route handler and any relevant middleware are invoked in this event loop.
     ///
-    /// If you cannot ensure that a library returns on this EventLoop, you can use `eventLoopFuture.hop(to: request.eventLoop)`
+    /// - Warning: A futures-based route handler **MUST** return an `EventLoopFuture` bound to this event loop.
+    ///  If this is difficult or awkward to guarantee, use `EventLoopFuture.hop(to:)` to jump to this event loop.
     public let eventLoop: EventLoop
     
     /// A container containing the route parameters that were captured when receiving this request.


### PR DESCRIPTION
I've added documentation for some of the most commonly used Vapor APIs that were still missing doc comments.