### PR TITLE
Fix ambiguous error with Swift nightlies

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -227,7 +227,7 @@ extension HTTPHeaders {
 private extension Substring {
     /// Converts all `\"` to `"`.
     func unescapingDoubleQuotes() -> Substring {
-        self.lazy.split(separator: "\\").reduce(into: "") { (result, part) in
+        self.split(separator: "\\").reduce(into: "") { (result, part) in
             if result.isEmpty || part.first == "\"" {
                 result += part
             } else {


### PR DESCRIPTION
Fix a compilation error in the latest Swift nightlies due to using `String.lazy.split(separator:)`, which is not needed