### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           - vapor/queues
           - vapor/apns
     runs-on: ubuntu-latest
-    container: swift:5.5-focal
+    container: swift:5.6-focal
     steps: 
       - name: Check out Vapor
         uses: actions/checkout@v2
@@ -29,48 +29,8 @@ jobs:
       - name: Run tests with Thread Sanitizer
         run: swift test --sanitize=thread
         working-directory: provider
-
-  test-vapor-linux:
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - swift:5.2-focal
-          - swift:5.3-focal
-          - swift:5.4-focal
-          - swift:5.5-focal
-    runs-on: ubuntu-latest
-    container: ${{ matrix.image }}
-    steps:
-      - name: Check out Vapor
-        uses: actions/checkout@v2
-      - name: Run main tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --filter '^VaporTests' --sanitize=thread
-      - name: Run async tests without Thread Sanitizer
-        # TSAN and async don't play nice at the moment
-        run: swift test --enable-test-discovery --filter '^AsyncTests'
-  
-  test-vapor-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        xcode:
-          - latest
-          - latest-stable
-    runs-on: macos-11
-    steps: 
-      - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.xcode }}
-      - name: Check out Vapor
-        uses: actions/checkout@v2
-      - name: Run main tests with Thread Sanitizer
-        run: |
-          swift test --filter '^VaporTests' --sanitize=thread -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
-      - name: Run async tests without Thread Sanitizer
-        # TSAN and async don't play nice at the moment
-        run: |
-          swift test --filter '^AsyncTests' -Xlinker -rpath \
-                -Xlinker $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx
+  unit-tests:
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+     with:
+       with_coverage: false
+       with_tsan: false

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)