### PR TITLE
Remove manifst warnings when using 5.4 tools versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,7 @@ let package = Package(
         ]),
 	
         // Development
-        .target(name: "Development", dependencies: [
+        .executableTarget(name: "Development", dependencies: [
             .target(name: "Vapor"),
         ], swiftSettings: [
             // Enable better optimizations when building in Release configuration. Despite the use of
@@ -110,6 +110,13 @@ let package = Package(
         .testTarget(name: "VaporTests", dependencies: [
             .product(name: "NIOTestUtils", package: "swift-nio"),
             .target(name: "XCTVapor"),
+        ], resources: [
+            .copy("Utilities/foo.txt"),
+            .copy("Utilities/index.html"),
+            .copy("Utilities/SubUtilities/"),
+            .copy("Utilities/foo bar.html"),
+            .copy("Utilities/test.env"),
+            .copy("Utilities/my-secret-env-content"),
         ]),
         .testTarget(name: "AsyncTests", dependencies: [
             .product(name: "NIOTestUtils", package: "swift-nio"),


### PR DESCRIPTION
This only affects tests and the Development target so no release needed