### PR TITLE
Update comment in DebuggableError.swift

### DIFF
--- a/Sources/Vapor/Error/DebuggableError.swift
+++ b/Sources/Vapor/Error/DebuggableError.swift
@@ -56,7 +56,7 @@ public protocol DebuggableError: LocalizedError, CustomDebugStringConvertible, C
     var gitHubIssues: [String] { get }
 
     /// Which log level this error should report as. 
-    /// Defaults to `.error`.
+    /// Defaults to `.warning`.
     var logLevel: Logger.Level { get }
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Fix incorrect comment. Now default logLevel is `.warning`( changed in #2598  )
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
