### PR TITLE
Fix handling unicode characters in multipart filenames

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -29,13 +29,11 @@ extension HTTPHeaders {
         public var value: Value
         public var name: String?
         public var filename: String?
-        public var filenameASCII: String?
 
-        public init(_ value: Value, name: String? = nil, filename: String? = nil, filenameASCII: String? = nil) {
+        public init(_ value: Value, name: String? = nil, filename: String? = nil) {
             self.value = value
             self.name = name
             self.filename = filename
-            self.filenameASCII = filenameASCII
         }
 
         init?(directives: [Directive]) {
@@ -56,7 +54,7 @@ extension HTTPHeaders {
                 case "filename":
                     self.filename = .init(parameter)
                 case "filename*":
-                    self.filenameASCII = .init(parameter)
+                    self.filename = .init(parameter)
                 default:
                     return nil
                 }
@@ -72,9 +70,6 @@ extension HTTPHeaders {
             }
             if let filename = self.filename {
                 directives.append(.init(value: "filename", parameter: filename))
-            }
-            if let filenameASCII = filenameASCII {
-                directives.append(.init(value: "filename*", parameter: filenameASCII))
             }
             return directives
         }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -29,11 +29,13 @@ extension HTTPHeaders {
         public var value: Value
         public var name: String?
         public var filename: String?
+        public var filenameASCII: String?
 
-        public init(_ value: Value, name: String? = nil, filename: String? = nil) {
+        public init(_ value: Value, name: String? = nil, filename: String? = nil, filenameASCII: String? = nil) {
             self.value = value
             self.name = name
             self.filename = filename
+            self.filenameASCII = filenameASCII
         }
 
         init?(directives: [Directive]) {
@@ -54,7 +56,7 @@ extension HTTPHeaders {
                 case "filename":
                     self.filename = .init(parameter)
                 case "filename*":
-                    self.filename = .init(parameter)
+                    self.filenameASCII = .init(parameter)
                 default:
                     return nil
                 }
@@ -70,6 +72,9 @@ extension HTTPHeaders {
             }
             if let filename = self.filename {
                 directives.append(.init(value: "filename", parameter: filename))
+            }
+            if let filenameASCII = filenameASCII {
+                directives.append(.init(value: "filename*", parameter: filenameASCII))
             }
             return directives
         }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -53,6 +53,8 @@ extension HTTPHeaders {
                     self.name = .init(parameter)
                 case "filename":
                     self.filename = .init(parameter)
+                case "filename*":
+                    self.filename = .init(parameter)
                 default:
                     return nil
                 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -103,7 +103,7 @@ final class ContentTests: XCTestCase {
             XCTAssertContains(res.body.string, "hi")
         }
     }
-
+    
     func testMultipartDecode() throws {
         let data = """
         --123\r
@@ -125,6 +125,52 @@ final class ContentTests: XCTestCase {
             name: "Vapor",
             age: 4,
             image: File(data: "<contents of image>", filename: "droplet.png")
+        )
+
+        struct User: Content, Equatable {
+            var name: String
+            var age: Int
+            var image: File
+        }
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.routes.get("multipart") { req -> User in
+            let decoded = try req.content.decode(User.self)
+            XCTAssertEqual(decoded, expected)
+            return decoded
+        }
+
+        try app.testable().test(.GET, "/multipart", headers: [
+            "Content-Type": "multipart/form-data; boundary=123"
+        ], body: .init(string: data)) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqualJSON(res.body.string, expected)
+        }
+    }
+    
+    func testMultipartDecodeUnicode() throws {
+        let data = """
+        --123\r
+        Content-Disposition: form-data; name="name"\r
+        \r
+        Vapor\r
+        --123\r
+        Content-Disposition: form-data; name="age"\r
+        \r
+        4\r
+        --123\r
+        Content-Disposition: form-data; name="image"; filename="她在吃水果.png"; filename*="UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png"\r
+        \r
+        <contents of image>\r
+        --123--\r
+
+        """
+        let expected = User(
+            name: "Vapor",
+            age: 4,
+            image: File(data: "<contents of image>", filename: "UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png")
         )
 
         struct User: Content, Equatable {
@@ -174,6 +220,34 @@ final class ContentTests: XCTestCase {
             XCTAssertContains(res.body.string, "Content-Disposition: form-data; name=\"name\"")
             XCTAssertContains(res.body.string, "--\(boundary)")
             XCTAssertContains(res.body.string, "filename=droplet.png")
+            XCTAssertContains(res.body.string, "name=\"image\"")
+        }
+    }
+    
+    func testMultiPartEncodeUnicode() throws {
+        struct User: Content {
+            static var defaultContentType: HTTPMediaType = .formData
+            var name: String
+            var age: Int
+            var image: File
+        }
+
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.get("multipart") { req -> User in
+            return User(
+                name: "Vapor",
+                age: 4,
+                image: File(data: "<contents of image>", filename: "UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png")
+            )
+        }
+        try app.testable().test(.GET, "/multipart") { res in
+            XCTAssertEqual(res.status, .ok)
+            let boundary = res.headers.contentType?.parameters["boundary"] ?? "none"
+            XCTAssertContains(res.body.string, "Content-Disposition: form-data; name=\"name\"")
+            XCTAssertContains(res.body.string, "--\(boundary)")
+            XCTAssertContains(res.body.string, "filename=UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png")
             XCTAssertContains(res.body.string, "name=\"image\"")
         }
     }


### PR DESCRIPTION
Adds a case to ContentDisposition to be compliant with [rfc-5987](https://www.rfc-editor.org/rfc/rfc5987). This allows handling of unicode and other format characters in filenames.

closes #2802 
