### PR TITLE
Add convenience methods for sending `Client` requests with a `Content` body

### DIFF
--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -31,6 +31,18 @@ extension Client {
     public func delete(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) -> EventLoopFuture<ClientResponse> {
         return self.send(.DELETE, headers: headers, to: url, beforeSend: beforeSend)
     }
+    
+    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.post(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
+
+    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.patch(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
+
+    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.put(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
 
     public func send(
         _ method: HTTPMethod,

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -32,16 +32,16 @@ extension Client {
         return self.send(.DELETE, headers: headers, to: url, beforeSend: beforeSend)
     }
     
-    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
-        return self.post(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.post(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
 
-    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
-        return self.patch(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.patch(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
 
-    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) -> EventLoopFuture<ClientResponse> where T: Content {
-        return self.put(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) -> EventLoopFuture<ClientResponse> where T: Content {
+        return self.put(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
 
     public func send(

--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -23,16 +23,16 @@ extension Client {
         return try await self.send(.DELETE, headers: headers, to: url, beforeSend: beforeSend).get()
     }
         
-    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
-        return try await self.post(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) async throws -> ClientResponse where T: Content {
+        return try await self.post(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
     
-    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
-        return try await self.patch(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) async throws -> ClientResponse where T: Content {
+        return try await self.patch(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
     
-    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
-        return try await self.put(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], content: T) async throws -> ClientResponse where T: Content {
+        return try await self.put(url, headers: headers, beforeSend: { try $0.content.encode(content) })
     }
 
     public func send(

--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -22,6 +22,18 @@ extension Client {
     public func delete(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) async throws -> ClientResponse {
         return try await self.send(.DELETE, headers: headers, to: url, beforeSend: beforeSend).get()
     }
+        
+    public func post<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
+        return try await self.post(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
+    
+    public func patch<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
+        return try await self.patch(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
+    
+    public func put<T>(_ url: URI, headers: HTTPHeaders = [:], body: T) async throws -> ClientResponse where T: Content {
+        return try await self.put(url, headers: headers, beforeSend: { try $0.content.encode(body) })
+    }
 
     public func send(
         _ method: HTTPMethod,

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -70,6 +70,22 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(data.headers["Content-Type"], "application/json; charset=utf-8")
     }
     
+    func testClientContent() throws {
+        let app = Application()
+        defer { app.shutdown() }
+        try app.boot()
+        
+        let res = try app.client.post("http://httpbin.org/anything", content: ["hello": "world"]).wait()
+
+        struct HTTPBinAnything: Codable {
+            var headers: [String: String]
+            var json: [String: String]
+        }
+        let data = try res.content.decode(HTTPBinAnything.self)
+        XCTAssertEqual(data.json, ["hello": "world"])
+        XCTAssertEqual(data.headers["Content-Type"], "application/json; charset=utf-8")
+    }
+    
     func testBoilerplateClient() throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
Adds `post`, `put` and `patch` convenience functions for sending `Client` requests with a `Content` body.

E.g.

```swift
struct MyData: Content {
  let title: String
  let count: Int
}

let myData = MyData(...)

let response = try await req.client.post(url, myData)
```
