### PR TITLE
Do not conform UUID to LosslessStringConvertible

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder.swift
@@ -1,9 +1,3 @@
 public protocol RoutesBuilder {
     func add(_ route: Route)
 }
-
-extension UUID: LosslessStringConvertible {
-    public init?(_ description: String) {
-        self.init(uuidString: description)
-    }
-}


### PR DESCRIPTION
Vapor should not extend a type it does not own with a protocol it does not own. Doing so can lead to conflicts with other code.