### PR TITLE
Add definition for application/json-seq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,7 @@ name: test
 on: { pull_request: {} }
 
 jobs:
-  getcidata:
-    runs-on: ubuntu-latest
-    outputs:
-      environments: ${{ steps.output.outputs.environments }}
-    steps:
-      - id: output
-        run: |
-          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
-          echo "::set-output name=environments::${envblob}"
-    
   test-providers:
-    needs: getcidata
     strategy:
       fail-fast: false
       matrix:
@@ -40,28 +29,48 @@ jobs:
       - name: Run tests with Thread Sanitizer
         run: swift test --sanitize=thread
         working-directory: provider
-        
-  test-vapor:
-    needs: getcidata
+
+  test-vapor-linux:
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
-    runs-on: ${{ matrix.env.os }}
-    container: ${{ matrix.env.image }}
-    steps: 
-      - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
-        with:
-          xcode-version: ${{ matrix.env.toolchain }}
-        if: ${{ matrix.env.toolchain != '' }}
+        image:
+          - swift:5.2-focal
+          - swift:5.3-focal
+          - swift:5.4-focal
+          - swift:5.5-focal
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    steps:
       - name: Check out Vapor
         uses: actions/checkout@v2
       - name: Run main tests with Thread Sanitizer
-        timeout-minutes: 30
-        run: swift test --enable-test-discovery --filter VaporTests --sanitize=thread
+        run: swift test --enable-test-discovery --filter '^VaporTests' --sanitize=thread
       - name: Run async tests without Thread Sanitizer
-        # TSAN and async aren't playing nice at the moment
-        timeout-minutes: 30
-        if: ${{ matrix.env.toolchain == '' }}
-        run: swift test --enable-test-discovery --filter AsyncTests
+        # TSAN and async don't play nice at the moment
+        run: swift test --enable-test-discovery --filter '^AsyncTests'
+  
+  test-vapor-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode:
+          - latest
+          - latest-stable
+    runs-on: macos-11
+    steps: 
+      - name: Select toolchain
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+      - name: Check out Vapor
+        uses: actions/checkout@v2
+      - name: Run main tests with Thread Sanitizer
+        run: |
+          swift test --filter '^VaporTests' --sanitize=thread -Xlinker -rpath \
+                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+      - name: Run async tests without Thread Sanitizer
+        # TSAN and async don't play nice at the moment
+        run: |
+          swift test --filter '^AsyncTests' -Xlinker -rpath \
+                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
@@ -17,7 +17,7 @@ extension HTTPHeaders {
     
     /// Returns a collection of `MediaTypePreference`s specified by this HTTP message's `"Accept"` header.
     ///
-    /// You can returns all `MediaType`s in this collection to check membership.
+    /// You can access all `MediaType`s in this collection to check membership.
     ///
     ///     httpReq.accept.mediaTypes.contains(.html)
     ///

--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -188,8 +188,14 @@ public extension HTTPMediaType {
     static let multipart = HTTPMediaType(type: "multipart", subType: "mixed")
     /// JSON media type.
     static let json = HTTPMediaType(type: "application", subType: "json", parameters: ["charset": "utf-8"])
-    /// JSON API media type (see https://jsonapi.org/format/).
+    /// JSON API media type.
+    ///
+    /// > Note: [JSON API specification](https://jsonapi.org/format/)
     static let jsonAPI = HTTPMediaType(type: "application", subType: "vnd.api+json", parameters: ["charset": "utf-8"])
+    /// JSON sequence media type.
+    ///
+    /// > Note: [JSON Text Sequence RFC](https://datatracker.ietf.org/doc/html/rfc7464)
+    static let jsonSequence = HTTPMediaType(type: "application", subType: "json-seq", parameters: ["charset": "utf-8"])
     /// XML media type.
     static let xml = HTTPMediaType(type: "application", subType: "xml", parameters: ["charset": "utf-8"])
     /// DTD media type.


### PR DESCRIPTION
Also fixes a couple of minor formatting and wording issues in a couple of comments.

I would've added `ContentConfiguration` for the `.jsonSequence` media type, but its most effective use in a Vapor context would be via `Request.Body.drain(_:)` and `Response.Body.init(stream:)`, and `ContentEncoder`/`ContentDecoder` are not really set up for that. Here is a supposed-to-be-quick contrived example (which mostly has the effect of showcasing that `BodyStreamWriter` could _desperately_ use some Concurrency extensions!):

```swift
app.get("json-stream") { req -> Response in
    var headers = HTTPHeaders()
    headers.contentType = .jsonSequence
    return Response(status: .ok, headers: headers, body: .init(stream: { writer in
        _ = writer.eventLoop.performWithTask {
            do {
                let stream = AsyncStream<Int> { c in Task.detached {
                    for _ in 0..<100 {
                        try! await Task.sleep(nanoseconds: 1_000_000_000)
                        c.yield(Int.random(in: .min ... .max))
                    }
                    c.finish()
                } }
                for await i in stream {
                    var buffer = ByteBufferAllocator().buffer(capacity: 0)
                    buffer.writeBytes([0x1e]) // <RS>
                    try JSONEncoder().encode(["i": i], into: &buffer)
                    buffer.writeBytes([0x0a]) // <LF>
                    try await writer.eventLoop.flatSubmit { writer.write(.buffer(buffer)) }.get()
                }
                try await writer.eventLoop.flatSubmit { writer.write(.end) }.get()
            } catch {
                try? await writer.eventLoop.flatSubmit { writer.write(.error(error)) }.get()
            }
        }
    }))
}
```
