### PR TITLE
Remove dangerous and problematic re-export of XCTest

### DIFF
--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,2 +1,1 @@
-@_exported import XCTest
 @_exported import Vapor


### PR DESCRIPTION
This removes the re-export of the `XCTest` module from the `XCTVapor` module. This incorrect, ill-advised export causes problems when building with different SDKs on macOS and is generally a nuisance without being a help to anyone. While this would normally be a semver-major break, the fact that it applies only to a testing-related module, and that most unit test files end up having an `import XCTest` statement by default in any event, sufficiently justifies the source compatibility break in light of the difficulties the improper re-exporting causes.