### PR TITLE
Require version of swift-nio-http2 with security fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.2"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.20.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),


### PR DESCRIPTION
Per https://github.com/apple/swift-nio-http2/security/advisories/GHSA-q36x-r5x4-h4q6
