### PR TITLE
Async Next Steps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -130,14 +130,14 @@ public func routes(_ app: Application) throws {
     let sessions = app.grouped("sessions")
         .grouped(app.sessions.middleware)
     sessions.get("set", ":value") { req -> HTTPStatus in
-        req.session.data["name"] = req.parameters.get("value")
+        await req.asyncSession().data["name"] = req.parameters.get("value")
         return .ok
     }
     sessions.get("get") { req -> String in
-        req.session.data["name"] ?? "n/a"
+        await req.asyncSession().data["name"] ?? "n/a"
     }
     sessions.get("del") { req -> String in
-        req.session.destroy()
+        await req.asyncSession().destroy()
         return "done"
     }
 

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -277,7 +277,7 @@ public func routes(_ app: Application) throws {
     
     let basicAuthRoutes = asyncRoutes.grouped(Test.authenticator(), Test.guardMiddleware())
     basicAuthRoutes.get("auth") { req async throws -> String in
-        return try await req.auth.require(Test.self).name
+        return try await req.auth.asyncRequire(Test.self).name
     }
     
     struct Test: Authenticatable {
@@ -294,7 +294,7 @@ public func routes(_ app: Application) throws {
         func authenticate(basic: BasicAuthorization, for request: Request) async throws {
             if basic.username == "test" && basic.password == "secret" {
                 let test = Test(name: "Vapor")
-                await request.auth.login(test)
+                await request.auth.asyncLogin(test)
             }
         }
     }

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -278,7 +278,7 @@ public func routes(_ app: Application) throws {
         
         let basicAuthRoutes = asyncRoutes.grouped(Test.authenticator(), Test.guardMiddleware())
         basicAuthRoutes.get("auth") { req async throws -> String in
-            return try req.auth.require(Test.self).name
+            return try await req.auth.require(Test.self).name
         }
     }
     
@@ -298,7 +298,7 @@ public func routes(_ app: Application) throws {
         func authenticate(basic: BasicAuthorization, for request: Request) async throws {
             if basic.username == "test" && basic.password == "secret" {
                 let test = Test(name: "Vapor")
-                request.auth.login(test)
+                await request.auth.login(test)
             }
         }
     }

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -130,14 +130,14 @@ public func routes(_ app: Application) throws {
     let sessions = app.grouped("sessions")
         .grouped(app.sessions.middleware)
     sessions.get("set", ":value") { req -> HTTPStatus in
-        await req.asyncSession().data["name"] = req.parameters.get("value")
+        await req.asyncSession.data["name"] = req.parameters.get("value")
         return .ok
     }
     sessions.get("get") { req -> String in
-        await req.asyncSession().data["name"] ?? "n/a"
+        await req.asyncSession.data["name"] ?? "n/a"
     }
     sessions.get("del") { req -> String in
-        await req.asyncSession().destroy()
+        await req.asyncSession.destroy()
         return "done"
     }
 

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -130,7 +130,7 @@ public func routes(_ app: Application) throws {
     let sessions = app.grouped("sessions")
         .grouped(app.sessions.middleware)
     sessions.get("set", ":value") { req -> HTTPStatus in
-        await req.asyncSession.data["name"] = req.parameters.get("value")
+        await req.asyncSession.set("name", to: req.parameters.get("value"))
         return .ok
     }
     sessions.get("get") { req -> String in

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -6,6 +6,7 @@ public final class Application {
     public let eventLoopGroupProvider: EventLoopGroupProvider
     public let eventLoopGroup: EventLoopGroup
     public var asyncStorage: AsyncStorage
+    @available(*, deprecated, message: "To ensure thread safety when using async/await, you should migrate to `asyncStorage`")
     public var storage: Storage
     public private(set) var didShutdown: Bool
     public var logger: Logger

--- a/Sources/Vapor/Authentication/AuthenticationCache.swift
+++ b/Sources/Vapor/Authentication/AuthenticationCache.swift
@@ -16,7 +16,7 @@ extension Request {
 
 extension Request.Authentication {
     /// Authenticates the supplied instance for this request.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to the async API")
+    @available(*, deprecated, message: "To ensure thread safety, use `asyncLogin` instead")
     public func login<A>(_ instance: A)
         where A: Authenticatable
     {
@@ -24,7 +24,7 @@ extension Request.Authentication {
     }
 
     /// Unauthenticates an authenticatable type.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to the async API")
+    @available(*, deprecated, message: "To ensure thread safety, use `asyncLogout` instead")
     public func logout<A>(_ type: A.Type = A.self)
         where A: Authenticatable
     {
@@ -34,7 +34,7 @@ extension Request.Authentication {
     /// Returns an instance of the supplied type. Throws if no
     /// instance of that type has been authenticated or if there
     /// was a problem.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to the async API")
+    @available(*, deprecated, message: "To ensure thread safety, use `asyncRequire` instead")
     @discardableResult public func require<A>(_ type: A.Type = A.self) throws -> A
         where A: Authenticatable
     {
@@ -46,7 +46,7 @@ extension Request.Authentication {
 
     /// Returns the authenticated instance of the supplied type.
     /// - note: `nil` if no type has been authed.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to the async API")
+    @available(*, deprecated, message: "To ensure thread safety, use `asyncGet` instead")
     public func get<A>(_ type: A.Type = A.self) -> A?
         where A: Authenticatable
     {
@@ -54,7 +54,7 @@ extension Request.Authentication {
     }
 
     /// Returns `true` if the type has been authenticated.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to the async API")
+    @available(*, deprecated, message: "To ensure thread safety, use `asyncHas` instead")
     public func has<A>(_ type: A.Type = A.self) -> Bool
         where A: Authenticatable
     {
@@ -62,14 +62,14 @@ extension Request.Authentication {
     }
     
     #if(canImport(_Concurrency))
-    public func login<A>(_ instance: A) async
+    public func asyncLogin<A>(_ instance: A) async
         where A: Authenticatable
     {
         await self.getCache()[A.self] = instance
     }
 
     /// Unauthenticates an authenticatable type.
-    public func logout<A>(_ type: A.Type = A.self) async
+    public func asyncLogout<A>(_ type: A.Type = A.self) async
         where A: Authenticatable
     {
         await self.getCache()[A.self] = nil
@@ -78,10 +78,10 @@ extension Request.Authentication {
     /// Returns an instance of the supplied type. Throws if no
     /// instance of that type has been authenticated or if there
     /// was a problem.
-    @discardableResult public func require<A>(_ type: A.Type = A.self) async throws -> A
+    @discardableResult public func asyncRequire<A>(_ type: A.Type = A.self) async throws -> A
         where A: Authenticatable
     {
-        guard let a = await self.get(A.self) else {
+        guard let a = await self.asyncGet(A.self) else {
             throw Abort(.unauthorized)
         }
         return a
@@ -89,17 +89,17 @@ extension Request.Authentication {
 
     /// Returns the authenticated instance of the supplied type.
     /// - note: `nil` if no type has been authed.
-    public func get<A>(_ type: A.Type = A.self) async -> A?
+    public func asyncGet<A>(_ type: A.Type = A.self) async -> A?
         where A: Authenticatable
     {
         return await self.getCache()[A.self]
     }
 
     /// Returns `true` if the type has been authenticated.
-    public func has<A>(_ type: A.Type = A.self) async -> Bool
+    public func asyncHas<A>(_ type: A.Type = A.self) async -> Bool
         where A: Authenticatable
     {
-        return await self.get(A.self) != nil
+        return await self.asyncGet(A.self) != nil
     }
     #endif
 

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -24,7 +24,7 @@ extension Authenticatable {
 
 
 
-private final class GuardAuthenticationMiddleware<A>: Middleware
+private final class GuardAuthenticationMiddleware<A>: AsyncMiddleware
     where A: Authenticatable
 {
     /// Error to throw when guard fails.
@@ -39,10 +39,10 @@ private final class GuardAuthenticationMiddleware<A>: Middleware
         self.error = error
     }
 
-    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        guard request.auth.has(A.self) else {
-            return request.eventLoop.makeFailedFuture(self.error)
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard await request.auth.has(A.self) else {
+            throw error
         }
-        return next.respond(to: request)
+        return try await next.respond(to: request)
     }
 }

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -40,7 +40,7 @@ private final class GuardAuthenticationMiddleware<A>: AsyncMiddleware
     }
 
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-        guard await request.auth.has(A.self) else {
+        guard await request.auth.asyncHas(A.self) else {
             throw error
         }
         return try await next.respond(to: request)

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -27,7 +27,7 @@ private final class RedirectMiddleware<A>: AsyncMiddleware
     }
     
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-        if await request.auth.has(A.self) {
+        if await request.auth.asyncHas(A.self) {
             return try await next.respond(to: request)
         }
 

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -16,7 +16,7 @@ extension SessionAuthenticator {
                 return try await next.respond(to: request).get()
             }
 
-            if let aID = await request.asyncSession().authenticated(User.self) {
+            if let aID = await request.asyncSession.authenticated(User.self) {
                 // try to find user with id from session
                 try await self.authenticate(sessionID: aID, for: request).get()
             }
@@ -25,11 +25,11 @@ extension SessionAuthenticator {
             let response = try await next.respond(to: request).get()
             if let user = await request.auth.get(User.self) {
                 // if a user has been authed (or is still authed), store in the session
-                await request.asyncSession().authenticate(user)
+                await request.asyncSession.authenticate(user)
             } else if await request.hasAsyncSession {
                 // if no user is authed, it's possible they've been unauthed.
                 // remove from session.
-                await request.asyncSession().unauthenticate(User.self)
+                await request.asyncSession.unauthenticate(User.self)
             }
             return response
         }

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -80,7 +80,7 @@ extension Session {
 }
 
 #if canImport(_Concurrency)
-extension Session {
+extension AsyncSession {
     /// Authenticates the model into the session.
     public func authenticate<A>(_ a: A) async
         where A: SessionAuthenticatable

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -57,6 +57,7 @@ private extension SessionAuthenticatable {
     }
 }
 
+@available(*, deprecated, message: "Migrate to the async session APIs")
 extension Session {
     /// Authenticates the model into the session.
     public func authenticate<A>(_ a: A)
@@ -81,3 +82,30 @@ extension Session {
             .flatMap { A.SessionID.init($0) }
     }
 }
+
+#if canImport(_Concurrency)
+extension Session {
+    /// Authenticates the model into the session.
+    public func authenticate<A>(_ a: A) async
+        where A: SessionAuthenticatable
+    {
+        self.data["_" + A.sessionName + "Session"] = a.sessionID.description
+    }
+
+    /// Un-authenticates the model from the session.
+    public func unauthenticate<A>(_ a: A.Type) async
+        where A: SessionAuthenticatable
+    {
+        self.data["_" + A.sessionName + "Session"] = nil
+    }
+
+    /// Returns the authenticatable type's ID if it exists
+    /// in the session data.
+    public func authenticated<A>(_ a: A.Type) async -> A.SessionID?
+        where A: SessionAuthenticatable
+    {
+        self.data["_" + A.sessionName + "Session"]
+            .flatMap { A.SessionID.init($0) }
+    }
+}
+#endif

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -26,7 +26,7 @@ extension SessionAuthenticator {
             if let user = await request.auth.get(User.self) {
                 // if a user has been authed (or is still authed), store in the session
                 await request.asyncSession().authenticate(user)
-            } else if request.hasSession {
+            } else if await request.hasAsyncSession {
                 // if no user is authed, it's possible they've been unauthed.
                 // remove from session.
                 await request.asyncSession().unauthenticate(User.self)

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -12,7 +12,7 @@ extension SessionAuthenticator {
         promise.completeWithTask {
             // if the user has already been authenticated
             // by a previous middleware, continue
-            if await request.auth.has(User.self) {
+            if await request.auth.asyncHas(User.self) {
                 return try await next.respond(to: request).get()
             }
 
@@ -23,7 +23,7 @@ extension SessionAuthenticator {
 
             // respond to the request
             let response = try await next.respond(to: request).get()
-            if let user = await request.auth.get(User.self) {
+            if let user = await request.auth.asyncGet(User.self) {
                 // if a user has been authed (or is still authed), store in the session
                 await request.asyncSession.authenticate(user)
             } else if await request.hasAsyncSession {

--- a/Sources/Vapor/Concurrency/AnyResponse+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/AnyResponse+Concurrency.swift
@@ -1,4 +1,4 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
 /// A type erased response useful for routes that can return more than one type.
@@ -33,7 +33,6 @@ import NIOCore
 ///         }
 ///     }
 ///
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public struct AnyAsyncResponse: AsyncResponseEncodable {
     /// The wrapped `AsyncResponseEncodable` type.
     private let encodable: AsyncResponseEncodable

--- a/Sources/Vapor/Concurrency/AsyncBasicResponder.swift
+++ b/Sources/Vapor/Concurrency/AsyncBasicResponder.swift
@@ -1,8 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
 /// A basic, async closure-based `Responder`.
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public struct AsyncBasicResponder: AsyncResponder {
     /// The stored responder closure.
     private let closure: (Request) async throws -> Response

--- a/Sources/Vapor/Concurrency/AsyncMiddleware.swift
+++ b/Sources/Vapor/Concurrency/AsyncMiddleware.swift
@@ -1,4 +1,4 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
 /// `AsyncMiddleware` is placed between the server and your router. It is capable of
@@ -7,7 +7,6 @@ import NIOCore
 /// return a custom `Response` if desired.
 ///
 /// This is an async version of `Middleware`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncMiddleware: Middleware {
     /// Called with each `Request` that passes through this middleware.
     /// - parameters:
@@ -17,7 +16,6 @@ public protocol AsyncMiddleware: Middleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncMiddleware {
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         let promise = request.eventLoop.makePromise(of: Response.self)

--- a/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncPasswordHasher {
     public func hash<Password>(_ password: Password) async throws -> [UInt8]
         where Password: DataProtocol

--- a/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
+++ b/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
@@ -1,10 +1,9 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
 /// Capable of managing CRUD operations for `Session`s.
 ///
 /// This is an async version of `SessionDriver`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncSessionDriver: SessionDriver {
     func createSession(_ data: SessionData, for request: Request) async throws -> SessionID
     func readSession(_ sessionID: SessionID, for request: Request) async throws -> SessionData?
@@ -12,7 +11,6 @@ public protocol AsyncSessionDriver: SessionDriver {
     func deleteSession(_ sessionID: SessionID, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncSessionDriver {
     public func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let promise = request.eventLoop.makePromise(of: SessionID.self)

--- a/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
@@ -101,7 +101,7 @@ extension AsyncSessionAuthenticator {
             return try await next.respond(to: request)
         }
 
-        if let aID = await request.asyncSession().authenticated(User.self) {
+        if let aID = await request.asyncSession.authenticated(User.self) {
             // try to find user with id from session
             try await self.authenticate(sessionID: aID, for: request)
         }
@@ -110,11 +110,11 @@ extension AsyncSessionAuthenticator {
         let response = try await next.respond(to: request)
         if let user = await request.auth.get(User.self) {
             // if a user has been authed (or is still authed), store in the session
-            await request.asyncSession().authenticate(user)
+            await request.asyncSession.authenticate(user)
         } else if await request.hasAsyncSession {
             // if no user is authed, it's possible they've been unauthed.
             // remove from session.
-            await request.asyncSession().unauthenticate(User.self)
+            await request.asyncSession.unauthenticate(User.self)
         }
         return response
     }

--- a/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
@@ -97,7 +97,7 @@ extension AsyncSessionAuthenticator {
     public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         // if the user has already been authenticated
         // by a previous middleware, continue
-        if await request.auth.has(User.self) {
+        if await request.auth.asyncHas(User.self) {
             return try await next.respond(to: request)
         }
 
@@ -108,7 +108,7 @@ extension AsyncSessionAuthenticator {
         
         // respond to the request
         let response = try await next.respond(to: request)
-        if let user = await request.auth.get(User.self) {
+        if let user = await request.auth.asyncGet(User.self) {
             // if a user has been authed (or is still authed), store in the session
             await request.asyncSession.authenticate(user)
         } else if await request.hasAsyncSession {

--- a/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
@@ -101,7 +101,7 @@ extension AsyncSessionAuthenticator {
             return try await next.respond(to: request)
         }
 
-        if let aID = await request.session.authenticated(User.self) {
+        if let aID = await request.asyncSession().authenticated(User.self) {
             // try to find user with id from session
             try await self.authenticate(sessionID: aID, for: request)
         }
@@ -110,11 +110,11 @@ extension AsyncSessionAuthenticator {
         let response = try await next.respond(to: request)
         if let user = await request.auth.get(User.self) {
             // if a user has been authed (or is still authed), store in the session
-            await request.session.authenticate(user)
-        } else if request.hasSession {
+            await request.asyncSession().authenticate(user)
+        } else if await request.hasAsyncSession {
             // if no user is authed, it's possible they've been unauthed.
             // remove from session.
-            await request.session.unauthenticate(User.self)
+            await request.asyncSession().unauthenticate(User.self)
         }
         return response
     }

--- a/Sources/Vapor/Concurrency/Cache+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Cache+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension Cache {
 
     /// Gets a decodable value from the cache. Returns `nil` if not found.

--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Client {
     public func get(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) async throws -> ClientResponse {
         return try await self.send(.GET, headers: headers, to: url, beforeSend: beforeSend).get()

--- a/Sources/Vapor/Concurrency/FileIO+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/FileIO+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension FileIO {
     /// Reads the contents of a file at the supplied path.
     ///

--- a/Sources/Vapor/Concurrency/Responder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Responder+Concurrency.swift
@@ -1,12 +1,10 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncResponder: Responder {
     func respond(to request: Request) async throws -> Response
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncResponder {
     public func respond(to request: Request) -> EventLoopFuture<Response> {
         let promise = request.eventLoop.makePromise(of: Response.self)

--- a/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
@@ -1,5 +1,7 @@
 import NIOCore
 
+#if canImport(_Concurrency)
+
 /// Can convert `self` to a `Response`.
 ///
 /// Types that conform to this protocol can be returned in route closures.
@@ -11,10 +13,7 @@ public protocol AsyncResponseEncodable {
     /// - parameters:
     ///     - for: The `HTTPRequest` associated with this `HTTPResponse`.
     /// - returns: An `HTTPResponse`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     func encodeResponse(for request: Request) async throws -> Response
-    #endif
 }
 
 /// Can convert `Request` to a `Self`.
@@ -28,24 +27,16 @@ public protocol AsyncRequestDecodable {
     /// - parameters:
     ///     - request: The `HTTPRequest` to be decoded.
     /// - returns: An asynchronous `Self`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     static func decodeRequest(_ request: Request) async throws -> Self
-    #endif
 }
 
 extension Request: AsyncRequestDecodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public static func decodeRequest(_ request: Request) async throws -> Request {
         return request
     }
-    #endif
 }
 
 // MARK: Convenience
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncResponseEncodable {
     /// Asynchronously encodes `Self` into a `Response`, setting the supplied status and headers.
     ///
@@ -69,44 +60,32 @@ extension AsyncResponseEncodable {
         return response
     }
 }
-#endif
 
 // MARK: Default Conformances
 
 extension Response: AsyncResponseEncodable {
     // See `AsyncResponseCodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return self
     }
-    #endif
 }
 
 extension StaticString: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(staticString: self))
         return res
     }
-    #endif
 }
 
 extension String: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(string: self))
         return res
     }
-    #endif
 }
 
-#if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Content {
     public func encodeResponse(for request: Request) async throws -> Response {
         let response = Response()
@@ -119,11 +98,8 @@ extension Content {
         return content
     }
 }
-#endif
 
 extension ClientResponse: AsyncResponseEncodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let body: Response.Body
         if let buffer = self.body {
@@ -138,14 +114,13 @@ extension ClientResponse: AsyncResponseEncodable {
         )
         return response
     }
-    #endif
 }
 
 extension HTTPStatus: AsyncResponseEncodable {
-    #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return Response(status: self)
     }
-    #endif
+    
 }
+
+#endif

--- a/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension RoutesBuilder {
     @discardableResult
     public func get<Response>(

--- a/Sources/Vapor/Concurrency/ViewRenderer+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ViewRenderer+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension ViewRenderer {
     func render<E>(_ name: String, _ context: E) async throws -> View where E: Encodable {
         try await self.render(name, context).get()
@@ -12,7 +11,6 @@ public extension ViewRenderer {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension View: AsyncResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
         let response = Response()

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension Request {
 
     /// Upgrades an existing request to a websocket connection
@@ -28,7 +27,6 @@ extension Request {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension RoutesBuilder {
 
     /// Adds a route for opening a web socket connection
@@ -72,7 +70,6 @@ extension RoutesBuilder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension WebSocket {
     public static func connect(
         to url: String,

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -181,8 +181,12 @@ public final class Request: CustomStringConvertible {
     /// Use this container to grab any non-static parameters from the URL, such as model IDs in a REST API.
     public var parameters: Parameters
 
-    /// This container is used as arbitrary request-local storage during the request-response lifecycle.Z
+    /// This container is used as arbitrary request-local storage during the request-response lifecycle.
+    @available(*, deprecated, message: "To ensure thread safety when using async/await, you should migrate to `asyncStorage`")
     public var storage: Storage
+    
+    /// This container is used as arbitrary request-local therad safe storage during the request-response lifecycle.
+    public var asyncStorage: AsyncStorage
 
     public var byteBufferAllocator: ByteBufferAllocator
     
@@ -241,6 +245,7 @@ public final class Request: CustomStringConvertible {
         self.eventLoop = eventLoop
         self.parameters = .init()
         self.storage = .init()
+        self.asyncStorage = .init()
         self.isKeepAlive = true
         self.logger = logger
         self.logger[metadataKey: "request-id"] = .string(UUID().uuidString)

--- a/Sources/Vapor/Sessions/AsyncSessionCache.swift
+++ b/Sources/Vapor/Sessions/AsyncSessionCache.swift
@@ -1,0 +1,14 @@
+/// Singleton service cache for an `AsyncSession`. Used with a message's private container.
+internal final class AsyncSessionCache {
+    /// Set to `true` when passing through middleware.
+    var middlewareFlag: Bool
+
+    /// The cached session.
+    var session: AsyncSession?
+
+    /// Creates a new `SessionCache`.
+    init(session: AsyncSession? = nil) {
+        self.session = session
+        self.middlewareFlag = false
+    }
+}

--- a/Sources/Vapor/Sessions/AsyncSessions.swift
+++ b/Sources/Vapor/Sessions/AsyncSessions.swift
@@ -29,4 +29,8 @@ public final actor AsyncSession {
     public func destroy() {
         self.isValid = false
     }
+    
+    public func set(_ key: String, to value: String?) {
+        self.data[key] = value
+    }
 }

--- a/Sources/Vapor/Sessions/AsyncSessions.swift
+++ b/Sources/Vapor/Sessions/AsyncSessions.swift
@@ -7,7 +7,7 @@
 /// This is the version of ``Session`` for use with `async`/`await`
 public final actor AsyncSession {
     /// This session's unique identifier. Usually a cookie value.
-    public var id: SessionID?
+    public let id: SessionID?
 
     /// This session's data.
     public var data: SessionData
@@ -17,7 +17,7 @@ public final actor AsyncSession {
 
     /// Create a new `Session`.
     ///
-    /// Normally you will use `Request.session()` to do this.
+    /// Normally you will use ``Request.asyncSession`` to do this.
     public init(id: SessionID? = nil, data: SessionData = .init()) {
         self.id = id
         self.data = data
@@ -30,6 +30,11 @@ public final actor AsyncSession {
         self.isValid = false
     }
     
+    
+    /// Set the underlying session data in a safe way
+    /// - Parameters:
+    ///   - key: The key for that piece of session data
+    ///   - value: The value of the session data
     public func set(_ key: String, to value: String?) {
         self.data[key] = value
     }

--- a/Sources/Vapor/Sessions/AsyncSessions.swift
+++ b/Sources/Vapor/Sessions/AsyncSessions.swift
@@ -1,0 +1,32 @@
+/// Sessions are a method for associating data with a client accessing your app.
+///
+/// Each session has a unique identifier that is used to look it up with each request
+/// to your app. This is usually done via HTTP cookies.
+///
+/// See ``Request.asyncSession`` and ``SessionsMiddleware`` for more information.
+/// This is the version of ``Session`` for use with `async`/`await`
+public final actor AsyncSession {
+    /// This session's unique identifier. Usually a cookie value.
+    public var id: SessionID?
+
+    /// This session's data.
+    public var data: SessionData
+
+    /// `true` if this session is still valid.
+    var isValid: Bool
+
+    /// Create a new `Session`.
+    ///
+    /// Normally you will use `Request.session()` to do this.
+    public init(id: SessionID? = nil, data: SessionData = .init()) {
+        self.id = id
+        self.data = data
+        self.isValid = true
+    }
+
+    /// Invalidates the current session, removing persisted data from the session driver
+    /// and invalidating the cookie.
+    public func destroy() {
+        self.isValid = false
+    }
+}

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -26,8 +26,7 @@ extension Request {
         }
     }
     
-    #warning("Introduce AsyncSession as a thread safe actor")
-    public var asyncSession: Session {
+    public var asyncSession: AsyncSession {
         get async {
             if await !self._asyncSessionCache.middlewareFlag {
                 // No `SessionsMiddleware` was detected on your app.
@@ -39,7 +38,7 @@ extension Request {
             if let existing = await self._asyncSessionCache.session {
                 return existing
             } else {
-                let new = Session()
+                let new = AsyncSession()
                 await self._asyncSessionCache.session = new
                 return new
             }
@@ -62,6 +61,10 @@ extension Request {
         typealias Value = SessionCache
     }
     
+    private struct AsyncSessionCacheKey: StorageKey {
+        typealias Value = AsyncSessionCache
+    }
+    
     internal var _legacySessionCache: SessionCache {
         if let existing = self.storage[SessionCacheKey.self] {
             return existing
@@ -72,13 +75,13 @@ extension Request {
         }
     }
     
-    internal var _asyncSessionCache: SessionCache {
+    internal var _asyncSessionCache: AsyncSessionCache {
         get async {
-            if let existing = await self.asyncStorage.get(SessionCacheKey.self) {
+            if let existing = await self.asyncStorage.get(AsyncSessionCacheKey.self) {
                 return existing
             } else {
-                let new = SessionCache()
-                await self.asyncStorage.set(SessionCacheKey.self, to: new)
+                let new = AsyncSessionCache()
+                await self.asyncStorage.set(AsyncSessionCacheKey.self, to: new)
                 return new
             }
         }

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -26,6 +26,7 @@ extension Request {
         }
     }
     
+    #warning("Just make session an actor?")
     public func asyncSession() async -> Session {
         if !self._sessionCache.middlewareFlag {
             // No `SessionsMiddleware` was detected on your app.

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -8,7 +8,7 @@ extension Request {
     ///
     /// - note: `SessionsMiddleware` must be added and enabled.
     /// - returns: `Session` for this `Request`.
-    @available(*, deprecated, message: "To ensure thread safety, migrate to `asyncSession()`")
+    @available(*, deprecated, message: "To ensure thread safety, migrate to `asyncSession`")
     public var session: Session {
         if !self._legacySessionCache.middlewareFlag {
             // No `SessionsMiddleware` was detected on your app.
@@ -27,20 +27,22 @@ extension Request {
     }
     
     #warning("Introduce AsyncSession as a thread safe actor")
-    public func asyncSession() async -> Session {
-        if await !self._asyncSessionCache.middlewareFlag {
-            // No `SessionsMiddleware` was detected on your app.
-            // Suggested solutions:
-            // - Add the `SessionsMiddleware` globally to your app using `app.middleware.use`
-            // - Add the `SessionsMiddleware` to a route group.
-            assertionFailure("No `SessionsMiddleware` detected.")
-        }
-        if let existing = await self._asyncSessionCache.session {
-            return existing
-        } else {
-            let new = Session()
-            await self._asyncSessionCache.session = new
-            return new
+    public var asyncSession: Session {
+        get async {
+            if await !self._asyncSessionCache.middlewareFlag {
+                // No `SessionsMiddleware` was detected on your app.
+                // Suggested solutions:
+                // - Add the `SessionsMiddleware` globally to your app using `app.middleware.use`
+                // - Add the `SessionsMiddleware` to a route group.
+                assertionFailure("No `SessionsMiddleware` detected.")
+            }
+            if let existing = await self._asyncSessionCache.session {
+                return existing
+            } else {
+                let new = Session()
+                await self._asyncSessionCache.session = new
+                return new
+            }
         }
     }
     

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -8,7 +8,25 @@ extension Request {
     ///
     /// - note: `SessionsMiddleware` must be added and enabled.
     /// - returns: `Session` for this `Request`.
+    @available(*, deprecated, message: "To ensure thread safety, migrate to `asyncSession()`")
     public var session: Session {
+        if !self._sessionCache.middlewareFlag {
+            // No `SessionsMiddleware` was detected on your app.
+            // Suggested solutions:
+            // - Add the `SessionsMiddleware` globally to your app using `app.middleware.use`
+            // - Add the `SessionsMiddleware` to a route group.
+            assertionFailure("No `SessionsMiddleware` detected.")
+        }
+        if let existing = self._sessionCache.session {
+            return existing
+        } else {
+            let new = Session()
+            self._sessionCache.session = new
+            return new
+        }
+    }
+    
+    public func asyncSession() async -> Session {
         if !self._sessionCache.middlewareFlag {
             // No `SessionsMiddleware` was detected on your app.
             // Suggested solutions:
@@ -39,6 +57,16 @@ extension Request {
         } else {
             let new = SessionCache()
             self.storage[SessionCacheKey.self] = new
+            return new
+        }
+    }
+    
+    internal func getSessionCache() async -> SessionCache {
+        if let existing = await self.asyncStorage.get(SessionCacheKey.self) {
+            return existing
+        } else {
+            let new = SessionCache()
+            await self.asyncStorage.set(SessionCacheKey.self, to: new)
             return new
         }
     }

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -26,7 +26,7 @@ extension Request {
         }
     }
     
-    #warning("Just make session an actor?")
+    #warning("Introduce AsyncSession as a thread safe actor")
     public func asyncSession() async -> Session {
         if !self._sessionCache.middlewareFlag {
             // No `SessionsMiddleware` was detected on your app.

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -28,18 +28,18 @@ extension Request {
     
     #warning("Introduce AsyncSession as a thread safe actor")
     public func asyncSession() async -> Session {
-        if !self._sessionCache.middlewareFlag {
+        if await !self._asyncSessionCache.middlewareFlag {
             // No `SessionsMiddleware` was detected on your app.
             // Suggested solutions:
             // - Add the `SessionsMiddleware` globally to your app using `app.middleware.use`
             // - Add the `SessionsMiddleware` to a route group.
             assertionFailure("No `SessionsMiddleware` detected.")
         }
-        if let existing = self._sessionCache.session {
+        if let existing = await self._asyncSessionCache.session {
             return existing
         } else {
             let new = Session()
-            self._sessionCache.session = new
+            await self._asyncSessionCache.session = new
             return new
         }
     }
@@ -62,13 +62,15 @@ extension Request {
         }
     }
     
-    internal func getSessionCache() async -> SessionCache {
-        if let existing = await self.asyncStorage.get(SessionCacheKey.self) {
-            return existing
-        } else {
-            let new = SessionCache()
-            await self.asyncStorage.set(SessionCacheKey.self, to: new)
-            return new
+    internal var _asyncSessionCache: SessionCache {
+        get async {
+            if let existing = await self.asyncStorage.get(SessionCacheKey.self) {
+                return existing
+            } else {
+                let new = SessionCache()
+                await self.asyncStorage.set(SessionCacheKey.self, to: new)
+                return new
+            }
         }
     }
 }

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -81,7 +81,7 @@ public final class SessionsMiddleware: AsyncMiddleware {
         // A session exists or has been created. we must
         // set a cookie value on the response
         let newID: SessionID
-        if let id = await session.id {
+        if let id = session.id {
             // A cookie exists, just update this session.
             newID = try await self.session.updateSession(id, to: session.data, for: request).get()
         } else {

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -67,9 +67,6 @@ public final class SessionsMiddleware: AsyncMiddleware {
                 }
             }
             try await createOrUpdateSessionCookie(session: session, for: request, to: response)
-        } else if let session = request._legacySessionCache.session, session.isValid {
-            // Test old session
-            try await createOrUpdateSessionCookie(session: session, for: request, to: response)
         } else if let cookieValue = request.cookies[self.configuration.cookieName] {
             // The request had a session cookie, but now there is no valid session.
             // we need to perform cleanup.

--- a/Sources/Vapor/Utilities/AsyncStorage.swift
+++ b/Sources/Vapor/Utilities/AsyncStorage.swift
@@ -1,0 +1,113 @@
+#if canImport(_Concurrency)
+
+/// A container providing arbitrary storage for extensions of an existing type, designed to obviate
+/// the problem of being unable to add stored properties to a type in an extension. Each stored item
+/// is keyed by a type conforming to ``StorageKey`` protocol.
+public actor AsyncStorage {
+    /// The internal storage area.
+    var storage: [ObjectIdentifier: AnyAsyncStorageValue]
+
+    /// A container for a stored value and an associated optional `deinit`-like closure.
+    struct Value<T>: AnyAsyncStorageValue {
+        var value: T
+        var onShutdown: ((T) async throws -> ())?
+        func shutdown(logger: Logger) async {
+            do {
+                try await self.onShutdown?(self.value)
+            } catch {
+                logger.warning("Could not shutdown \(T.self): \(error)")
+            }
+        }
+    }
+    
+    /// The logger provided to shutdown closures.
+    let logger: Logger
+
+    /// Create a new ``Storage`` container using the given logger.
+    public init(logger: Logger = .init(label: "codes.vapor.storage")) {
+        self.storage = [:]
+        self.logger = logger
+    }
+
+    /// Delete all values from the container. Does _not_ invoke shutdown closures.
+    public func clear() {
+        self.storage = [:]
+    }
+
+//    /// Read/write access to values via keyed subscript.
+//    public subscript<Key>(_ key: Key.Type) async -> Key.Value?
+//        where Key: StorageKey
+//    {
+//        get {
+//            self.get(Key.self)
+//        }
+//        set {
+//            await self.set(Key.self, to: newValue)
+//        }
+//    }
+//
+//    /// Read access to a value via keyed subscript, adding the provided default
+//    /// value to the storage if the key does not already exist. Similar to
+//    /// ``Swift/Dictionary/subscript(key:default:)``. The `defaultValue` autoclosure
+//    /// is evaluated only when the key does not already exist in the container.
+//    public subscript<Key>(_ key: Key.Type, default defaultValue: @autoclosure () -> Key.Value) -> Key.Value
+//        where Key: StorageKey
+//    {
+//        get {
+//            if let existing = self[key] { return existing }
+//            let new = defaultValue()
+//            await self.set(Key.self, to: new)
+//            return new
+//        }
+//    }
+
+    /// Test whether the given key exists in the container.
+    public func contains<Key>(_ key: Key.Type) -> Bool {
+        self.storage.keys.contains(ObjectIdentifier(Key.self))
+    }
+
+    /// Get the value of the given key if it exists and is of the proper type.
+    public func get<Key>(_ key: Key.Type) -> Key.Value?
+        where Key: StorageKey
+    {
+        guard let value = self.storage[ObjectIdentifier(Key.self)] as? Value<Key.Value> else {
+            return nil
+        }
+        return value.value
+    }
+
+    /// Set or remove a value for a given key, optionally providing a shutdown closure for the value.
+    ///
+    /// If a key that has a shutdown closure is removed by this method, the closure **is** invoked.
+    public func set<Key>(
+        _ key: Key.Type,
+        to value: Key.Value?,
+        onShutdown: ((Key.Value) async throws -> ())? = nil
+    ) async
+        where Key: StorageKey
+    {
+        let key = ObjectIdentifier(Key.self)
+        if let value = value {
+            self.storage[key] = Value(value: value, onShutdown: onShutdown)
+        } else if let existing = self.storage[key] {
+            self.storage[key] = nil
+            await existing.shutdown(logger: self.logger)
+        }
+    }
+
+    /// For every key in the container having a shutdown closure, invoke the closure. Designed to
+    /// be invoked during an explicit app shutdown process or in a reference type's `deinit`.
+    public func shutdown() async {
+        for storageValue in self.storage.values {
+            await storageValue.shutdown(logger: self.logger)
+        }
+    }
+}
+
+/// ``Storage`` uses this protocol internally to generically invoke shutdown closures for arbitrarily-
+/// typed key values.
+protocol AnyAsyncStorageValue {
+    func shutdown(logger: Logger) async
+}
+
+#endif

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -1,6 +1,7 @@
 /// A container providing arbitrary storage for extensions of an existing type, designed to obviate
 /// the problem of being unable to add stored properties to a type in an extension. Each stored item
 /// is keyed by a type conforming to ``StorageKey`` protocol.
+@available(*, deprecated, message: "To ensure thread safety when using async/await, you should migrate to `AsyncStorage`")
 public struct Storage {
     /// The internal storage area.
     var storage: [ObjectIdentifier: AnyStorageValue]

--- a/Tests/AsyncTests/AsyncAuthTests.swift
+++ b/Tests/AsyncTests/AsyncAuthTests.swift
@@ -1,7 +1,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncAuthenticationTests: XCTestCase {
     func testBearerAuthenticator() throws {
         struct Test: Authenticatable {
@@ -16,7 +15,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    request.auth.login(test)
+                    await request.auth.login(test)
                 }
             }
         }
@@ -26,8 +25,8 @@ final class AsyncAuthenticationTests: XCTestCase {
 
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
-        ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+        ]).get("test") { req async throws -> String in
+            return try await req.auth.require(Test.self).name
         }
 
         try app.testable().test(.GET, "/test") { res in
@@ -58,7 +57,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    request.auth.login(test)
+                    await request.auth.login(test)
                 }
             }
         }
@@ -68,8 +67,8 @@ final class AsyncAuthenticationTests: XCTestCase {
 
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
-        ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+        ]).get("test") { req async throws -> String in
+            return try await req.auth.require(Test.self).name
         }
 
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -99,7 +98,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret:with:colon" {
                     let test = Test(name: "Vapor")
-                    request.auth.login(test)
+                    await request.auth.login(test)
                 }
             }
         }
@@ -110,7 +109,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            return try await req.auth.require(Test.self).name
         }
 
         let basic = "test:secret:with:colon".data(using: .utf8)!.base64EncodedString()
@@ -137,7 +136,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    request.auth.login(test)
+                    await request.auth.login(test)
                 }
             }
         }
@@ -152,7 +151,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), redirectMiddleware
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            return try await req.auth.require(Test.self).name
         }
 
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -185,7 +184,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    request.auth.login(test)
+                    await request.auth.login(test)
                 }
             }
         }
@@ -195,7 +194,7 @@ final class AsyncAuthenticationTests: XCTestCase {
 
             func authenticate(sessionID: String, for request: Request) async throws {
                 let test = Test(name: sessionID)
-                request.auth.login(test)
+                await request.auth.login(test)
             }
         }
 
@@ -208,7 +207,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             Test.bearerAuthenticator(),
             Test.guardMiddleware(),
         ]).get("test") { req -> String in
-            try req.auth.require(Test.self).name
+            try await req.auth.require(Test.self).name
         }
 
         var sessionCookie: HTTPCookies.Value?

--- a/Tests/AsyncTests/AsyncAuthTests.swift
+++ b/Tests/AsyncTests/AsyncAuthTests.swift
@@ -15,7 +15,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -26,7 +26,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req async throws -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
 
         try app.testable().test(.GET, "/test") { res in
@@ -57,7 +57,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -68,7 +68,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req async throws -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
 
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -98,7 +98,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret:with:colon" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -109,7 +109,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
 
         let basic = "test:secret:with:colon".data(using: .utf8)!.base64EncodedString()
@@ -136,7 +136,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -151,7 +151,7 @@ final class AsyncAuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), redirectMiddleware
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
 
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -184,7 +184,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -194,7 +194,7 @@ final class AsyncAuthenticationTests: XCTestCase {
 
             func authenticate(sessionID: String, for request: Request) async throws {
                 let test = Test(name: sessionID)
-                await request.auth.login(test)
+                await request.auth.asyncLogin(test)
             }
         }
 
@@ -207,7 +207,7 @@ final class AsyncAuthenticationTests: XCTestCase {
             Test.bearerAuthenticator(),
             Test.guardMiddleware(),
         ]).get("test") { req -> String in
-            try await req.auth.require(Test.self).name
+            try await req.auth.asyncRequire(Test.self).name
         }
 
         var sessionCookie: HTTPCookies.Value?

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncCacheTests: XCTestCase {
     func testInMemoryCache() async throws {
         let app = Application(.testing)

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -1,8 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import Vapor
 import XCTest
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncClientTests: XCTestCase {
     func testClientConfigurationChange() async throws {
         let app = Application(.testing)

--- a/Tests/AsyncTests/AsyncMiddlewareTests.swift
+++ b/Tests/AsyncTests/AsyncMiddlewareTests.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncMiddlewareTests: XCTestCase {
     final class OrderMiddleware: AsyncMiddleware {
         static var order: [String] = []

--- a/Tests/AsyncTests/AsyncPasswordTests.swift
+++ b/Tests/AsyncTests/AsyncPasswordTests.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncPasswordTests: XCTestCase {
     func testAsyncBCryptRequestPassword() throws {
         let test = Environment(name: "testing", arguments: ["vapor"])

--- a/Tests/AsyncTests/AsyncRouteTests.swift
+++ b/Tests/AsyncTests/AsyncRouteTests.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncRouteTests: XCTestCase {
     func testEnumResponse() throws {
         enum IntOrString: AsyncResponseEncodable {

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -38,7 +38,7 @@ final class AsyncSessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            await req.asyncSession.data["foo"] = "bar"
+            await req.asyncSession.set("foo", to: "bar")
             return "set"
         }
         sessions.get("del") { req  -> String in

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -38,11 +38,11 @@ final class AsyncSessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            await req.asyncSession().data["foo"] = "bar"
+            await req.asyncSession.data["foo"] = "bar"
             return "set"
         }
         sessions.get("del") { req  -> String in
-            await req.asyncSession().destroy()
+            await req.asyncSession.destroy()
             return "del"
         }
 

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -1,7 +1,6 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncSessionTests: XCTestCase {
     func testSessionDestroy() throws {
         final class MockKeyedCache: AsyncSessionDriver {
@@ -39,11 +38,11 @@ final class AsyncSessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            req.session.data["foo"] = "bar"
+            await req.asyncSession().data["foo"] = "bar"
             return "set"
         }
         sessions.get("del") { req  -> String in
-            req.session.destroy()
+            await req.asyncSession().destroy()
             return "del"
         }
 

--- a/Tests/AsyncTests/AsyncWebSocketTests.swift
+++ b/Tests/AsyncTests/AsyncWebSocketTests.swift
@@ -1,8 +1,7 @@
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 import XCTVapor
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncWebSocketTests: XCTestCase {
     func testWebSocketClient() async throws {
         let server = Application(.testing)

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -26,7 +26,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            return try await req.auth.require(Test.self).name
         }
 
         try app.testable().test(.GET, "/test") { res in
@@ -69,7 +69,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try req.auth.require(Test.self).name
+            return try await req.auth.require(Test.self).name
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -15,7 +15,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -26,7 +26,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
 
         try app.testable().test(.GET, "/test") { res in
@@ -57,7 +57,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -68,7 +68,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -98,7 +98,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret:with:colon" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -109,7 +109,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
         
         let basic = "test:secret:with:colon".data(using: .utf8)!.base64EncodedString()
@@ -136,7 +136,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -147,7 +147,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), Test.guardMiddleware()
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
         
         let basic = Data("test:".utf8).base64EncodedString()
@@ -174,7 +174,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(basic: BasicAuthorization, for request: Request) async throws {
                 if basic.username == "test" && basic.password == "secret" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -189,7 +189,7 @@ final class AuthenticationTests: XCTestCase {
         app.routes.grouped([
             Test.authenticator(), redirectMiddleware
         ]).get("test") { req -> String in
-            return try await req.auth.require(Test.self).name
+            return try await req.auth.asyncRequire(Test.self).name
         }
         
         let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
@@ -222,7 +222,7 @@ final class AuthenticationTests: XCTestCase {
             func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
                 if bearer.token == "test" {
                     let test = Test(name: "Vapor")
-                    await request.auth.login(test)
+                    await request.auth.asyncLogin(test)
                 }
             }
         }
@@ -232,7 +232,7 @@ final class AuthenticationTests: XCTestCase {
 
             func authenticate(sessionID: String, for request: Request) async throws {
                 let test = Test(name: sessionID)
-                await request.auth.login(test)
+                await request.auth.asyncLogin(test)
             }
         }
         
@@ -245,7 +245,7 @@ final class AuthenticationTests: XCTestCase {
             Test.bearerAuthenticator(),
             Test.guardMiddleware(),
         ]).get("test") { req -> String in
-            try await req.auth.require(Test.self).name
+            try await req.auth.asyncRequire(Test.self).name
         }
 
         var sessionCookie: HTTPCookies.Value?

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -282,7 +282,7 @@ final class RouteTests: XCTestCase {
 
         app.grouped(SessionsMiddleware(session: app.sessions.driver))
             .get("get") { req -> String in
-                await req.asyncSession().data["name"] ?? "n/a"
+                await req.asyncSession.data["name"] ?? "n/a"
             }
 
         var headers = HTTPHeaders()

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -282,7 +282,7 @@ final class RouteTests: XCTestCase {
 
         app.grouped(SessionsMiddleware(session: app.sessions.driver))
             .get("get") { req -> String in
-                return req.session.data["name"] ?? "n/a"
+                await req.asyncSession().data["name"] ?? "n/a"
             }
 
         var headers = HTTPHeaders()

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -37,7 +37,7 @@ final class SessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            await req.asyncSession.data["foo"] = "bar"
+            await req.asyncSession.set("foo", to: "bar")
             return "set"
         }
         sessions.get("del") { req  -> String in
@@ -80,7 +80,7 @@ final class SessionTests: XCTestCase {
 
         // Adds data to the request session.
         app.get("set") { req -> HTTPStatus in
-            await req.asyncSession.data["foo"] = "bar"
+            await req.asyncSession.set("foo", to: "bar")
             return .ok
         }
 

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -37,11 +37,11 @@ final class SessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            req.session.data["foo"] = "bar"
+            await req.asyncSession().data["foo"] = "bar"
             return "set"
         }
         sessions.get("del") { req  -> String in
-            req.session.destroy()
+            await req.asyncSession().destroy()
             return "del"
         }
 
@@ -80,13 +80,13 @@ final class SessionTests: XCTestCase {
 
         // Adds data to the request session.
         app.get("set") { req -> HTTPStatus in
-            req.session.data["foo"] = "bar"
+            await req.asyncSession().data["foo"] = "bar"
             return .ok
         }
 
         // Fetches data from the request session.
         app.get("get") { req -> String in
-            guard let foo = req.session.data["foo"] else {
+            guard let foo = await req.asyncSession().data["foo"] else {
                 throw Abort(.badRequest)
             }
             return foo

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -37,11 +37,11 @@ final class SessionTests: XCTestCase {
         app.sessions.use { _ in cache }
         let sessions = app.routes.grouped(app.sessions.middleware)
         sessions.get("set") { req -> String in
-            await req.asyncSession().data["foo"] = "bar"
+            await req.asyncSession.data["foo"] = "bar"
             return "set"
         }
         sessions.get("del") { req  -> String in
-            await req.asyncSession().destroy()
+            await req.asyncSession.destroy()
             return "del"
         }
 
@@ -80,13 +80,13 @@ final class SessionTests: XCTestCase {
 
         // Adds data to the request session.
         app.get("set") { req -> HTTPStatus in
-            await req.asyncSession().data["foo"] = "bar"
+            await req.asyncSession.data["foo"] = "bar"
             return .ok
         }
 
         // Fetches data from the request session.
         app.get("get") { req -> String in
-            guard let foo = await req.asyncSession().data["foo"] else {
+            guard let foo = await req.asyncSession.data["foo"] else {
                 throw Abort(.badRequest)
             }
             return foo

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -121,6 +121,58 @@ final class SessionTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         })
     }
+    
+    func testInvalidCookieLegacySession() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        // Configure sessions.
+        app.sessions.use(.memory)
+        app.middleware.use(app.sessions.middleware)
+
+        // Adds data to the request session.
+        app.get("set") { req -> HTTPStatus in
+            req.session.data["foo"] = "bar"
+            return .ok
+        }
+
+        // Fetches data from the request session.
+        app.get("get") { req -> String in
+            guard let foo = req.session.data["foo"] else {
+                throw Abort(.badRequest)
+            }
+            return foo
+        }
+
+
+        // Test accessing session with no cookie.
+        try app.test(.GET, "get") { res in
+            XCTAssertEqual(res.status, .badRequest)
+        }
+
+        // Test setting session with invalid cookie.
+        var newCookie: HTTPCookies.Value?
+        try app.test(.GET, "set", beforeRequest: { req in
+            req.headers.cookie = ["vapor-session": "foo"]
+        }, afterResponse: { res in
+            // We should get a new cookie back.
+            newCookie = res.headers.setCookie?["vapor-session"]
+            XCTAssertNotNil(newCookie)
+            // That is not the same as the invalid cookie we sent.
+            XCTAssertNotEqual(newCookie?.string, "foo")
+            XCTAssertEqual(res.status, .ok)
+        })
+
+        // Test accessing newly created session.
+        try app.test(.GET, "get", beforeRequest: { req in
+            // Pass cookie from previous request.
+            req.headers.cookie = ["vapor-session": newCookie!]
+        }, afterResponse: { res in
+            // Session access should be successful.
+            XCTAssertEqual(res.body.string, "bar")
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
 
     func testCookieQuotes() throws {
         var headers = HTTPHeaders()


### PR DESCRIPTION
This PR has a number of aims:

* Allow easier adoption of `Sendable` in Vapor
* Allow user's to back-deploy async/await to older OSes
* Ensure that we're safe in an async/await world.

To achieve this, the PR bumps the minimum supported Swift version to 5.6. This allows us to adopt `Sendable` and backdeploy Concurrency without needing a ton of duplication all over the code base.

This PR also starts deprecating `Storage` to move to an actor based `AsyncStorage` to ensure we can handle reads and writes from multiple concurrent contexts. This is going to be a far-reaching change as almost everything is underpinned by `Storage` so migrating away is going to require some tricks (like semaphores to ensure we can synchronously wait in non-async contexts), shuffling data between legacy storage systems and new storage systems and forcibly nudging users to use the new APIs
