### PR TITLE
Make Middlewares.resolve public

### DIFF
--- a/Sources/Vapor/Middleware/MiddlewareConfiguration.swift
+++ b/Sources/Vapor/Middleware/MiddlewareConfiguration.swift
@@ -34,7 +34,7 @@ public struct Middlewares {
     }
 
     /// Resolves the configured middleware for a given container
-    internal func resolve() -> [Middleware] {
+    public func resolve() -> [Middleware] {
         return self.storage
     }
 }


### PR DESCRIPTION
Makes the resolve function public so users of Vapor can use it when making their own Responder. 
