### PR TITLE
Provide async closures in XCTVapor

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -103,6 +103,30 @@ public protocol XCTApplicationTester {
 }
 
 extension XCTApplicationTester {
+    #if compiler(>=5.5) && canImport(_Concurrency)
+    @discardableResult
+    public func test(
+        _ method: HTTPMethod,
+        _ path: String,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        afterResponse: (XCTHTTPResponse) async throws -> ()
+    ) async throws -> XCTApplicationTester {
+        try await self.test(
+            method,
+            path,
+            headers: headers,
+            body: body,
+            file: file,
+            line: line,
+            beforeRequest: { _ in },
+            afterResponse: afterResponse
+        )
+    }
+    #endif
+
     @discardableResult
     public func test(
         _ method: HTTPMethod,
@@ -125,6 +149,35 @@ extension XCTApplicationTester {
         )
     }
 
+    #if compiler(>=5.5) && canImport(_Concurrency)
+    @discardableResult
+    public func test(
+        _ method: HTTPMethod,
+        _ path: String,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        beforeRequest: (inout XCTHTTPRequest) async throws -> () = { _ in },
+        afterResponse: (XCTHTTPResponse) async throws -> () = { _ in }
+    ) async throws -> XCTApplicationTester {
+        var request = XCTHTTPRequest(
+            method: method,
+            url: .init(path: path),
+            headers: headers,
+            body: body ?? ByteBufferAllocator().buffer(capacity: 0)
+        )
+        try await beforeRequest(&request)
+        do {
+            let response = try self.performTest(request: request)
+            try await afterResponse(response)
+        } catch {
+            XCTFail("\(error)", file: (file), line: line)
+            throw error
+        }
+        return self
+    }
+    #endif
 
     @discardableResult
     public func test(
@@ -153,6 +206,32 @@ extension XCTApplicationTester {
         }
         return self
     }
+    
+    #if compiler(>=5.5) && canImport(_Concurrency)
+    public func sendRequest(
+        _ method: HTTPMethod,
+        _ path: String,
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        file: StaticString = #file,
+        line: UInt = #line,
+        beforeRequest: (inout XCTHTTPRequest) async throws -> () = { _ in }
+    ) async throws -> XCTHTTPResponse {
+        var request = XCTHTTPRequest(
+            method: method,
+            url: .init(path: path),
+            headers: headers,
+            body: body ?? ByteBufferAllocator().buffer(capacity: 0)
+        )
+        try await beforeRequest(&request)
+        do {
+            return try self.performTest(request: request)
+        } catch {
+            XCTFail("\(error)", file: (file), line: line)
+            throw error
+        }
+    }
+    #endif
 
     public func sendRequest(
         _ method: HTTPMethod,


### PR DESCRIPTION
This adds the ability to perform asynchronous work in the `beforeRequest` and `afterResponse` closures in XCTVapor. 

E.g.

```swift
try await app.test(.GET, "/hello", beforeRequest: { req async throws in
  let currentUsersCount = try await User.query(on: app.db).count()
}, afterResponse: { res async throws in
  let newUsersCount = try await User.query(on: app.db).count()
})
```