### PR TITLE
Add support for using AsyncCommand and booting in fully async context

### DIFF
--- a/Sources/Vapor/Concurrency/Application+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Application+Concurrency.swift
@@ -4,30 +4,44 @@ import ConsoleKit
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Application {
 
-    /// Async version of ``start()``. Honors the commands registered in ``asyncCommands-swift.property``
-    /// in addition to the ones registered on ``commands``. Otherwise identical to the non-async version.
-    public func start() async throws {
-        self.asyncCommands.merge(oldCommands: self.commands.commands)
+    /// Namespacing wrapper to isolate additional API for starting from an async entrypoint.
+    public struct Async {
+        let application: Application
+        
+        /// Public interface to the `Application.asyncCommands` provider, which is deliberately made publicly
+        /// visible only through this namespace.
+        public var commands: AsyncCommands {
+            get { self.application.asyncCommands }
+        }
+        
+        /// Async version of ``start()``. Honors the commands registered in ``asyncCommands-swift.property``
+        /// in addition to the ones registered on ``commands``. Otherwise identical to the non-async version.
+        public func start() async throws {
+            self.commands.merge(oldCommands: self.application.commands.commands)
 
-        try self.boot()
-        let command = self.asyncCommands.group()
-        var context = CommandContext(console: self.console, input: self.environment.commandInput)
-        context.application = self
-        try await self.console.run(command, with: context)
-    }
+            try self.application.boot()
+            let command = self.commands.group()
+            var context = CommandContext(console: self.application.console, input: self.application.environment.commandInput)
+            context.application = self.application
+            try await self.application.console.run(command, with: context)
+        }
 
-    /// Async version of ``run()``. Identical to the non-async version except that the async version
-    /// of ``start()`` is called instead.
-    public func run() async throws {
-        do {
-            try await self.start()
-            try await self.running?.onStop.get()
-        } catch {
-            self.logger.report(error: error)
-            throw error
+        /// Async version of ``run()``. Identical to the non-async version except that the async version
+        /// of ``start()`` is called instead.
+        public func run() async throws {
+            do {
+                try await self.start()
+                try await self.application.running?.onStop.get()
+            } catch {
+                self.application.logger.report(error: error)
+                throw error
+            }
         }
     }
-
+    
+    public var async: Async {
+        .init(application: self)
+    }
 }
 
 #endif

--- a/Sources/Vapor/Concurrency/Application+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Application+Concurrency.swift
@@ -1,0 +1,33 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
+import ConsoleKit
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension Application {
+
+    /// Async version of ``start()``. Honors the commands registered in ``asyncCommands-swift.property``
+    /// in addition to the ones registered on ``commands``. Otherwise identical to the non-async version.
+    public func start() async throws {
+        self.asyncCommands.merge(oldCommands: self.commands.commands)
+
+        try self.boot()
+        let command = self.asyncCommands.group()
+        var context = CommandContext(console: self.console, input: self.environment.commandInput)
+        context.application = self
+        try await self.console.run(command, with: context)
+    }
+
+    /// Async version of ``run()``. Identical to the non-async version except that the async version
+    /// of ``start()`` is called instead.
+    public func run() async throws {
+        do {
+            try await self.start()
+            try await self.running?.onStop.get()
+        } catch {
+            self.logger.report(error: error)
+            throw error
+        }
+    }
+
+}
+
+#endif

--- a/Sources/Vapor/Concurrency/Commands+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Commands+Concurrency.swift
@@ -104,8 +104,8 @@ extension Application {
         }
     }
     
-    /// The async version of ``Application/commands``.
-    public var asyncCommands: AsyncCommands {
+    /// The async version of ``Application/commands``. See `Application+Concurrency.swift` for the public interface.
+    internal var asyncCommands: AsyncCommands {
         .init(application: self)
     }
 

--- a/Sources/Vapor/Concurrency/Commands+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Commands+Concurrency.swift
@@ -1,0 +1,114 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
+import NIOCore
+import ConsoleKit
+
+/// Trivial adapter to turn non-async ``Command``s into ``AsyncCommand``s.
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+struct AnyCommandAsyncAdapter: AnyAsyncCommand {
+    private let syncCommand: AnyCommand
+    
+    init(_ syncCommand: AnyCommand) {
+        self.syncCommand = syncCommand
+    }
+    
+    var help: String {
+        self.syncCommand.help
+    }
+
+    func run(using context: inout CommandContext) async throws {
+        try self.syncCommand.run(using: &context)
+    }
+
+    func outputAutoComplete(using context: inout CommandContext) throws {
+        try self.syncCommand.outputAutoComplete(using: &context)
+    }
+
+    func outputHelp(using context: inout CommandContext) throws {
+        try self.syncCommand.outputHelp(using: &context)
+    }
+
+    func renderCompletionFunctions(using context: CommandContext, shell: Shell) -> String {
+        self.syncCommand.renderCompletionFunctions(using: context, shell: shell)
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension Application {
+
+    /// A provider for an async counterpart to ``Application``'s existing ``Commands``.
+    public struct AsyncCommands {
+        
+        // MARK: - Provider boilerplate
+        final class Storage {
+            var asyncCommands = ConsoleKit.AsyncCommands()
+        }
+
+        struct Key: StorageKey { typealias Value = Storage }
+        
+        let application: Application
+        
+        var storage: Storage { self.application.storage[Key.self, default: .init()] }
+        
+        // MARK: - API access for ``ConsoleKit/AsyncCommands``
+
+        /// Direct access to the underlying ``ConsoleKit/AsyncCommands`` instance.
+        public var asyncCommands: ConsoleKit.AsyncCommands {
+            get { self.storage.asyncCommands }
+            set { self.storage.asyncCommands = newValue }
+        }
+        
+        /// See ``ConsoleKit/AsyncCommands/commands``.
+        public var commands: [String: ConsoleKit.AnyAsyncCommand] {
+            get { self.storage.asyncCommands.commands }
+            set { self.storage.asyncCommands.commands = newValue }
+        }
+        
+        /// See ``ConsoleKit/AsyncCommands/enableAutocomplete``.
+        public var enableAutocomplete: Bool {
+            get { self.storage.asyncCommands.enableAutocomplete }
+            set { self.storage.asyncCommands.enableAutocomplete = newValue }
+        }
+        
+        /// See ``ConsoleKit/AsyncCommands/defaultCommand``.
+        public var defaultCommand: AnyAsyncCommand? {
+            get { self.storage.asyncCommands.defaultCommand }
+            set { self.storage.asyncCommands.defaultCommand = newValue }
+        }
+        
+        /// See ``ConsoleKit/AsyncCommands/use(_:as:isDefault:)``.
+        public mutating func use(_ command: AnyAsyncCommand, as name: String, isDefault: Bool = false) {
+            self.storage.asyncCommands.use(command, as: name, isDefault: isDefault)
+        }
+        
+        /// Allows directly registering ``AnyCommand``s.
+        public mutating func use(_ command: AnyCommand, as name: String, isDefault: Bool = false) {
+            self.use(AnyCommandAsyncAdapter(command), as: name, isDefault: isDefault)
+        }
+        
+        /// See ``ConsoleKit/AsyncCommands/group(help:)``.
+        public func group(help: String = "") -> ConsoleKit.AsyncCommandGroup {
+            self.storage.asyncCommands.group(help: help)
+        }
+        
+        // MARK: - Old/new merge logic
+        
+        /// Register async versions of the given non-async commands. This API is intended
+        /// for use only by ``Application``.
+        ///
+        /// If a non-async command's name is already registered, a fatal error occurs.
+        func merge(oldCommands: [String: AnyCommand]) {
+            let commonKeys = Set(self.commands.keys).intersection(oldCommands.keys)
+            precondition(commonKeys.isEmpty, "The following command names were registered multiple times: \(commonKeys)")
+            
+            self.storage.asyncCommands.commands.merge(oldCommands.mapValues(AnyCommandAsyncAdapter.init(_:))) { a, b in a }
+        }
+    }
+    
+    /// The async version of ``Application/commands``.
+    public var asyncCommands: AsyncCommands {
+        .init(application: self)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Support for `AsyncCommand` goes through a new `asyncCommands` property on `Application`, which supersedes `commands`. Anything added to `commands` - including Vapor's butilin default commands - is automatically included in the `asyncCommands` (assuming the async entry point methods are called).

To correctly boot Vapor from an `async` entry point, call `try await app.run()` instead of `try app.run()`; it's a subtle change, but makes a significant difference.

This is an alternative to #2853 and vapor/console-kit#175; this PR should not be merged if those are, and vice versa.