### PR TITLE
Add missing protocol `ExpressibleByStringLiteral` to `HTTPHeaders.Name`

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -1,6 +1,6 @@
 extension HTTPHeaders {
     /// Type used for the name of a HTTP header in the `HTTPHeaders` storage.
-    public struct Name: Codable, Hashable, Equatable, CustomStringConvertible {
+    public struct Name: Codable, Hashable, Equatable, CustomStringConvertible, ExpressibleByStringLiteral {
         /// See `Hashable`
         public func hash(into hasher: inout Hasher) {
             self.lowercased.hash(into: &hasher)


### PR DESCRIPTION
Add missing protocol `ExpressibleByStringLiteral` to `HTTPHeaders.Name`. The implementation `init(stringLiteral:)` was there, but the actual protocol was missing.