### PR TITLE
Use YML compatible quotes in the `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 metadata:
-  authors: “Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community.”
+  authors: "Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community."


### PR DESCRIPTION
We're picking these up as part of the text:

<img width="599" alt="Screenshot 2023-02-13 at 12 44 52@2x" src="https://user-images.githubusercontent.com/5180/218461001-0c04e636-20db-4d19-a8cf-33d2df2eff48.png">
