### PR TITLE
Fix: FileIO headers

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -152,7 +152,7 @@ public struct FileIO {
         var headers: HTTPHeaders = [:]
 
         // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
-        let fileETag = "\(modifiedAt.timeIntervalSince1970)-\(fileSize)"
+        let fileETag = "\"\(modifiedAt.timeIntervalSince1970)-\(fileSize)\""
         headers.replaceOrAdd(name: .eTag, value: fileETag)
 
         // Check if file has been cached already and return NotModified response if the etags match

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -160,7 +160,11 @@ public struct FileIO {
 
         // Check if file has been cached already and return NotModified response if the etags match
         if fileETag == request.headers.first(name: .ifNoneMatch) {
-            return Response(status: .notModified)
+            // Per RFC 9110 here: https://www.rfc-editor.org/rfc/rfc9110.html#status.304
+            // and here: https://www.rfc-editor.org/rfc/rfc9110.html#name-content-encoding
+            // A 304 response MUST include the ETag header and a Content-Length header matching what the original resource's content length would have been were this a 200 response.
+            headers.replaceOrAdd(name: .contentLength, value: fileSize.description)
+            return Response(status: .notModified, version: .http1_1, headersNoUpdate: headers, body: .empty)
         }
 
         // Create the HTTP response.

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -151,6 +151,9 @@ public struct FileIO {
         // Create empty headers array.
         var headers: HTTPHeaders = [:]
 
+        // Respond with lastModified header
+        headers.lastModified = HTTPHeaders.LastModified(value: modifiedAt)
+        
         // Generate ETag value, "HEX value of last modified date" + "-" + "file size"
         let fileETag = "\"\(modifiedAt.timeIntervalSince1970)-\(fileSize)\""
         headers.replaceOrAdd(name: .eTag, value: fileETag)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

- Adds `Last-Modified` header to file requests
- Fixes `ETag` header formatting in file requests: According to [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag), the `ETag` header should start and end with double-quotes.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
