### PR TITLE
Update Server Configuration after start

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -222,7 +222,7 @@ public final class HTTPServer: Server {
     }
 
     private let responder: Responder
-    private let configuration: Configuration
+    private var configuration: Configuration
     private let eventLoopGroup: EventLoopGroup
     
     private var connection: HTTPServerConnection?
@@ -277,6 +277,7 @@ public final class HTTPServer: Server {
             on: self.eventLoopGroup
         ).wait()
 
+        self.configuration = configuration
         self.didStart = true
     }
     


### PR DESCRIPTION
This ensures that the `Application`'s configuration is updated correctly when the server starts. This allows you to retrieve correct hostname and ports from the `Application`.

Resolves #2755
