### PR TITLE
Fix CredentialsAuthenticator not receiving all the body

### DIFF
--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -64,12 +64,14 @@ public protocol CredentialsAuthenticator: RequestAuthenticator {
 
 extension CredentialsAuthenticator {
     public func authenticate(request: Request) -> EventLoopFuture<Void> {
-        let credentials: Credentials
-        do {
-            credentials = try request.content.decode(Credentials.self)
-        } catch {
-            return request.eventLoop.makeSucceededFuture(())
+        return request.body.collect(max: nil).flatMap { _ -> EventLoopFuture<Void> in
+            let credentials: Credentials
+            do {
+                credentials = try request.content.decode(Credentials.self)
+            } catch {
+                return request.eventLoop.makeSucceededFuture(())
+            }
+            return self.authenticate(credentials: credentials, for: request)
         }
-        return self.authenticate(credentials: credentials, for: request)
     }
 }


### PR DESCRIPTION
This is a workaround for #2742. This ensures the request body is available in the middleware rather than it failing silently.
