### PR TITLE
Add support for asynchronous body stream writing

### DIFF
--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -49,3 +49,14 @@ extension BodyStreamWriter {
         return promise.futureResult
     }
 }
+
+public protocol AsyncBodyStreamWriter {
+    func write(_ result: BodyStreamResult) async throws
+    func writeBuffer(_ buffer: ByteBuffer) async throws
+}
+
+extension AsyncBodyStreamWriter {
+    public func writeBuffer(_ buffer: ByteBuffer) async throws {
+        try await write(.buffer(buffer))
+    }
+}

--- a/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
@@ -32,7 +32,6 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
             status: response.status,
             headers: response.headers
         ))), promise: nil)
-
         
         if response.status == .noContent || response.forHeadRequest {
             // don't send bodies for 204 (no content) responses
@@ -66,6 +65,17 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
                     count: stream.count == -1 ? nil : stream.count
                 )
                 stream.callback(channelStream)
+            case .asyncStream(let stream):
+                let channelStream = ChannelResponseBodyStream(
+                    context: context,
+                    handler: self,
+                    promise: nil,
+                    count: stream.count == -1 ? nil : stream.count
+                )
+                
+                promise?.completeWithTask {
+                    try await stream.callback(channelStream)
+                }
             }
         }
     }
@@ -80,7 +90,7 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
     }
 }
 
-private final class ChannelResponseBodyStream: BodyStreamWriter {
+private final class ChannelResponseBodyStream: BodyStreamWriter, AsyncBodyStreamWriter {
     let context: ChannelHandlerContext
     let handler: HTTPServerResponseEncoder
     let promise: EventLoopPromise<Void>?
@@ -111,9 +121,18 @@ private final class ChannelResponseBodyStream: BodyStreamWriter {
         self.isComplete = false
     }
     
+    func write(_ result: BodyStreamResult) async throws {
+        try await self.eventLoop.flatSubmit {
+            let promise = self.eventLoop.makePromise(of: Void.self)
+            self.write(result, promise: promise)
+            return promise.futureResult
+        }.get()
+    }
+    
     func write(_ result: BodyStreamResult, promise: EventLoopPromise<Void>?) {
         switch result {
         case .buffer(let buffer):
+            // TODO: What if it's complete at this point?
             self.context.writeAndFlush(self.handler.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: promise)
             self.currentCount += buffer.readableBytes
             if let count = self.count, self.currentCount > count {
@@ -121,6 +140,7 @@ private final class ChannelResponseBodyStream: BodyStreamWriter {
                 promise?.fail(Error.notEnoughBytes)
             }
         case .end:
+            // TODO: What if it's already complete?
             self.isComplete = true
             if let count = self.count, self.currentCount != count {
                 self.promise?.fail(Error.notEnoughBytes)

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -3,6 +3,11 @@ extension Response {
         let count: Int
         let callback: (BodyStreamWriter) -> ()
     }
+    
+    struct AsyncBodyStream {
+        let count: Int
+        let callback: @Sendable (AsyncBodyStreamWriter) async throws -> ()
+    }
 
     /// Represents a `Response`'s body.
     ///
@@ -20,6 +25,7 @@ extension Response {
             case staticString(StaticString)
             case string(String)
             case stream(BodyStream)
+            case asyncStream(AsyncBodyStream)
         }
         
         /// An empty `Response.Body`.
@@ -47,6 +53,7 @@ extension Response {
             case .buffer(let buffer): return buffer.readableBytes
             case .none: return 0
             case .stream(let stream): return stream.count
+            case .asyncStream(let stream): return stream.count
             }
         }
         
@@ -60,6 +67,7 @@ extension Response {
             case .string(let string): return Data(string.utf8)
             case .none: return nil
             case .stream: return nil
+            case .asyncStream: return nil
             }
         }
         
@@ -80,6 +88,7 @@ extension Response {
                 return buffer
             case .none: return nil
             case .stream: return nil
+            case .asyncStream: return nil
             }
         }
 
@@ -105,6 +114,7 @@ extension Response {
             case .staticString(let string): return string.description
             case .string(let string): return string
             case .stream: return "<stream>"
+            case .asyncStream: return "<async stream>"
             }
         }
         
@@ -154,6 +164,31 @@ extension Response {
 
         public init(stream: @escaping (BodyStreamWriter) -> (), byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
             self.init(stream: stream, count: -1, byteBufferAllocator: byteBufferAllocator)
+        }
+        
+        public init(asyncStream: @escaping @Sendable (AsyncBodyStreamWriter) async throws -> (), count: Int, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
+            self.byteBufferAllocator = byteBufferAllocator
+            self.storage = .asyncStream(.init(count: count, callback: asyncStream))
+        }
+        
+        public init(asyncStream: @escaping @Sendable (AsyncBodyStreamWriter) async throws -> (), byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
+            self.init(asyncStream: asyncStream, count: -1, byteBufferAllocator: byteBufferAllocator)
+        }
+        
+        public init(managedAsyncStream: @escaping @Sendable (AsyncBodyStreamWriter) async throws -> (), count: Int, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
+            self.byteBufferAllocator = byteBufferAllocator
+            self.storage = .asyncStream(.init(count: count) { writer in
+                do {
+                    try await managedAsyncStream(writer)
+                    try await writer.write(.end)
+                } catch {
+                    try await writer.write(.error(error))
+                }
+            })
+        }
+        
+        public init(managedAsyncStream: @escaping @Sendable (AsyncBodyStreamWriter) async throws -> (), byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
+            self.init(managedAsyncStream: managedAsyncStream, count: -1, byteBufferAllocator: byteBufferAllocator)
         }
         
         /// `ExpressibleByStringLiteral` conformance.


### PR DESCRIPTION
- Fixes #2930 - a crash when users try to write a body from within a task towards the ELF APIs.
- Introduces a new API for writing chunked HTTP response bodies
- Adds a helper that automatically managed failing and closing streams