### PR TITLE
Add `.mjs` for `application/javascript` media type

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -255,6 +255,7 @@ let fileExtensionMediaTypeMapping: [String: HTTPMediaType] = [
     "ser": HTTPMediaType(type: "application", subType: "java-serialized-object"),
     "class": HTTPMediaType(type: "application", subType: "java-vm"),
     "js": HTTPMediaType(type: "application", subType: "javascript"),
+    "mjs": HTTPMediaType(type: "application", subType: "javascript"),
     "json": HTTPMediaType(type: "application", subType: "json"),
     "m3g": HTTPMediaType(type: "application", subType: "m3g"),
     "hqx": HTTPMediaType(type: "application", subType: "mac-binhex40"),


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), `.mjs` is an extension that JavaScript files with support for EcmaScript Module system can use.
The lack of this extension in the mapping causes some browsers to throw `'text/plain' is not a valid JavaScript MIME type.` error.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
