### PR TITLE
Make Services in Vapor Usable

### DIFF
--- a/Sources/Vapor/Services/App+Service.swift
+++ b/Sources/Vapor/Services/App+Service.swift
@@ -1,0 +1,9 @@
+extension Application {
+    public struct Services {
+        public let application: Application
+    }
+
+    public var services: Services {
+        .init(application: self)
+    }
+}

--- a/Sources/Vapor/Services/Req+Service.swift
+++ b/Sources/Vapor/Services/Req+Service.swift
@@ -1,0 +1,12 @@
+extension Request {
+    public struct Services {
+        public let request: Request
+        init(request: Request) {
+            self.request = request
+        }
+    }
+
+    public var services: Services {
+        Services(request: self)
+    }
+}

--- a/Sources/Vapor/Services/Service.swift
+++ b/Sources/Vapor/Services/Service.swift
@@ -1,0 +1,53 @@
+public extension Application {
+    struct Service<ServiceType> {
+
+        let application: Application
+
+        public init(application: Application) {
+            self.application = application
+        }
+
+        public struct Provider {
+            let run: (Application) -> ()
+
+            public init(_ run: @escaping (Application) -> ()) {
+                self.run = run
+            }
+        }
+
+        final class Storage {
+            var makeService: ((Application) -> ServiceType)?
+            init() { }
+        }
+
+        struct Key: StorageKey {
+            typealias Value = Storage
+        }
+
+        public var service: ServiceType {
+            guard let makeService = self.storage.makeService else {
+                fatalError("No service configured for \(ServiceType.self)")
+            }
+            return makeService(self.application)
+        }
+
+        public func use(_ provider: Provider) {
+            provider.run(self.application)
+        }
+
+        public func use(_ makeService: @escaping (Application) -> ServiceType) {
+            self.storage.makeService = makeService
+        }
+
+        func initialize() {
+            self.application.storage[Key.self] = .init()
+        }
+
+        private var storage: Storage {
+            if self.application.storage[Key.self] == nil {
+                self.initialize()
+            }
+            return self.application.storage[Key.self]!
+        }
+    }
+}

--- a/Sources/Vapor/Services/Service.swift
+++ b/Sources/Vapor/Services/Service.swift
@@ -1,7 +1,7 @@
 import NIOConcurrencyHelpers
 
-public extension Application {
-    struct Service<ServiceType> {
+extension Application {
+    public struct Service<ServiceType> {
 
         let application: Application
 
@@ -43,15 +43,18 @@ public extension Application {
             self.storage.makeService.withLockedValue { $0 = makeService }
         }
 
-        func initialize() {
-            self.application.storage[Key.self] = .init()
+        func initialize() -> Storage {
+            let new = Storage()
+            self.application.storage[Key.self] = new
+            return new
         }
 
         private var storage: Storage {
-            if self.application.storage[Key.self] == nil {
-                self.initialize()
+            if let storage = application.storage[Key.self] {
+                return storage
+            } else {
+                return self.initialize()
             }
-            return self.application.storage[Key.self]!
         }
     }
 }

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -7,25 +7,25 @@ final class ServiceTests: XCTestCase {
     func testReadOnly() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-        
+
         app.get("test") { req in
             req.readOnly.foos()
         }
-        
+
         try app.test(.GET, "test") { res in
             XCTAssertEqual(res.status, .ok)
             try XCTAssertEqual(res.content.decode([String].self), ["foo"])
         }
     }
-    
+
     func testWritable() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-        
+
         app.writable = .init(apiKey: "foo")
         XCTAssertEqual(app.writable?.apiKey, "foo")
     }
-    
+
     func testLifecycle() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
@@ -54,9 +54,9 @@ final class ServiceTests: XCTestCase {
         app.sync.withLock {
             // Do something.
         }
-        
+
         struct TestKey: LockKey { }
-        
+
         let test = app.locks.lock(for: TestKey.self)
         test.withLock {
             // Do something.
@@ -119,7 +119,7 @@ struct MyTestService: MyService {
 
 private struct ReadOnly {
     let client: Client
-    
+
     func foos() -> EventLoopFuture<[String]> {
         self.client.eventLoop.makeSucceededFuture(["foo"])
     }

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -50,7 +50,7 @@ final class ServiceTests: XCTestCase {
     func testLocks() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-        
+
         app.sync.withLock {
             // Do something.
         }

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -7,25 +7,25 @@ final class ServiceTests: XCTestCase {
     func testReadOnly() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-
+        
         app.get("test") { req in
             req.readOnly.foos()
         }
-
+        
         try app.test(.GET, "test") { res in
             XCTAssertEqual(res.status, .ok)
             try XCTAssertEqual(res.content.decode([String].self), ["foo"])
         }
     }
-
+    
     func testWritable() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-
+        
         app.writable = .init(apiKey: "foo")
         XCTAssertEqual(app.writable?.apiKey, "foo")
     }
-
+    
     func testLifecycle() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
@@ -50,23 +50,76 @@ final class ServiceTests: XCTestCase {
     func testLocks() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-
+        
         app.sync.withLock {
             // Do something.
         }
-
+        
         struct TestKey: LockKey { }
-
+        
         let test = app.locks.lock(for: TestKey.self)
         test.withLock {
             // Do something.
         }
     }
+    
+    func testServiceHelpers() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        let testString = "This is a test - \(Int.random())"
+        let myFakeServicce = MyTestService(cannedResponse: testString, eventLoop: app.eventLoopGroup.next(), logger: app.logger)
+        
+        app.services.myService.use { _ in
+            myFakeServicce
+        }
+        
+        app.get("myService") { req -> String in
+            let thing = req.services.myService.doSomething()
+            return thing
+        }
+        
+        try app.test(.GET, "myService", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, testString)
+        })
+    }
+}
+
+protocol MyService {
+    func `for`(_ request: Request) -> MyService
+    func doSomething() -> String
+}
+
+extension Application.Services {
+    var myService: Application.Service<MyService> {
+        .init(application: self.application)
+    }
+}
+
+extension Request.Services {
+    var myService: MyService {
+        self.request.application.services.myService.service.for(request)
+    }
+}
+
+struct MyTestService: MyService {
+    let cannedResponse: String
+    let eventLoop: EventLoop
+    let logger: Logger
+    
+    func `for`(_ request: Vapor.Request) -> MyService {
+        return MyTestService(cannedResponse: self.cannedResponse, eventLoop: request.eventLoop, logger: request.logger)
+    }
+    
+    func doSomething() -> String {
+        return cannedResponse
+    }
 }
 
 private struct ReadOnly {
     let client: Client
-
+    
     func foos() -> EventLoopFuture<[String]> {
         self.client.eventLoop.makeSucceededFuture(["foo"])
     }


### PR DESCRIPTION
This adds real support to Vapor to make it easy to integrate different services that can be tested.

For example, if you have a service defined as:

```swift
protocol MyService {
    func `for`(_ request: Request) -> MyService
    func doSomething() -> String
}
```

You may then have a real implementation:

```swift

import Vapor

struct MyRealService: MyService {
    let logger: Logger
    let eventLoop: EventLoop
    
    func `for`(_ request: Vapor.Request) -> MyService {
        return MyRealService(logger: request.logger, eventLoop: request.eventLoop)
    }
    
    func doSomething() -> String {
        return "Tada"
    }
    
}
```

This is a very contrived example, but shows a service that needs a `Logger` and `EventLoop` - things that are normally tied to specific requests. Doing this in a safe and testable way involves a lot of boilerplate. This moves the boilerplate into Vapor to make it easier to do.

Now, you can define your services:

```swift
extension Application.Services {
    var myService: Application.Service<MyService> {
        .init(application: self.application)
    }
}

extension Request.Services {
    var myService: MyService {
        self.request.application.services.myService.service.for(request)
    }
}
```

Configure it in **configure.swift**:

```swift
app.services.myService.use { app in
    MyRealService(logger: app.logger, eventLoop: app.eventLoopGroup.next())
}
```

And then use it in routes:

```swift
app.get("myService") { req -> String in
    let thing = req.services.myService.doSomething()
    return thing
}
```

## Testing

This approach makes it very easy to write test services as well. With the protocol defined above, you can create an implementation for testing:

```swift
struct MyFakeService: MyService {
    let cannedResponse: String
    let eventLoop: EventLoop
    let logger: Logger
    
    func `for`(_ request: Vapor.Request) -> App.MyService {
        return MyFakeService(cannedResponse: self.cannedResponse, eventLoop: request.eventLoop, logger: request.logger)
    }
    
    func doSomething() -> String {
        return cannedResponse
    }   
}
```

And then you can configure your test application and use it:

```swift
let myFakeServicce = MyFakeService(cannedResponse: testString, eventLoop: app.eventLoopGroup.next(), logger: app.logger)        
app.services.myService.use { _ in
    myFakeServicce
}
    
try app.test(.GET, "myService", afterResponse: { res in
    XCTAssertEqual(res.status, .ok)
    XCTAssertEqual(res.body.string, testString)
})
``

