### PR TITLE
Prevent vapor from crashing during a crash in third-party code, obfuscating the real problem

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -161,7 +161,8 @@ public final class Application {
     deinit {
         self.logger.trace("Application deinitialized, goodbye!")
         if !self.didShutdown {
-            assertionFailure("Application.shutdown() was not called before Application deinitialized.")
+            self.logger.error("Application.shutdown() was not called before Application deinitialized.")
+            self.shutdown()
         }
     }
 }

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -64,6 +64,14 @@ final class ApplicationTests: XCTestCase {
         XCTAssertEqual(foo.didBootFlag, true)
         XCTAssertEqual(foo.shutdownFlag, true)
     }
+    
+    func testThrowDoesNotCrash() throws {
+        enum Static {
+            static var app: Application!
+        }
+        Static.app = Application(.testing)
+        Static.app = nil
+    }
 
     func testSwiftError() throws {
         struct Foo: Error { }


### PR DESCRIPTION
If a third-party library or user defined code crashed a Vapor app, the Vapor Application deinit will crash the app before the real issue pops up. This leads to frustrating debug sessions