### PR TITLE
testRequestBodyBackpressureWorks: forgot one assert

### DIFF
--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -770,6 +770,7 @@ final class ServerTests: XCTestCase {
                         _ = numberOfTimesTheServerGotOfferedBytes.add(1)
                         _ = bytesTheServerSaw.add(bytes.readableBytes)
                     case .end:
+                        XCTFail("backpressure should prevent us seeing the end of the request.")
                         serverSawEnd.store(true)
                         writer.write(.end, promise: nil)
                     case .error(let error):


### PR DESCRIPTION
This makes the test slightly less probabilistic (ie. fails more reliably if backpressure were broken).