### PR TITLE
Adds `cache.delete(_:)`

### DIFF
--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -9,12 +9,12 @@ public protocol Cache {
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
         where T: Encodable
     
-    /// Sets an encodable value into the cache. Removes value
-    func setToNil(_ key: String) -> EventLoopFuture<Void>
-    
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
         where T: Encodable
+    
+    /// Sets an encodable value into the cache. Removes value
+    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void>
     
     /// Creates a request-specific cache instance.
     func `for`(_ request: Request) -> Self

--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -12,10 +12,7 @@ public protocol Cache {
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
         where T: Encodable
-    
-    /// Sets an encodable value into the cache. Removes value
-    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void>
-    
+        
     /// Creates a request-specific cache instance.
     func `for`(_ request: Request) -> Self
 }
@@ -26,6 +23,11 @@ extension Cache {
         where T: Encodable
     {
         return self.set(key, to: value)
+    }
+    
+    public func delete(_ key: String) -> EventLoopFuture<Void>
+    {
+        return self.set(key, to: String?.none)
     }
     
     /// Gets a decodable value from the cache. Returns `nil` if not found.

--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -1,3 +1,4 @@
+import NIOCore
 /// Codable key-value pair cache.
 public protocol Cache {
     /// Gets a decodable value from the cache. Returns `nil` if not found.
@@ -7,6 +8,9 @@ public protocol Cache {
     /// Sets an encodable value into the cache. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
         where T: Encodable
+    
+    /// Sets an encodable value into the cache. Removes value
+    func setToNil(_ key: String) -> EventLoopFuture<Void>
     
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -82,6 +82,13 @@ private final class MemoryCacheStorage {
             self.storage.removeValue(forKey: key)
         }
     }
+    
+    func setToNil(_ key: String)
+    {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.storage.removeValue(forKey: key)
+    }
 }
 
 private struct MemoryCache: Cache {
@@ -103,6 +110,11 @@ private struct MemoryCache: Cache {
         where T: Encodable
     {
         self.set(key, to: value, expiresIn: nil)
+    }
+    
+    func setToNil(_ key: String) -> EventLoopFuture<Void> {
+        self.storage.setToNil(key)
+        return self.eventLoop.makeSucceededFuture(())
     }
     
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -83,21 +83,6 @@ private final class MemoryCacheStorage {
             self.storage.removeValue(forKey: key)
         }
     }
-    
-    func set(_ key: String, to value: ExpressibleByNilLiteral?, expiresIn expirationTime: CacheExpirationTime?)
-    {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        if let value = value {
-            var box = CacheEntryBox(value)
-            if let expirationTime = expirationTime {
-                box.expiresAt = Date().addingTimeInterval(TimeInterval(expirationTime.seconds))
-            }
-            self.storage[key] = box
-        } else {
-            self.storage.removeValue(forKey: key)
-        }
-    }
 }
 
 private struct MemoryCache: Cache {
@@ -119,12 +104,6 @@ private struct MemoryCache: Cache {
         where T: Encodable
     {
         self.set(key, to: value, expiresIn: nil)
-    }
-    
-    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void>
-    {
-        self.storage.set(key, to: value, expiresIn: nil)
-        return self.eventLoop.makeSucceededFuture(())
     }
     
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>

--- a/Sources/Vapor/Concurrency/Cache+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Cache+Concurrency.swift
@@ -13,15 +13,14 @@ public extension Cache {
     func set<T>(_ key: String, to value: T?) async throws where T: Encodable {
         try await self.set(key, to: value).get()
     }
-    
-    /// Sets an encodable value into the cache. Removes value
-    func set(_ key: String, to value: ExpressibleByNilLiteral?) async throws {
-        try await self.set(key, to: value).get()
-    }
 
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) async throws where T: Encodable {
         try await self.set(key, to: value, expiresIn: expirationTime).get()
+    }
+    
+    func delete(_ key: String) async throws {
+        try await self.delete(key).get()
     }
 
     /// Gets a decodable value from the cache. Returns `nil` if not found.

--- a/Sources/Vapor/Concurrency/Cache+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Cache+Concurrency.swift
@@ -13,6 +13,11 @@ public extension Cache {
     func set<T>(_ key: String, to value: T?) async throws where T: Encodable {
         try await self.set(key, to: value).get()
     }
+    
+    /// Sets an encodable value into the cache. Removes value
+    func setToNil(_ key: String) async throws {
+        try await self.setToNil(key).get()
+    }
 
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) async throws where T: Encodable {

--- a/Sources/Vapor/Concurrency/Cache+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Cache+Concurrency.swift
@@ -15,8 +15,8 @@ public extension Cache {
     }
     
     /// Sets an encodable value into the cache. Removes value
-    func setToNil(_ key: String) async throws {
-        try await self.setToNil(key).get()
+    func set(_ key: String, to value: ExpressibleByNilLiteral?) async throws {
+        try await self.set(key, to: value).get()
     }
 
     /// Sets an encodable value into the cache with an expiry time. Existing values are replaced. If `nil`, removes value.

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -21,6 +21,14 @@ final class AsyncCacheTests: XCTestCase {
         sleep(1)
         let value4 = try await app.cache.get("foo2", as: String.self)
         XCTAssertNil(value4)
+        
+        // Test reset
+        try await app.cache.set("foo3", to: "bar3")
+        let value5: String? = try await app.cache.get("foo3")
+        XCTAssertEqual(value5, "bar3")
+        try await app.cache.setToNil("foo3")
+        let value6 = try await app.cache.get("foo3", as: String.self)
+        XCTAssertNil(value6)
     }
 
     func testCustomCache() async throws {
@@ -60,6 +68,10 @@ struct FooCache: Cache {
     }
 
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void> where T : Encodable {
+        return self.eventLoop.makeSucceededFuture(())
+    }
+    
+    func setToNil(_ key: String) -> EventLoopFuture<Void> {
         return self.eventLoop.makeSucceededFuture(())
     }
 

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -22,11 +22,11 @@ final class AsyncCacheTests: XCTestCase {
         let value4 = try await app.cache.get("foo2", as: String.self)
         XCTAssertNil(value4)
         
-        // Test reset
+        // Test reset value
         try await app.cache.set("foo3", to: "bar3")
         let value5: String? = try await app.cache.get("foo3")
         XCTAssertEqual(value5, "bar3")
-        try await app.cache.setToNil("foo3")
+        try await app.cache.set("foo3", to: nil)
         let value6 = try await app.cache.get("foo3", as: String.self)
         XCTAssertNil(value6)
     }
@@ -71,7 +71,7 @@ struct FooCache: Cache {
         return self.eventLoop.makeSucceededFuture(())
     }
     
-    func setToNil(_ key: String) -> EventLoopFuture<Void> {
+    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void> {
         return self.eventLoop.makeSucceededFuture(())
     }
 

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -26,7 +26,7 @@ final class AsyncCacheTests: XCTestCase {
         try await app.cache.set("foo3", to: "bar3")
         let value5: String? = try await app.cache.get("foo3")
         XCTAssertEqual(value5, "bar3")
-        try await app.cache.set("foo3", to: nil)
+        try await app.cache.delete("foo3")
         let value6 = try await app.cache.get("foo3", as: String.self)
         XCTAssertNil(value6)
     }
@@ -68,10 +68,6 @@ struct FooCache: Cache {
     }
 
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void> where T : Encodable {
-        return self.eventLoop.makeSucceededFuture(())
-    }
-    
-    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void> {
         return self.eventLoop.makeSucceededFuture(())
     }
 

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -14,6 +14,12 @@ final class CacheTests: XCTestCase {
         try XCTAssertEqual(app.cache.get("foo2").wait(), "bar2")
         sleep(1)
         try XCTAssertNil(app.cache.get("foo2", as: String.self).wait())
+        
+        // Reset value
+        try app.cache.set("foo3", to: "bar3").wait()
+        try XCTAssertEqual(app.cache.get("foo3").wait(), "bar3")
+        try app.cache.setToNil("foo3").wait()
+        try XCTAssertNil(app.cache.get("foo3", as: String.self).wait())
     }
     
     func testCustomCache() throws {
@@ -52,6 +58,10 @@ struct FooCache: Cache {
     }
     
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void> where T : Encodable {
+        return self.eventLoop.makeSucceededFuture(())
+    }
+    
+    func setToNil(_ key: String) -> EventLoopFuture<Void> {
         return self.eventLoop.makeSucceededFuture(())
     }
     

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -18,7 +18,7 @@ final class CacheTests: XCTestCase {
         // Test reset value
         try app.cache.set("foo3", to: "bar3").wait()
         try XCTAssertEqual(app.cache.get("foo3").wait(), "bar3")
-        try app.cache.set("foo3", to: nil).wait()
+        try app.cache.delete("foo3").wait()
         try XCTAssertNil(app.cache.get("foo3", as: String.self).wait())
     }
     

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -15,10 +15,10 @@ final class CacheTests: XCTestCase {
         sleep(1)
         try XCTAssertNil(app.cache.get("foo2", as: String.self).wait())
         
-        // Reset value
+        // Test reset value
         try app.cache.set("foo3", to: "bar3").wait()
         try XCTAssertEqual(app.cache.get("foo3").wait(), "bar3")
-        try app.cache.setToNil("foo3").wait()
+        try app.cache.set("foo3", to: nil).wait()
         try XCTAssertNil(app.cache.get("foo3", as: String.self).wait())
     }
     
@@ -62,6 +62,10 @@ struct FooCache: Cache {
     }
     
     func setToNil(_ key: String) -> EventLoopFuture<Void> {
+        return self.eventLoop.makeSucceededFuture(())
+    }
+    
+    func set(_ key: String, to value: ExpressibleByNilLiteral?) -> EventLoopFuture<Void> {
         return self.eventLoop.makeSucceededFuture(())
     }
     


### PR DESCRIPTION
closes #2659 

Adds a function called `delete` to remove a cached value. I wasn't able to override the method with `ExpressableByNilLiteral?` instead of `T?` without making breaking changes