### PR TITLE
Update FileIO streamFile to allow async / await in whenComplete closure

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -122,7 +122,7 @@ public struct FileIO {
         at path: String,
         chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
         mediaType: HTTPMediaType? = nil,
-        onCompleted: @escaping (Result<Void, Error>) -> () = { _ in }
+        onCompleted: @escaping (Result<Void, Error>) async -> () = { _ in }
     ) -> Response {
         // Get file attributes for this file.
         guard
@@ -202,7 +202,7 @@ public struct FileIO {
                 case .success:
                     stream.write(.end, promise: nil)
                 }
-                onCompleted(result)
+                await onCompleted(result)
             }
         }, count: byteCount, byteBufferAllocator: request.byteBufferAllocator)
         


### PR DESCRIPTION
Currently the 'whenComplete' is called, it does not support async / await. Trying to resolve this issue as I would like to await some updates once completed.

```swift
        let r = request.fileio.streamFile(at: f.path(study: study)) { result in
            switch result {
            case .success(): 
               doSomeSuccessProcessing() //works fine
               await doSomeSuccessProcessing() //doesn't work
            case .failure(let err):
               doSomeProcessing() //works fine
               await doSomeProcessing() //doesn't work
            }
       }
```