### PR TITLE
Add flag to enable/disable metrics

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -143,7 +143,10 @@ public final class HTTPServer: Server {
         
         /// If set, this name will be serialized as the `Server` header in outgoing responses.
         public var serverName: String?
-        
+
+        /// When `true`, report http metrics through `swift-metrics`
+        public var reportMetrics: Bool
+
         /// Any uncaught server or responder errors will go here.
         public var logger: Logger
 
@@ -162,6 +165,7 @@ public final class HTTPServer: Server {
             supportVersions: Set<HTTPVersionMajor>? = nil,
             tlsConfiguration: TLSConfiguration? = nil,
             serverName: String? = nil,
+            reportMetrics: Bool = true,
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10)
         ) {
@@ -176,6 +180,7 @@ public final class HTTPServer: Server {
                 supportVersions: supportVersions,
                 tlsConfiguration: tlsConfiguration,
                 serverName: serverName,
+                reportMetrics: reportMetrics,
                 logger: logger,
                 shutdownTimeout: shutdownTimeout
             )
@@ -192,6 +197,7 @@ public final class HTTPServer: Server {
             supportVersions: Set<HTTPVersionMajor>? = nil,
             tlsConfiguration: TLSConfiguration? = nil,
             serverName: String? = nil,
+            reportMetrics: Bool = true,
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10)
         ) {
@@ -209,6 +215,7 @@ public final class HTTPServer: Server {
             }
             self.tlsConfiguration = tlsConfiguration
             self.serverName = serverName
+            self.reportMetrics = reportMetrics
             self.logger = logger ?? Logger(label: "codes.vapor.http-server")
             self.shutdownTimeout = shutdownTimeout
         }

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -39,7 +39,8 @@ extension Application {
         public var `default`: Vapor.Responder {
             DefaultResponder(
                 routes: self.application.routes,
-                middleware: self.application.middleware.resolve()
+                middleware: self.application.middleware.resolve(),
+                reportMetrics: self.application.http.server.configuration.reportMetrics
             )
         }
 

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -4,6 +4,7 @@ import Metrics
 internal struct DefaultResponder: Responder {
     private let router: TrieRouter<CachedRoute>
     private let notFoundResponder: Responder
+    private let reportMetrics: Bool
 
     private struct CachedRoute {
         let route: Route
@@ -11,7 +12,7 @@ internal struct DefaultResponder: Responder {
     }
 
     /// Creates a new `ApplicationResponder`
-    public init(routes: Routes, middleware: [Middleware] = []) {
+    public init(routes: Routes, middleware: [Middleware] = [], reportMetrics: Bool = true) {
         let options = routes.caseInsensitive ?
             Set(arrayLiteral: TrieRouter<CachedRoute>.ConfigurationOption.caseInsensitive) : []
         let router = TrieRouter(CachedRoute.self, options: options)
@@ -56,6 +57,7 @@ internal struct DefaultResponder: Responder {
         }
         self.router = router
         self.notFoundResponder = middleware.makeResponder(chainingTo: NotFoundResponder())
+        self.reportMetrics = reportMetrics
     }
 
     /// See `Responder`
@@ -76,11 +78,13 @@ internal struct DefaultResponder: Responder {
             case .failure:
                 status = .internalServerError
             }
-            self.updateMetrics(
-                for: request,
-                startTime: startTime,
-                statusCode: status.code
-            )
+            if self.reportMetrics {
+                self.updateMetrics(
+                    for: request,
+                    startTime: startTime,
+                    statusCode: status.code
+                )
+            }
         }
     }
     

--- a/Tests/VaporTests/MetricsTests.swift
+++ b/Tests/VaporTests/MetricsTests.swift
@@ -122,5 +122,36 @@ class MetricsTests: XCTestCase {
             XCTAssertNil(timer.dimensions.first(where: { $0.1 == "200" }))
         })
     }
+
+    func testMetricsDisabled() {
+        let metrics = CapturingMetricsSystem()
+        MetricsSystem.bootstrapInternal(metrics)
+
+        let app = Application(.testing)
+        app.http.server.configuration.reportMetrics = false
+        defer { app.shutdown() }
+
+        struct User: Content {
+            let id: Int
+            let name: String
+        }
+
+        app.routes.get("users", ":userID") { req -> User in
+            let userID = try req.parameters.require("userID", as: Int.self)
+            if userID == 1 {
+                return User(id: 1, name: "Tim")
+            } else {
+                throw Abort(.notFound)
+            }
+        }
+
+        XCTAssertNoThrow(try app.testable().test(.GET, "/users/1") { res in
+            XCTAssertEqual(res.status, .ok)
+            let resData = try res.content.decode(User.self)
+            XCTAssertEqual(resData.id, 1)
+            XCTAssertEqual(metrics.counters.count, 0)
+            XCTAssertNil(metrics.timers["http_request_duration_seconds"])
+        })
+    }
 }
 


### PR DESCRIPTION
Adds a flag that defaults to true to enable / disable reporting metrics via the default handler.

Relates to:
https://github.com/vapor/vapor/issues/2171
https://github.com/vapor/vapor/issues/2488