### PR TITLE
Adding .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Package.resolved
 .swiftpm
 Tests/LinuxMain.swift
 .vscode
+.env


### PR DESCRIPTION
Adding .env to the default .gitignore to help prevent accidentally pushing a .env file to a public repo.
