### PR TITLE
Fixing issue #2755: using a reference type config

### DIFF
--- a/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
+++ b/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
@@ -35,9 +35,10 @@ extension Application.HTTP {
 
         public var configuration: HTTPServer.Configuration {
             get {
-                self.application.storage[ConfigurationKey.self] ?? .init(
-                    logger: self.application.logger
-                )
+                if self.application.storage[ConfigurationKey.self] == nil {
+                    self.application.storage[ConfigurationKey.self] = .init(logger: self.application.logger)
+                }
+                return self.application.storage[ConfigurationKey.self].unsafelyUnwrapped
             }
             nonmutating set {
                 if self.application.storage.contains(Key.self) {


### PR DESCRIPTION
If we change HTTPServer.Configuration to be a reference type rather than a value type we can then pass this reference into HTTPServer from the server extension service and then any changes done inside HTTPServer are automatically reflected on the storage in the server extension service.

There are no changes in terms of usage, though now if you pass `--hostname host` when serving your app `app.http.server.config` will reflect that change (whereas before it was keeping the default value of `127.0.0.1`)

Resolves #2755  