### PR TITLE
Make `HTTPServer.init` and `Middleware.resolve` public

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -231,7 +231,7 @@ public final class HTTPServer: Server {
 
     private var application: Application
     
-    init(
+    public init(
         application: Application,
         responder: Responder,
         configuration: Configuration,


### PR DESCRIPTION
Make `Middlewares.resolve()` public to allow users to create their own `Responders` (#2762)
Add a public initializer to `HTTPServer` to allow users to create heir own instance (#2761)
