### PR TITLE
Fix unused generator parameter in Array.random(count:using:)

### DIFF
--- a/Sources/Vapor/Utilities/Array+Random.swift
+++ b/Sources/Vapor/Utilities/Array+Random.swift
@@ -21,7 +21,7 @@ extension Array where Element: FixedWidthInteger {
         where T: RandomNumberGenerator
     {
         var array: [Element] = .init(repeating: 0, count: count)
-        (0..<count).forEach { array[$0] = Element.random() }
+        (0..<count).forEach { array[$0] = Element.random(using: &generator) }
         return array
     }
 }


### PR DESCRIPTION
The `generator` parameter in `Array.random(count:using:)` was unused in what appears to be a copy-paste error. This change passes it down to `FixedWidthInteger.random(using:)`, which was the original intention.