### PR TITLE
Added custom failure descriptions to Validation Errors

### DIFF
--- a/Sources/Vapor/Validation/Validation.swift
+++ b/Sources/Vapor/Validation/Validation.swift
@@ -1,7 +1,7 @@
 public struct Validation {
     let run: (KeyedDecodingContainer<ValidationKey>) -> ValidationResult
 
-    init<T>(key: ValidationKey, required: Bool, validator: Validator<T>) {
+    init<T>(key: ValidationKey, required: Bool, validator: Validator<T>, customFailureDescription: String?) {
         self.init { container in
             let result: ValidatorResult
             do {
@@ -21,11 +21,12 @@ public struct Validation {
             } catch {
                result = ValidatorResults.Codable(error: error)
            }
-            return .init(key: key, result: result)
+            
+            return .init(key: key, result: result, customFailureDescription: customFailureDescription)
         }
     }
     
-    init(nested key: ValidationKey, required: Bool, keyed validations: Validations) {
+    init(nested key: ValidationKey, required: Bool, keyed validations: Validations, customFailureDescription: String?) {
         self.init { container in
             let result: ValidatorResult
             do {
@@ -43,11 +44,11 @@ public struct Validation {
             } catch {
                 result = ValidatorResults.Codable(error: error)
             }
-            return .init(key: key, result: result)
+            return .init(key: key, result: result, customFailureDescription: customFailureDescription)
         }
     }
     
-    init(nested key: ValidationKey, required: Bool, unkeyed factory: @escaping (Int, inout Validations) -> ()) {
+    init(nested key: ValidationKey, required: Bool, unkeyed factory: @escaping (Int, inout Validations) -> (), customFailureDescription: String?) {
         self.init { container in
             let result: ValidatorResult
             do {
@@ -66,13 +67,13 @@ public struct Validation {
             } catch {
                 result = ValidatorResults.Codable(error: error)
             }
-            return .init(key: key, result: result)
+            return .init(key: key, result: result, customFailureDescription: customFailureDescription)
         }
     }
     
-    init(key: ValidationKey, result: ValidatorResult) {
+    init(key: ValidationKey, result: ValidatorResult, customFailureDescription: String?) {
         self.init { decoder in
-            .init(key: key, result: result)
+            .init(key: key, result: result, customFailureDescription: customFailureDescription)
         }
     }
     
@@ -84,6 +85,13 @@ public struct Validation {
 public struct ValidationResult {
     public let key: ValidationKey
     public let result: ValidatorResult
+    public let customFailureDescription: String?
+    
+    init(key: ValidationKey, result: ValidatorResult, customFailureDescription: String? = nil) {
+        self.key = key
+        self.result = result
+        self.customFailureDescription = customFailureDescription
+    }
 }
 
 extension ValidationResult: ValidatorResult {

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -9,37 +9,41 @@ public struct Validations {
         _ key: ValidationKey,
         as type: T.Type = T.self,
         is validator: Validator<T> = .valid,
-        required: Bool = true
+        required: Bool = true,
+        customFailureDescription: String? = nil
     ) {
-        let validation = Validation(key: key, required: required, validator: validator)
+        let validation = Validation(key: key, required: required, validator: validator, customFailureDescription: customFailureDescription)
         self.storage.append(validation)
     }
     
     public mutating func add(
         _ key: ValidationKey,
-        result: ValidatorResult
+        result: ValidatorResult,
+        customFailureDescription: String? = nil
     ) {
-        let validation = Validation(key: key, result: result)
+        let validation = Validation(key: key, result: result, customFailureDescription: customFailureDescription)
         self.storage.append(validation)
     }
 
     public mutating func add(
         _ key: ValidationKey,
         required: Bool = true,
+        customFailureDescription: String? = nil,
         _ nested: (inout Validations) -> ()
     ) {
         var validations = Validations()
         nested(&validations)
-        let validation = Validation(nested: key, required: required, keyed: validations)
+        let validation = Validation(nested: key, required: required, keyed: validations, customFailureDescription: customFailureDescription)
         self.storage.append(validation)
     }
     
     public mutating func add(
         each key: ValidationKey,
         required: Bool = true,
+        customFailureDescription: String? = nil,
         _ handler: @escaping (Int, inout Validations) -> ()
     ) {
-        let validation = Validation(nested: key, required: required, unkeyed: handler)
+        let validation = Validation(nested: key, required: required, unkeyed: handler, customFailureDescription: customFailureDescription)
         self.storage.append(validation)
     }
     

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -23,7 +23,7 @@ public struct ValidationsError: Error {
 
 extension ValidationsError: CustomStringConvertible {
     public var description: String {
-        self.failures.compactMap { $0.failureDescription }
+        self.failures.compactMap { $0.customFailureDescription ?? $0.failureDescription }
             .joined(separator: ", ")
     }
 }


### PR DESCRIPTION
This adds support for custom failure descriptions when running validations. This allows you to customise the any unreadable keys and allows you to provide localized failure descriptions for each Validation.