### PR TITLE
Fixing issue #2755: updating config storage inside HTTPServer

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -232,8 +232,23 @@ public final class HTTPServer: Server {
         return connection.channel.closeFuture
     }
 
+    public var configuration: Configuration {
+        get { _configuration }
+        set {
+            guard !didStart else {
+                _configuration.logger.warning("Cannot modify server configuration after server has been started.")
+                return
+            }
+            _configuration = newValue
+        }
+    }
+
     private let responder: Responder
-    private var configuration: Configuration
+    private var _configuration: Configuration {
+        willSet {
+            self.application.storage[Application.HTTP.Server.ConfigurationKey.self] = newValue
+        }
+    }
     private let eventLoopGroup: EventLoopGroup
     
     private var connection: HTTPServerConnection?
@@ -250,7 +265,7 @@ public final class HTTPServer: Server {
     ) {
         self.application = application
         self.responder = responder
-        self.configuration = configuration
+        self._configuration = configuration
         self.eventLoopGroup = eventLoopGroup
         self.didStart = false
         self.didShutdown = false


### PR DESCRIPTION
We can update application.storage from within HTTPServer, this way we can keep any changes that happen to the configuration internally up-to-date with the application storage.

This possibly has the least changes and less surface of potential flaws, since we are only adding an extra param and working on top of it. However, now we are setting the application storage from within `HTTPServer`, there is no issue with that, is just that now we have 2 places changing the storage for the config.

Resolves #2755 