### PR TITLE
Bump AsyncHTTPClient to 1.8.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.2.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.8.2"),
 
         // Sugary extensions for the SwiftNIO library
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),


### PR DESCRIPTION
[This](https://github.com/swift-server/async-http-client/issues/532#issue-1083537901) AsyncHTTPClient issue claims that `tls_protocol_version_t` was causing build issues due to only being available in newer macOS/iOS versions. As such the AsyncHTTPClient authors issued a fix in version `1.5.1`. This PR bumps AsyncHTTPClient to 1.8.2 which fixes the issue happening in vapor.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
