### PR TITLE
Add documentation comments and a defaulting subscript to `Storage`.

### DIFF
--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -18,7 +18,7 @@ public struct Storage {
         }
     }
     
-    /// The logger provied to shutdown closures.
+    /// The logger provided to shutdown closures.
     let logger: Logger
 
     /// Create a new ``Storage`` container using the given logger.

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -1,6 +1,11 @@
+/// A container providing arbitrary storage for extensions of an existing type, designed to obviate
+/// the problem of being unable to add stored properties to a type in an extension. Each stored item
+/// is keyed by a type conforming to ``StorageKey`` protocol.
 public struct Storage {
+    /// The internal storage area.
     var storage: [ObjectIdentifier: AnyStorageValue]
 
+    /// A container for a stored value and an associated optional `deinit`-like closure.
     struct Value<T>: AnyStorageValue {
         var value: T
         var onShutdown: ((T) throws -> ())?
@@ -12,17 +17,22 @@ public struct Storage {
             }
         }
     }
+    
+    /// The logger provied to shutdown closures.
     let logger: Logger
 
+    /// Create a new ``Storage`` container using the given logger.
     public init(logger: Logger = .init(label: "codes.vapor.storage")) {
         self.storage = [:]
         self.logger = logger
     }
 
+    /// Delete all values from the container. Does _not_ invoke shutdown closures.
     public mutating func clear() {
         self.storage = [:]
     }
 
+    /// Read/write access to values via keyed subscript.
     public subscript<Key>(_ key: Key.Type) -> Key.Value?
         where Key: StorageKey
     {
@@ -34,10 +44,26 @@ public struct Storage {
         }
     }
 
+    /// Read access to a value via keyed subscript, adding the provided default
+    /// value to the storage if the key does not already exist. Similar to
+    /// ``Swift/Dictionary/subscript(key:default:)``. The `defaultValue` autoclosure
+    /// is evaluated only when the key does not already exist in the container.
+    public subscript<Key>(_ key: Key.Type, default defaultValue: @autoclosure () -> Key.Value) -> Key.Value
+        where Key: StorageKey
+    {
+        mutating get {
+            if let existing = self[key] { return existing }
+            self.set(Key.self, to: defaultValue())
+            return self[key]!
+        }
+    }
+
+    /// Test whether the given key exists in the container.
     public func contains<Key>(_ key: Key.Type) -> Bool {
         self.storage.keys.contains(ObjectIdentifier(Key.self))
     }
 
+    /// Get the value of the given key if it exists and is of the proper type.
     public func get<Key>(_ key: Key.Type) -> Key.Value?
         where Key: StorageKey
     {
@@ -47,6 +73,9 @@ public struct Storage {
         return value.value
     }
 
+    /// Set or remove a value for a given key, optionally providing a shutdown closure for the value.
+    ///
+    /// If a key that has a shutdown closure is removed by this method, the closure **is** invoked.
     public mutating func set<Key>(
         _ key: Key.Type,
         to value: Key.Value?,
@@ -63,6 +92,8 @@ public struct Storage {
         }
     }
 
+    /// For every key in the container having a shutdown closure, invoke the closure. Designed to
+    /// be invoked during an explicit app shutdown process or in a reference type's `deinit`.
     public func shutdown() {
         self.storage.values.forEach {
             $0.shutdown(logger: self.logger)
@@ -70,11 +101,14 @@ public struct Storage {
     }
 }
 
-
+/// ``Storage`` uses this protocol internally to generically invoke shutdown closures for arbitrarily-
+/// typed key values.
 protocol AnyStorageValue {
     func shutdown(logger: Logger)
 }
 
+/// A key used to store values in a ``Storage`` must conform to this protocol.
 public protocol StorageKey {
+    /// The type of the stored value associated with this key type.
     associatedtype Value
 }

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -53,8 +53,9 @@ public struct Storage {
     {
         mutating get {
             if let existing = self[key] { return existing }
-            self.set(Key.self, to: defaultValue())
-            return self[key]!
+            let new = defaultValue()
+            self.set(Key.self, to: new)
+            return new
         }
     }
 


### PR DESCRIPTION
The new subscript simplifies "provider" implementations that extend `Application` and use its `Storage` instance without complex initialization requirements:

```swift
extension Application {
    public struct Foo {
        final class Storage { /* content which needs no special initialization */ }
        struct Key: StorageKey { typealias Value = Storage }
        let application: Application

        // Before:
        var storage: Storage {
            if self.application.storage[Key.self] == nil { self.initialize() }
            return self.application.storage[Key.self]!
        }

        func initialize() { self.application.storage[Key.self] = .init() }

        // After:
        var storage: Storage { self.application.storage[Key.self, default: .init()] }
```