### PR TITLE
Reducing minimum target for Concurrency related code

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -232,7 +232,7 @@ public func routes(_ app: Application) throws {
     }
 
     #if compiler(>=5.5) && canImport(_Concurrency)
-    if #available(macOS 12, *) {
+    if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
         let asyncRoutes = app.grouped("async").grouped(TestAsyncMiddleware(number: 1))
         asyncRoutes.get("client") { req async throws -> String in
             let response = try await req.client.get("https://www.google.com")
@@ -282,7 +282,7 @@ public func routes(_ app: Application) throws {
         }
     }
     
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     struct Test: Authenticatable {
         static func authenticator() -> AsyncAuthenticator {
             TestAuthenticator()
@@ -291,7 +291,7 @@ public func routes(_ app: Application) throws {
         var name: String
     }
 
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     struct TestAuthenticator: AsyncBasicAuthenticator {
         typealias User = Test
 
@@ -337,7 +337,7 @@ struct TestError: AbortError, DebuggableError {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct TestAsyncMiddleware: AsyncMiddleware {
     let number: Int
     

--- a/Sources/Vapor/Concurrency/AnyResponse+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/AnyResponse+Concurrency.swift
@@ -33,7 +33,7 @@ import NIOCore
 ///         }
 ///     }
 ///
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct AnyAsyncResponse: AsyncResponseEncodable {
     /// The wrapped `AsyncResponseEncodable` type.
     private let encodable: AsyncResponseEncodable

--- a/Sources/Vapor/Concurrency/AsyncBasicResponder.swift
+++ b/Sources/Vapor/Concurrency/AsyncBasicResponder.swift
@@ -2,7 +2,7 @@
 import NIOCore
 
 /// A basic, async closure-based `Responder`.
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct AsyncBasicResponder: AsyncResponder {
     /// The stored responder closure.
     private let closure: (Request) async throws -> Response

--- a/Sources/Vapor/Concurrency/AsyncMiddleware.swift
+++ b/Sources/Vapor/Concurrency/AsyncMiddleware.swift
@@ -7,7 +7,7 @@ import NIOCore
 /// return a custom `Response` if desired.
 ///
 /// This is an async version of `Middleware`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncMiddleware: Middleware {
     /// Called with each `Request` that passes through this middleware.
     /// - parameters:
@@ -17,7 +17,7 @@ public protocol AsyncMiddleware: Middleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncMiddleware {
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         let promise = request.eventLoop.makePromise(of: Response.self)

--- a/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncPasswordHasher {
     public func hash<Password>(_ password: Password) async throws -> [UInt8]
         where Password: DataProtocol

--- a/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
+++ b/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
@@ -4,7 +4,7 @@ import NIOCore
 /// Capable of managing CRUD operations for `Session`s.
 ///
 /// This is an async version of `SessionDriver`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncSessionDriver: SessionDriver {
     func createSession(_ data: SessionData, for request: Request) async throws -> SessionID
     func readSession(_ sessionID: SessionID, for request: Request) async throws -> SessionData?
@@ -12,7 +12,7 @@ public protocol AsyncSessionDriver: SessionDriver {
     func deleteSession(_ sessionID: SessionID, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSessionDriver {
     public func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let promise = request.eventLoop.makePromise(of: SessionID.self)

--- a/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Authentication+Concurrency.swift
@@ -6,7 +6,7 @@ import NIOCore
 /// See `AsyncRequestAuthenticator` and `AsyncSessionAuthenticator` for more information.
 ///
 /// This is an async version of `Authenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncAuthenticator: AsyncMiddleware { }
 
 /// Help for creating authentication middleware based on `Request`.
@@ -15,12 +15,12 @@ public protocol AsyncAuthenticator: AsyncMiddleware { }
 /// If valid authentication credentials are present, the authenticated user is added to `req.auth`.
 ///
 /// This is an async version of `RequestAuthenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncRequestAuthenticator: AsyncAuthenticator {
     func authenticate(request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncRequestAuthenticator {
     public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         try await self.authenticate(request: request)
@@ -33,12 +33,12 @@ extension AsyncRequestAuthenticator {
 /// Helper for creating authentication middleware using the Basic authorization header.
 ///
 /// This is an async version of `BasicAuthenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncBasicAuthenticator: AsyncRequestAuthenticator {
     func authenticate(basic: BasicAuthorization, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncBasicAuthenticator {
     public func authenticate(request: Request) async throws {
         guard let basicAuthorization = request.headers.basicAuthorization else {
@@ -53,12 +53,12 @@ extension AsyncBasicAuthenticator {
 /// Helper for creating authentication middleware using the Bearer authorization header.
 ///
 /// This is an async version of `BearerAuthenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncBearerAuthenticator: AsyncRequestAuthenticator {
     func authenticate(bearer: BearerAuthorization, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncBearerAuthenticator {
     public func authenticate(request: Request) async throws {
         guard let bearerAuthorization = request.headers.bearerAuthorization else {
@@ -73,13 +73,13 @@ extension AsyncBearerAuthenticator {
 /// Helper for creating authentication middleware using request body contents.
 ///
 /// This is an async version of `CredentialsAuthenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncCredentialsAuthenticator: AsyncRequestAuthenticator {
     associatedtype Credentials: Content
     func authenticate(credentials: Credentials, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncCredentialsAuthenticator {
     public func authenticate(request: Request) async throws {
         let credentials: Credentials
@@ -95,7 +95,7 @@ extension AsyncCredentialsAuthenticator {
 /// Helper for creating authentication middleware in conjunction with `SessionsMiddleware`.
 ///
 /// This is an async version of `SessionAuthenticator`
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncSessionAuthenticator: AsyncAuthenticator {
     associatedtype User: SessionAuthenticatable
 
@@ -103,7 +103,7 @@ public protocol AsyncSessionAuthenticator: AsyncAuthenticator {
     func authenticate(sessionID: User.SessionID, for request: Request) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncSessionAuthenticator {
     public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         // if the user has already been authenticated

--- a/Sources/Vapor/Concurrency/Cache+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Cache+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension Cache {
 
     /// Gets a decodable value from the cache. Returns `nil` if not found.

--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Client {
     public func get(_ url: URI, headers: HTTPHeaders = [:], beforeSend: (inout ClientRequest) throws -> () = { _ in }) async throws -> ClientResponse {
         return try await self.send(.GET, headers: headers, to: url, beforeSend: beforeSend).get()

--- a/Sources/Vapor/Concurrency/FileIO+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/FileIO+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension FileIO {
     /// Reads the contents of a file at the supplied path.
     ///

--- a/Sources/Vapor/Concurrency/Responder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Responder+Concurrency.swift
@@ -1,12 +1,12 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncResponder: Responder {
     func respond(to request: Request) async throws -> Response
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncResponder {
     public func respond(to request: Request) -> EventLoopFuture<Response> {
         let promise = request.eventLoop.makePromise(of: Response.self)

--- a/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
@@ -12,7 +12,7 @@ public protocol AsyncResponseEncodable {
     ///     - for: The `HTTPRequest` associated with this `HTTPResponse`.
     /// - returns: An `HTTPResponse`.
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func encodeResponse(for request: Request) async throws -> Response
     #endif
 }
@@ -29,14 +29,14 @@ public protocol AsyncRequestDecodable {
     ///     - request: The `HTTPRequest` to be decoded.
     /// - returns: An asynchronous `Self`.
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     static func decodeRequest(_ request: Request) async throws -> Self
     #endif
 }
 
 extension Request: AsyncRequestDecodable {
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public static func decodeRequest(_ request: Request) async throws -> Request {
         return request
     }
@@ -45,7 +45,7 @@ extension Request: AsyncRequestDecodable {
 
 // MARK: Convenience
 #if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncResponseEncodable {
     /// Asynchronously encodes `Self` into a `Response`, setting the supplied status and headers.
     ///
@@ -76,7 +76,7 @@ extension AsyncResponseEncodable {
 extension Response: AsyncResponseEncodable {
     // See `AsyncResponseCodable`.
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return self
     }
@@ -86,7 +86,7 @@ extension Response: AsyncResponseEncodable {
 extension StaticString: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(staticString: self))
         return res
@@ -97,7 +97,7 @@ extension StaticString: AsyncResponseEncodable {
 extension String: AsyncResponseEncodable {
     // See `AsyncResponseEncodable`.
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(headers: staticStringHeaders, body: .init(string: self))
         return res
@@ -106,7 +106,7 @@ extension String: AsyncResponseEncodable {
 }
 
 #if compiler(>=5.5) && canImport(_Concurrency)
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Content {
     public func encodeResponse(for request: Request) async throws -> Response {
         let response = Response()
@@ -123,7 +123,7 @@ extension Content {
 
 extension ClientResponse: AsyncResponseEncodable {
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         let body: Response.Body
         if let buffer = self.body {
@@ -143,7 +143,7 @@ extension ClientResponse: AsyncResponseEncodable {
 
 extension HTTPStatus: AsyncResponseEncodable {
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func encodeResponse(for request: Request) async throws -> Response {
         return Response(status: self)
     }

--- a/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RoutesBuilder {
     @discardableResult
     public func get<Response>(

--- a/Sources/Vapor/Concurrency/ViewRenderer+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ViewRenderer+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public extension ViewRenderer {
     func render<E>(_ name: String, _ context: E) async throws -> View where E: Encodable {
         try await self.render(name, context).get()
@@ -12,7 +12,7 @@ public extension ViewRenderer {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension View: AsyncResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
         let response = Response()

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Request {
 
     /// Upgrades an existing request to a websocket connection
@@ -28,7 +28,7 @@ extension Request {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RoutesBuilder {
 
     /// Adds a route for opening a web socket connection
@@ -72,7 +72,7 @@ extension RoutesBuilder {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension WebSocket {
     public static func connect(
         to url: String,

--- a/Tests/AsyncTests/AsyncAuthTests.swift
+++ b/Tests/AsyncTests/AsyncAuthTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncAuthenticationTests: XCTestCase {
     func testBearerAuthenticator() throws {
         struct Test: Authenticatable {

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncCacheTests: XCTestCase {
     func testInMemoryCache() async throws {
         let app = Application(.testing)

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -2,7 +2,7 @@
 import Vapor
 import XCTest
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncClientTests: XCTestCase {
     func testClientConfigurationChange() async throws {
         let app = Application(.testing)

--- a/Tests/AsyncTests/AsyncMiddlewareTests.swift
+++ b/Tests/AsyncTests/AsyncMiddlewareTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncMiddlewareTests: XCTestCase {
     final class OrderMiddleware: AsyncMiddleware {
         static var order: [String] = []

--- a/Tests/AsyncTests/AsyncPasswordTests.swift
+++ b/Tests/AsyncTests/AsyncPasswordTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncPasswordTests: XCTestCase {
     func testAsyncBCryptRequestPassword() throws {
         let test = Environment(name: "testing", arguments: ["vapor"])

--- a/Tests/AsyncTests/AsyncRouteTests.swift
+++ b/Tests/AsyncTests/AsyncRouteTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncRouteTests: XCTestCase {
     func testEnumResponse() throws {
         enum IntOrString: AsyncResponseEncodable {

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncSessionTests: XCTestCase {
     func testSessionDestroy() throws {
         final class MockKeyedCache: AsyncSessionDriver {

--- a/Tests/AsyncTests/AsyncWebSocketTests.swift
+++ b/Tests/AsyncTests/AsyncWebSocketTests.swift
@@ -2,7 +2,7 @@
 import XCTVapor
 import Vapor
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncWebSocketTests: XCTestCase {
     func testWebSocketClient() async throws {
         let server = Application(.testing)


### PR DESCRIPTION
Since Xcode 13.2, Swift Concurrency support has been extended to macOS 10.15, iOS 13, tvOS 13 and watchOS 6 therefore we can safely lower minimum target version on Concurrency related code
