### PR TITLE
Fix encoding/decoding an array of dates with URL Encoding

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -332,6 +332,11 @@ private struct _Decoder: Decoder {
                 return try T(from: decoder)
             } else {
                 let value = self.values[self.currentIndex]
+                // Check if we received a date. We need the decode with the appropriate format.
+                guard !(T.self is Date.Type) else {
+                    return try configuration.decodeDate(from: value, codingPath: codingPath, forKey: nil) as! T
+                }
+                
                 if let convertible = T.self as? URLQueryFragmentConvertible.Type {
                     if let result = convertible.init(urlQueryFragmentValue: value) {
                         return result as! T
@@ -428,6 +433,10 @@ private extension URLEncodedFormDecoder.Configuration {
             let decoder = _Decoder(data: data, codingPath: newCodingPath, configuration: self)
             return try callback(decoder)
         }
+    }
+    
+    func decodeDate(from data: URLQueryFragment, codingPath: [CodingKey], forKey key: CodingKey?) throws -> Date {
+        try self.decodeDate(from: .init(values: [data]), codingPath: codingPath, forKey: key)
     }
 }
 

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -274,7 +274,19 @@ private class _Encoder: Encoder {
         
         func encode<T>(_ value: T) throws where T: Encodable {
             defer { self.count += 1 }
-            if let convertible = value as? URLQueryFragmentConvertible {
+            
+            if let date = value as? Date {
+                let encodedDate = try configuration.encodeDate(date, codingPath: self.codingPath, forKey: nil)
+                
+                switch self.configuration.arrayEncoding {
+                case .bracket:
+                    var emptyStringChild = self.internalData.children[""] ?? []
+                    emptyStringChild.values.append(contentsOf: encodedDate.values)
+                    self.internalData.children[""] = emptyStringChild
+                case .separator, .values:
+                    self.internalData.values.append(contentsOf: encodedDate.values)
+                }
+            } else if let convertible = value as? URLQueryFragmentConvertible {
                 let value = convertible.urlQueryFragmentValue
                 switch self.configuration.arrayEncoding {
                 case .bracket:

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -157,6 +157,94 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("nums[]=3.14"))
         XCTAssert(result.contains("isCool=true"))
     }
+    
+    func testDateArrayCoding() throws {
+        let toEncode = DateArrayCoding(
+            dates: [
+                Date(timeIntervalSince1970: 0),
+                Date(timeIntervalSince1970: 10_000),
+                Date(timeIntervalSince1970: 20_000),
+                Date(timeIntervalSince1970: 30_000),
+                Date(timeIntervalSince1970: 40_000),
+                Date(timeIntervalSince1970: 50_000),
+            ]
+        )
+        
+        let decodedDefaultFromUnixTimestamp = try URLEncodedFormDecoder().decode(DateArrayCoding.self, from: "dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0")
+        XCTAssertEqual(decodedDefaultFromUnixTimestamp, toEncode)
+        
+        let resultForDefault = try URLEncodedFormEncoder().encode(toEncode)
+        XCTAssertEqual("dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0", resultForDefault)
+        
+        let decodedDefault = try URLEncodedFormDecoder().decode(DateArrayCoding.self, from: resultForDefault)
+        XCTAssertEqual(decodedDefault, toEncode)
+        
+        let resultForTimeIntervalSince1970 = try URLEncodedFormEncoder(
+            configuration: .init(dateEncodingStrategy: .secondsSince1970)
+        ).encode(toEncode)
+        XCTAssertEqual("dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0", resultForDefault)
+        
+        let decodedTimeIntervalSince1970 = try URLEncodedFormDecoder(
+            configuration: .init(dateDecodingStrategy: .secondsSince1970)
+        ).decode(DateArrayCoding.self, from: resultForTimeIntervalSince1970)
+        XCTAssertEqual(decodedTimeIntervalSince1970, toEncode)
+        
+        let resultForInternetDateTime = try URLEncodedFormEncoder(
+            configuration: .init(dateEncodingStrategy: .iso8601)
+        ).encode(toEncode)
+        XCTAssertEqual("dates[]=1970-01-01T00:00:00Z&dates[]=1970-01-01T02:46:40Z&dates[]=1970-01-01T05:33:20Z&dates[]=1970-01-01T08:20:00Z&dates[]=1970-01-01T11:06:40Z&dates[]=1970-01-01T13:53:20Z", resultForInternetDateTime)
+        
+        let decodedInternetDateTime = try URLEncodedFormDecoder(
+            configuration: .init(dateDecodingStrategy: .iso8601)
+        ).decode(DateArrayCoding.self, from: resultForInternetDateTime)
+        XCTAssertEqual(decodedInternetDateTime, toEncode)
+        
+        XCTAssertThrowsError(try URLEncodedFormDecoder(
+            configuration: .init(dateDecodingStrategy: .iso8601)
+        ).decode(DateArrayCoding.self, from: "dates=bad-date"))
+        
+        class DateFormatterFactory {
+            private var threadSpecificValue = ThreadSpecificVariable<DateFormatter>()
+            var currentValue: DateFormatter {
+                get {
+                    guard let dateFormatter = threadSpecificValue.currentValue else {
+                        let threadSpecificDateFormatter = self.newDateFormatter
+                        threadSpecificValue.currentValue = threadSpecificDateFormatter
+                        return threadSpecificDateFormatter
+                    }
+                    return dateFormatter
+                }
+            }
+            
+            private var newDateFormatter: DateFormatter {
+                let dateFormatter = DateFormatter()
+                dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+                dateFormatter.dateFormat = "'Date:' yyyy-MM-dd 'Time:' HH:mm:ss 'Timezone:' ZZZZZ"
+                dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+                return dateFormatter
+            }
+        }
+        let factory = DateFormatterFactory()
+        let resultCustom = try URLEncodedFormEncoder(
+            configuration: .init(dateEncodingStrategy: .custom({ (date, encoder) in
+                var container = encoder.singleValueContainer()
+                try container.encode(factory.currentValue.string(from: date))
+            }))
+        ).encode(toEncode)
+        XCTAssertEqual("dates[]=Date:%201970-01-01%20Time:%2000:00:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2002:46:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2005:33:20%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2008:20:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2011:06:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2013:53:20%20Timezone:%20Z", resultCustom)
+        
+        let decodedCustom = try URLEncodedFormDecoder(
+            configuration: .init(dateDecodingStrategy: .custom({ (decoder) -> Date in
+                let container = try decoder.singleValueContainer()
+                let string = try container.decode(String.self)
+                guard let date = factory.currentValue.date(from: string) else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode date from string '\(string)'")
+                }
+                return date
+            }))
+        ).decode(DateArrayCoding.self, from: resultCustom)
+        XCTAssertEqual(decodedCustom, toEncode)
+    }
 
     func testDateCoding() throws {
         let toEncode = DateCoding(date: Date(timeIntervalSince1970: 0))
@@ -619,4 +707,8 @@ private enum Foo: String, Codable {
 
 struct DateCoding: Codable, Equatable {
     let date: Date
+}
+
+struct DateArrayCoding: Codable, Equatable {
+    let dates: [Date]
 }


### PR DESCRIPTION
Fixes a bug where an Array of Dates wouldn't be encoded or decoded when using URL encoding.