### PR TITLE
Fixed HTTP Decompression Test Failures

### DIFF
--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -262,7 +262,7 @@ final class ServerTests: XCTestCase {
         defer { app.shutdown() }
 
         let smallOrigString = "Hello, world!"
-        let smallBody = ByteBuffer(base64String: "H4sIAAAAAAAAE/NIzcnJ11Eozy/KSVEEAObG5usNAAA=")! // "Hello, world!"
+        let smallBody = ByteBuffer(base64String: "H4sIAAAAAAAAE/NIzcnJ11Eozy/KSVEEAObG5usNAAAA")! // "Hello, world!"
         let bigBody = ByteBuffer(base64String: "H4sIAAAAAAAAE/NIzcnJ11HILU3OgBBJmenpqUUK5flFOSkKJRmJeQpJqWn5RamKAICcGhUqAAAA")! // "Hello, much much bigger world than before!"
         
         // Max out at the smaller payload (.size is of compressed data)


### PR DESCRIPTION
After the `1.14.0` version update in `swift-nio-extras` ([apple/swift-nio-extras#177](https://github.com/apple/swift-nio-extras/pull/177)), the `ServerTests.testConfigureHTTPDecompressionLimit` started failing with error `truncatedData`. This fixes the error by correcting the compressed string used in the test. 