### PR TITLE
Conform `Bool` to `Content`

### DIFF
--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -111,6 +111,8 @@ extension UInt16: Content { }
 extension UInt32: Content { }
 extension UInt64: Content { }
 
+extension Bool: Content {}
+
 extension BinaryFloatingPoint where Self: Content {
     public static var defaultContentType: HTTPMediaType {
         return .plainText

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -489,6 +489,19 @@ final class ContentTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         }
     }
+    
+    func testContentIsBool() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        app.routes.get("success") { req in
+            return true
+        }
+        
+        try app.testable().test(.GET, "/success") { res in
+            XCTAssertEqual(try res.content.decode(Bool.self), true)
+        }
+    }
 }
 
 private struct SampleContent: Content {


### PR DESCRIPTION
Conform `Bool` to `Content` to allow `Bool` types to be returned to the top level

```swift
app.get("isOK") { req in
    return true
}
```