### PR TITLE
Fix 24h timeformat for `expire` and `last-modified` header

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderExpires.swift
@@ -10,20 +10,20 @@ extension HTTPHeaders {
             let fmt = DateFormatter()
             fmt.locale = Locale(identifier: "en_US_POSIX")
             fmt.timeZone = TimeZone(secondsFromGMT: 0)
-            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
             if let date = fmt.date(from: dateString) {
                 return .init(expires: date)
             }
 
             // Obsolete RFC 850 format
-            fmt.dateFormat = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+            fmt.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss zzz"
             if let date = fmt.date(from: dateString) {
                 return .init(expires: date)
             }
 
             // Obsolete ANSI C asctime() format
-            fmt.dateFormat = "EEE MMM d hh:mm:s yyyy"
+            fmt.dateFormat = "EEE MMM d HH:mm:s yyyy"
             if let date = fmt.date(from: dateString) {
                 return .init(expires: date)
             }
@@ -40,7 +40,7 @@ extension HTTPHeaders {
             let fmt = DateFormatter()
             fmt.locale = Locale(identifier: "en_US_POSIX")
             fmt.timeZone = TimeZone(secondsFromGMT: 0)
-            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
             return fmt.string(from: expires)
         }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderLastModified.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderLastModified.swift
@@ -9,7 +9,7 @@ extension HTTPHeaders {
             let fmt = DateFormatter()
             fmt.locale = Locale(identifier: "en_US_POSIX")
             fmt.timeZone = TimeZone(secondsFromGMT: 0)
-            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
             guard let date = fmt.date(from: dateString) else {
                 return nil
@@ -22,7 +22,7 @@ extension HTTPHeaders {
             let fmt = DateFormatter()
             fmt.locale = Locale(identifier: "en_US_POSIX")
             fmt.timeZone = TimeZone(secondsFromGMT: 0)
-            fmt.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
 
             return fmt.string(from: self.value)
         }

--- a/Tests/VaporTests/HTTPCacheTests.swift
+++ b/Tests/VaporTests/HTTPCacheTests.swift
@@ -56,7 +56,7 @@ class HTTPCacheTests: XCTestCase {
 
     func testPreferredFormat() {
         let expires = "Sun, 06 Nov 1994 08:49:37 GMT"
-        let format = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        let format = "EEE, dd MMM yyyy HH:mm:ss zzz"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
@@ -66,7 +66,7 @@ class HTTPCacheTests: XCTestCase {
 
     func testObsoleteFormatOne() {
         let expires = "Sunday, 06-Nov-94 08:49:37 GMT"
-        let format = "EEEE, dd-MMM-yy hh:mm:ss zzz"
+        let format = "EEEE, dd-MMM-yy HH:mm:ss zzz"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)
@@ -76,7 +76,7 @@ class HTTPCacheTests: XCTestCase {
 
     func testObsoleteFormatTwo() {
         let expires = "Sun Nov  6 08:49:37 1994"
-        let format = "EEE MMM d hh:mm:s yyyy"
+        let format = "EEE MMM d HH:mm:s yyyy"
         let required = dateFromFormat(format: format, dateStr: expires)
         let headers = HTTPHeaders(dictionaryLiteral: ("Expires", expires))
         let response = ClientResponse(status: .ok, headers: headers)

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -394,4 +394,28 @@ final class HTTPHeaderTests: XCTestCase {
         headers.links = links
         XCTAssertEqual(headers.first(name: .link), #"<https://localhost/?a=1>; rel=next, <https://localhost/?a=2>; rel=last; custom1=whatever, </?a=-1>; rel=related, </?a=-2>; rel=related"#)
     }
+    
+    /// Test parse and serialize  of `Last-Modified` header
+    func testLastModifiedHeader() throws {
+        var headers = HTTPHeaders()
+        headers.lastModified = HTTPHeaders.LastModified(value: Date(timeIntervalSince1970: 18*3600))
+        guard let date = headers.lastModified else {
+            XCTFail("HTTPHeaders.LastModified parsing failed")
+            return
+        }
+        XCTAssertEqual(date.value.timeIntervalSince1970, 18*3600)
+        XCTAssertEqual(date.serialize(), "Thu, 01 Jan 1970 18:00:00 GMT")
+    }
+    
+    /// Test parse and serialize of `Expires` header
+    func testExpiresHeader() throws {
+        var headers = HTTPHeaders()
+        headers.expires = HTTPHeaders.Expires(expires: Date(timeIntervalSince1970: 18*3600))
+        guard let date = headers.expires else {
+            XCTFail("HTTPHeaders.Expires parsing failed")
+            return
+        }
+        XCTAssertEqual(date.expires.timeIntervalSince1970, 18*3600)
+        XCTAssertEqual(date.serialize(), "Thu, 01 Jan 1970 18:00:00 GMT")
+    }
 }


### PR DESCRIPTION
`Expire` and `Last-Modified` header were encoding the hour part in 12h format (`hh`) instead of 24h format (`HH`). This results in timestamps being 12 hours off for all afternoon hours. This fixes the format used to follow the [spec](https://httpwg.org/specs/rfc9110.html#field.last-modified) correctly and adds tests to ensure no regressions.