### PR TITLE
Fix up Imports

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-deploy:
-     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@fc8584486d15d22fbb3dabc28b27f518eb77a84c
+     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@0cf3a0b827263a51af91ef402341222dcc48b098
      secrets: inherit
      with:
        package_name: vapor

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-deploy:
-     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@0cf3a0b827263a51af91ef402341222dcc48b098
+     uses: vapor/api-docs/.github/workflows/build-and-deploy-docs-workflow.yml@main
      secrets: inherit
      with:
        package_name: vapor

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,3 +11,4 @@ jobs:
      with:
        package_name: vapor
        modules: Vapor,XCTVapor
+       pathsToInvalidate: /vapor /xctvapor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,16 +38,12 @@ jobs:
        with_tsan: false
        with_public_api_check: true
   test-exports:
-      name: Test exports
-      runs-on: ubuntu-latest
-      steps:
-        - name: Check out Vapor
-          uses: actions/checkout@v3
-          with:
-            fetch-depth: 0
-        - name: Remove exports
-          run: |
-            rm -rf Sources/Vapor/Exports.swift
-            rm -rf Sources/XCTVapor/Exports.swift
-        - name: Build
-          run: swift build
+    name: Test exports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Vapor
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: swift build -Xswiftc -DBUILDING_DOCC

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,17 @@ jobs:
        with_coverage: false
        with_tsan: false
        with_public_api_check: true
+  test-exports:
+      name: Test exports
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out Vapor
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+        - name: Remove exports
+          run: |
+            rm -rf Sources/Vapor/Exports.swift
+            rm -rf Sources/XCTVapor/Exports.swift
+        - name: Build
+          run: swift build

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,5 @@
 version: 1
 metadata:
   authors: "Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community."
+external_links:
+  documentation: "https://docs.vapor.codes"

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,4 +1,5 @@
 import Vapor
+import Logging
 
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -1,4 +1,6 @@
 import Vapor
+import NIOCore
+import NIOHTTP1
 
 struct Creds: Content {
     var email: String

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,5 +1,9 @@
 import Backtrace
 import NIOConcurrencyHelpers
+import NIOCore
+import Logging
+import ConsoleKit
+import NIOPosix
 
 /// Core type representing a Vapor application.
 public final class Application {

--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// Capable of being authenticated.
 public protocol Authenticatable { }
 

--- a/Sources/Vapor/Authentication/BasicAuthorization.swift
+++ b/Sources/Vapor/Authentication/BasicAuthorization.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOHTTP1
+
 /// A basic username and password.
 public struct BasicAuthorization {
     /// The username, sometimes an email address

--- a/Sources/Vapor/Authentication/BearerAuthorization.swift
+++ b/Sources/Vapor/Authentication/BearerAuthorization.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 /// A bearer token.
 public struct BearerAuthorization {
     /// The plaintext token

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Authenticatable {
     /// This middleware ensures that an `Authenticatable` type `A` has been authenticated
     /// by a previous `Middleware` or throws an `Error`. The middlewares that actually perform

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Authenticatable {
     /// Basic middleware to redirect unauthenticated requests to the supplied path
     ///

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// Helper for creating authentication middleware in conjunction with `SessionsMiddleware`.
 public protocol SessionAuthenticator: Authenticator {
     associatedtype User: SessionAuthenticatable

--- a/Sources/Vapor/Bcrypt/Bcrypt.swift
+++ b/Sources/Vapor/Bcrypt/Bcrypt.swift
@@ -1,3 +1,4 @@
+import Foundation
 import CVaporBcrypt
 
 // MARK: BCrypt

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -1,3 +1,4 @@
+import Foundation
 import NIOCore
 import NIOConcurrencyHelpers
 

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import Logging
+import NIOHTTP1
+
 public protocol Client {
     var eventLoop: EventLoop { get }
     var byteBufferAllocator: ByteBufferAllocator { get }

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import NIOHTTP1
+import Foundation
+
 public struct ClientRequest {
     public var method: HTTPMethod
     public var url: URI

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -1,4 +1,6 @@
-import NIO
+import NIOCore
+import NIOHTTP1
+import Foundation
 
 public struct ClientResponse {
     public var status: HTTPStatus

--- a/Sources/Vapor/Commands/BootCommand.swift
+++ b/Sources/Vapor/Commands/BootCommand.swift
@@ -1,3 +1,5 @@
+import ConsoleKit
+
 /// Boots the `Application` then exits successfully.
 ///
 ///     $ swift run Run boot

--- a/Sources/Vapor/Commands/CommandContext+Application.swift
+++ b/Sources/Vapor/Commands/CommandContext+Application.swift
@@ -1,3 +1,5 @@
+import ConsoleKit
+
 extension CommandContext {
     public var application: Application {
         get {

--- a/Sources/Vapor/Commands/RoutesCommand.swift
+++ b/Sources/Vapor/Commands/RoutesCommand.swift
@@ -1,3 +1,6 @@
+import ConsoleKit
+import RoutingKit
+
 /// Displays all routes registered to the `Application`'s `Router` in an ASCII-formatted table.
 ///
 ///     $ swift run Run routes

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -1,3 +1,6 @@
+import Foundation
+import ConsoleKit
+
 /// Boots the application's server. Listens for `SIGINT` and `SIGTERM` for graceful shutdown.
 ///
 ///     $ swift run Run serve

--- a/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/AsyncPasswordHasher+Concurrency.swift
@@ -1,5 +1,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
+import Foundation
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncPasswordHasher {

--- a/Sources/Vapor/Concurrency/Client+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/Client+Concurrency.swift
@@ -1,5 +1,6 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
+import NIOHTTP1
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Client {

--- a/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/ResponseCodable+Concurrency.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import NIOHTTP1
 
 /// Can convert `self` to a `Response`.
 ///

--- a/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
@@ -1,5 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
+import NIOHTTP1
+import RoutingKit
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension RoutesBuilder {

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -1,5 +1,8 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import NIOCore
+import NIOHTTP1
+import WebSocketKit
+import RoutingKit
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Request {

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// Convertible to / from content in an HTTP message.
 ///
 /// Conformance to this protocol consists of:

--- a/Sources/Vapor/Content/ContentCoders.swift
+++ b/Sources/Vapor/Content/ContentCoders.swift
@@ -1,3 +1,7 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
 public protocol ContentEncoder {
     func encode<E>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders) throws
         where E: Encodable

--- a/Sources/Vapor/Content/ContentConfiguration.swift
+++ b/Sources/Vapor/Content/ContentConfiguration.swift
@@ -1,3 +1,6 @@
+import Foundation
+import MultipartKit
+
 /// Configures which `Encoder`s and `Decoder`s to use when interacting with data in HTTP messages.
 ///
 ///     ContentConfiguration.global.use(encoder: JSONEncoder(), for: .json)

--- a/Sources/Vapor/Content/JSONCoders+Content.swift
+++ b/Sources/Vapor/Content/JSONCoders+Content.swift
@@ -1,3 +1,7 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
 extension JSONEncoder: ContentEncoder {
     public func encode<E>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders) throws
         where E: Encodable

--- a/Sources/Vapor/Content/PlaintextDecoder.swift
+++ b/Sources/Vapor/Content/PlaintextDecoder.swift
@@ -1,3 +1,6 @@
+import NIOCore
+import NIOHTTP1
+
 /// Decodes data as plaintext, utf8.
 public struct PlaintextDecoder: ContentDecoder {
 

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -1,3 +1,7 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
 /// Encodes data as plaintext, utf8.
 public struct PlaintextEncoder: ContentEncoder {
     /// Private encoder.

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -1,3 +1,7 @@
+import ConsoleKit
+import NIOCore
+import NIOPosix
+
 extension Application {
     public var console: Console {
         get { self.core.storage.console }

--- a/Sources/Vapor/Core/Running.swift
+++ b/Sources/Vapor/Core/Running.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Application {
     public struct Running {
         final class Storage {

--- a/Sources/Vapor/Deprecations/CORSMiddleware+Configuration+exposedHeaders.swift
+++ b/Sources/Vapor/Deprecations/CORSMiddleware+Configuration+exposedHeaders.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension CORSMiddleware.Configuration {
     /// Instantiate a CORSConfiguration struct that can be used to create a `CORSConfiguration`
     /// middleware for adding support for CORS in your responses.

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -1,3 +1,7 @@
+import Logging
+import NIOCore
+import NIOPosix
+
 extension DotEnvFile {
     /// Reads the dotenv files relevant to the environment and loads them into the process.
     ///

--- a/Sources/Vapor/Environment/Environment+Process.swift
+++ b/Sources/Vapor/Environment/Environment+Process.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Environment {    
     /// The process information of an environment. Wraps `ProcessInto.processInfo`.
     @dynamicMemberLookup public struct Process {

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import NIOPosix
+import AsyncKit
+
 extension Environment {
     /// Reads a file's content for a secret. The secret key is the name of the environment variable that is expected to
     /// specify the path of the file containing the secret.

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ConsoleKit
 
 /// The environment the application is running in, i.e., production, dev, etc. All `Container`s will have

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 /// Default implementation of `AbortError`. You can use this as a convenient method for throwing
 /// `AbortError`s without having to conform your own error-type to `AbortError`.
 ///

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 /// Errors conforming to this protocol will always be displayed by
 /// Vapor to the end-user (even in production mode where most errors are silenced).
 ///

--- a/Sources/Vapor/Error/DebuggableError.swift
+++ b/Sources/Vapor/Error/DebuggableError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 
 /// `Debuggable` provides an interface that allows a type
 /// to be more easily debugged in the case of an error.

--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -1,3 +1,4 @@
+import Foundation
 #if os(Linux)
 import Backtrace
 import CBacktrace

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -1,39 +1,39 @@
-@_exported import AsyncKit
-
-@_exported import class AsyncHTTPClient.HTTPClient
-@_exported import struct AsyncHTTPClient.HTTPClientError
-
-@_exported import Crypto
-@_exported import RoutingKit
-@_exported import ConsoleKit
-@_exported import Foundation
-
-@_exported import Logging
-
-@_exported import struct NIO.ByteBuffer
-@_exported import struct NIO.ByteBufferAllocator
-@_exported import protocol NIO.Channel
-@_exported import class NIO.EmbeddedChannel
-@_exported import class NIO.EmbeddedEventLoop
-@_exported import protocol NIO.EventLoop
-@_exported import class NIO.EventLoopFuture
-@_exported import protocol NIO.EventLoopGroup
-@_exported import struct NIO.EventLoopPromise
-@_exported import class NIO.MultiThreadedEventLoopGroup
-@_exported import struct NIO.NonBlockingFileIO
-@_exported import class NIO.NIOThreadPool
-@_exported import enum NIO.System
-
-@_exported import class NIOConcurrencyHelpers.Lock
-
-@_exported import struct NIOHTTP1.HTTPHeaders
-@_exported import enum NIOHTTP1.HTTPMethod
-@_exported import struct NIOHTTP1.HTTPVersion
-@_exported import enum NIOHTTP1.HTTPResponseStatus
-
-@_exported import enum NIOHTTPCompression.NIOHTTPDecompression
-
-@_exported import struct NIOSSL.TLSConfiguration
-
-@_exported import WebSocketKit
-@_exported import MultipartKit
+//@_exported import AsyncKit
+//
+//@_exported import class AsyncHTTPClient.HTTPClient
+//@_exported import struct AsyncHTTPClient.HTTPClientError
+//
+//@_exported import Crypto
+//@_exported import RoutingKit
+//@_exported import ConsoleKit
+//@_exported import Foundation
+//
+//@_exported import Logging
+//
+//@_exported import struct NIO.ByteBuffer
+//@_exported import struct NIO.ByteBufferAllocator
+//@_exported import protocol NIO.Channel
+//@_exported import class NIO.EmbeddedChannel
+//@_exported import class NIO.EmbeddedEventLoop
+//@_exported import protocol NIO.EventLoop
+//@_exported import class NIO.EventLoopFuture
+//@_exported import protocol NIO.EventLoopGroup
+//@_exported import struct NIO.EventLoopPromise
+//@_exported import class NIO.MultiThreadedEventLoopGroup
+//@_exported import struct NIO.NonBlockingFileIO
+//@_exported import class NIO.NIOThreadPool
+//@_exported import enum NIO.System
+//
+//@_exported import class NIOConcurrencyHelpers.Lock
+//
+//@_exported import struct NIOHTTP1.HTTPHeaders
+//@_exported import enum NIOHTTP1.HTTPMethod
+//@_exported import struct NIOHTTP1.HTTPVersion
+//@_exported import enum NIOHTTP1.HTTPResponseStatus
+//
+//@_exported import enum NIOHTTPCompression.NIOHTTPDecompression
+//
+//@_exported import struct NIOSSL.TLSConfiguration
+//
+//@_exported import WebSocketKit
+//@_exported import MultipartKit

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -1,39 +1,39 @@
-//@_exported import AsyncKit
-//
-//@_exported import class AsyncHTTPClient.HTTPClient
-//@_exported import struct AsyncHTTPClient.HTTPClientError
-//
-//@_exported import Crypto
-//@_exported import RoutingKit
-//@_exported import ConsoleKit
-//@_exported import Foundation
-//
-//@_exported import Logging
-//
-//@_exported import struct NIO.ByteBuffer
-//@_exported import struct NIO.ByteBufferAllocator
-//@_exported import protocol NIO.Channel
-//@_exported import class NIO.EmbeddedChannel
-//@_exported import class NIO.EmbeddedEventLoop
-//@_exported import protocol NIO.EventLoop
-//@_exported import class NIO.EventLoopFuture
-//@_exported import protocol NIO.EventLoopGroup
-//@_exported import struct NIO.EventLoopPromise
-//@_exported import class NIO.MultiThreadedEventLoopGroup
-//@_exported import struct NIO.NonBlockingFileIO
-//@_exported import class NIO.NIOThreadPool
-//@_exported import enum NIO.System
-//
-//@_exported import class NIOConcurrencyHelpers.Lock
-//
-//@_exported import struct NIOHTTP1.HTTPHeaders
-//@_exported import enum NIOHTTP1.HTTPMethod
-//@_exported import struct NIOHTTP1.HTTPVersion
-//@_exported import enum NIOHTTP1.HTTPResponseStatus
-//
-//@_exported import enum NIOHTTPCompression.NIOHTTPDecompression
-//
-//@_exported import struct NIOSSL.TLSConfiguration
-//
-//@_exported import WebSocketKit
-//@_exported import MultipartKit
+@_exported import AsyncKit
+
+@_exported import class AsyncHTTPClient.HTTPClient
+@_exported import struct AsyncHTTPClient.HTTPClientError
+
+@_exported import Crypto
+@_exported import RoutingKit
+@_exported import ConsoleKit
+@_exported import Foundation
+
+@_exported import Logging
+
+@_exported import struct NIO.ByteBuffer
+@_exported import struct NIO.ByteBufferAllocator
+@_exported import protocol NIO.Channel
+@_exported import class NIO.EmbeddedChannel
+@_exported import class NIO.EmbeddedEventLoop
+@_exported import protocol NIO.EventLoop
+@_exported import class NIO.EventLoopFuture
+@_exported import protocol NIO.EventLoopGroup
+@_exported import struct NIO.EventLoopPromise
+@_exported import class NIO.MultiThreadedEventLoopGroup
+@_exported import struct NIO.NonBlockingFileIO
+@_exported import class NIO.NIOThreadPool
+@_exported import enum NIO.System
+
+@_exported import class NIOConcurrencyHelpers.Lock
+
+@_exported import struct NIOHTTP1.HTTPHeaders
+@_exported import enum NIOHTTP1.HTTPMethod
+@_exported import struct NIOHTTP1.HTTPVersion
+@_exported import enum NIOHTTP1.HTTPResponseStatus
+
+@_exported import enum NIOHTTPCompression.NIOHTTPDecompression
+
+@_exported import struct NIOSSL.TLSConfiguration
+
+@_exported import WebSocketKit
+@_exported import MultipartKit

--- a/Sources/Vapor/Exports.swift
+++ b/Sources/Vapor/Exports.swift
@@ -1,3 +1,5 @@
+#if !BUILDING_DOCC
+
 @_exported import AsyncKit
 
 @_exported import class AsyncHTTPClient.HTTPClient
@@ -37,3 +39,4 @@
 
 @_exported import WebSocketKit
 @_exported import MultipartKit
+#endif

--- a/Sources/Vapor/HTTP/BasicResponder.swift
+++ b/Sources/Vapor/HTTP/BasicResponder.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// A basic, closure-based `Responder`.
 public struct BasicResponder: Responder {
     /// The stored responder closure.

--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 public enum BodyStreamResult {
     /// A normal data chunk.
     /// There will be 0 or more of these.

--- a/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
+++ b/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
@@ -1,3 +1,5 @@
+import AsyncHTTPClient
+
 extension Application.Clients.Provider {
     public static var http: Self {
         .init {

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -1,4 +1,7 @@
-import NIO
+import NIOCore
+import AsyncHTTPClient
+import Logging
+import Foundation
 
 extension HTTPClient {
     func delegating(to eventLoop: EventLoop, logger: Logger, byteBufferAllocator: ByteBufferAllocator) -> Client {

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -1,4 +1,8 @@
+import Foundation
 import NIOConcurrencyHelpers
+import NIOCore
+import Logging
+import NIOHTTP1
 
 public enum EndpointCacheError: Swift.Error {
     case unexpctedResponseStatus(HTTPStatus, uri: URI)

--- a/Sources/Vapor/HTTP/HTTPStatus.swift
+++ b/Sources/Vapor/HTTP/HTTPStatus.swift
@@ -1,3 +1,6 @@
+import NIOHTTP1
+import NIOCore
+
 /// Less verbose typealias for `HTTPResponseStatus`.
 public typealias HTTPStatus = HTTPResponseStatus
 

--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Get and set `HTTPCookies` for an HTTP request
     /// This accesses the `"Cookie"` header.

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
@@ -1,4 +1,5 @@
-import NIO
+import Foundation
+import NIOHTTP1
 
 // Comments on these properties are copied from the mozilla doc URL shown below.
 extension HTTPHeaders {

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderExpires.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderExpires.swift
@@ -1,4 +1,5 @@
-import NIO
+import Foundation
+import NIOHTTP1
 
 extension HTTPHeaders {
     public struct Expires {

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderLastModified.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderLastModified.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Represents the HTTP `Last-Modified` header.
     /// - See Also:

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Cache.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Cache.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Determines when the cached data should be expired.
     ///

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     public struct Connection: ExpressibleByStringLiteral, Equatable {
         public static let close: Self = "close"

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Convenience for accessing the Content-Disposition header.
     ///

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOHTTP1
 
 extension HTTPHeaders {
     

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Directive.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     struct Directive: Equatable, CustomStringConvertible {
         var value: Substring

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Forwarded.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Forwarded.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Convenience for accessing the Forwarded header. This header is added by
     /// proxies to pass information about the original request.

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Convenience for accessing the Link header as an array of provided links.
     ///

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// Type used for the name of a HTTP header in the `HTTPHeaders` storage.
     public struct Name: Codable, Hashable, Equatable, CustomStringConvertible, ExpressibleByStringLiteral {

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 extension HTTPHeaders {
     /// `MediaType` specified by this message's `"Content-Type"` header.
     public var contentType: HTTPMediaType? {

--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 /// Represents an encoded data-format, used in HTTP, HTML, email, and elsewhere.
 ///
 ///     text/plain

--- a/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOHTTP1
+
 /// Represents a `MediaType` and its associated preference, `q`.
 public struct HTTPMediaTypePreference {
     /// The `MediaType` in question.

--- a/Sources/Vapor/HTTP/Responder.swift
+++ b/Sources/Vapor/HTTP/Responder.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 public protocol Responder {
     func respond(to request: Request) -> EventLoopFuture<Response>
 }

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -1,9 +1,11 @@
-import NIO
+import NIOCore
 import NIOExtras
 import NIOHTTP1
 import NIOHTTP2
 import NIOHTTPCompression
 import NIOSSL
+import Logging
+import NIOPosix
 
 public enum HTTPVersionMajor: Equatable, Hashable {
     case one

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -1,4 +1,5 @@
-import NIO
+import NIOCore
+import Logging
 
 final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     typealias InboundIn = Request

--- a/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
@@ -1,5 +1,7 @@
-import NIO
+import Logging
+import NIOCore
 import NIOHTTP1
+import Foundation
 
 final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHandler {
     typealias InboundIn = HTTPServerRequestPart

--- a/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import NIOHTTP1
 
 final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelHandler {

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -1,6 +1,7 @@
 import NIO
 import NIOHTTP1
 import NIOWebSocket
+import WebSocketKit
 
 final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHandler {
     typealias InboundIn = Request

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOWebSocket
 import WebSocketKit

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -1,3 +1,6 @@
+import Foundation
+import Logging
+
 extension Logger {
     /// Reports an `Error` to this `Logger`.
     ///

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -1,3 +1,6 @@
+import Logging
+import ConsoleKit
+
 extension LoggingSystem {
     public static func bootstrap(from environment: inout Environment, _ factory: (Logger.Level) -> (String) -> LogHandler) throws {
         let level = try Logger.Level.detect(from: &environment)

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -1,3 +1,6 @@
+import NIOHTTP1
+import NIOCore
+
 /// Middleware that adds support for CORS settings in request responses.
 /// For configuration of this middleware please use the `CORSMiddleware.Configuration` object.
 ///

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -1,3 +1,7 @@
+import Foundation
+import NIOCore
+import NIOHTTP1
+
 /// Captures all errors and transforms them into an internal server error HTTP response.
 public final class ErrorMiddleware: Middleware {
     /// Structure of `ErrorMiddleware` default response.

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOCore
+
 /// Serves static files from a public directory.
 ///
 /// `FileMiddleware` will default to `DirectoryConfig`'s working directory with `"/Public"` appended.

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// `Middleware` is placed between the server and your router. It is capable of
 /// mutating both incoming requests and outgoing responses. `Middleware` can choose
 /// to pass requests on to the next `Middleware` in a chain, or they can short circuit and

--- a/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
+++ b/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
@@ -1,3 +1,4 @@
+import NIOCore
 import Logging
 
 /// Emits a log message containing the request method and path to a `Request`'s logger.

--- a/Sources/Vapor/Multipart/File+Multipart.swift
+++ b/Sources/Vapor/Multipart/File+Multipart.swift
@@ -1,3 +1,6 @@
+import MultipartKit
+import NIOHTTP1
+
 extension File: MultipartPartConvertible {
     public var multipart: MultipartPart? {
         var part = MultipartPart(headers: [:], body: .init(self.data.readableBytesView))

--- a/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
@@ -1,3 +1,5 @@
+import MultipartKit
+
 extension FormDataDecoder: ContentDecoder {
     public func decode<D>(_ decodable: D.Type, from body: ByteBuffer, headers: HTTPHeaders) throws -> D
         where D: Decodable

--- a/Sources/Vapor/Multipart/FormDataEncoder+Content.swift
+++ b/Sources/Vapor/Multipart/FormDataEncoder+Content.swift
@@ -1,3 +1,5 @@
+import MultipartKit
+
 extension FormDataEncoder: ContentEncoder {
     public func encode<E>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders) throws
         where E: Encodable

--- a/Sources/Vapor/Passwords/Application+Password.swift
+++ b/Sources/Vapor/Passwords/Application+Password.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Application {
     public var password: Password {
         .init(application: self)

--- a/Sources/Vapor/Passwords/AsyncPasswordHasher.swift
+++ b/Sources/Vapor/Passwords/AsyncPasswordHasher.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import NIOPosix
+import Foundation
+
 extension PasswordHasher {
     public func async(
         on threadPool: NIOThreadPool,

--- a/Sources/Vapor/Passwords/BcryptHasher.swift
+++ b/Sources/Vapor/Passwords/BcryptHasher.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Application.Passwords.Provider {
     public static var bcrypt: Self {
         .bcrypt(cost: 12)

--- a/Sources/Vapor/Passwords/PasswordHasher.swift
+++ b/Sources/Vapor/Passwords/PasswordHasher.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol PasswordHasher {
     func hash<Password>(_ password: Password) throws -> [UInt8]
         where Password: DataProtocol

--- a/Sources/Vapor/Passwords/PlaintextHasher.swift
+++ b/Sources/Vapor/Passwords/PlaintextHasher.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Application.Passwords.Provider {
     public static var plaintext: Self {
         .init {

--- a/Sources/Vapor/Passwords/Request+Password.swift
+++ b/Sources/Vapor/Passwords/Request+Password.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Request {
     public var password: Password {
         .init(request: self)

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Request {
     public struct Body: CustomStringConvertible {
         let request: Request

--- a/Sources/Vapor/Request/Request+BodyStream.swift
+++ b/Sources/Vapor/Request/Request+BodyStream.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import NIOConcurrencyHelpers
 
 extension Request {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 import NIOHTTP1
 import Logging
 import RoutingKit

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -1,5 +1,8 @@
+import Foundation
 import NIO
 import NIOHTTP1
+import Logging
+import RoutingKit
 
 /// Represents an HTTP request in an application.
 public final class Request: CustomStringConvertible {

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension Application {
     public var responder: Responder {
         .init(application: self)

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -1,4 +1,9 @@
+import Foundation
 import Metrics
+import RoutingKit
+import NIOCore
+import NIOHTTP1
+import Logging
 
 /// Vapor's main `Responder` type. Combines configured middleware + router to create a responder.
 internal struct DefaultResponder: Responder {

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOCore
+
 extension Response {
     struct BodyStream {
         let count: Int

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOFoundationCompat
 

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -1,3 +1,6 @@
+import NIOCore
+import NIOHTTP1
+
 /// Can convert `self` to a `Response`.
 ///
 /// Types that conform to this protocol can be returned in route closures.

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -1,3 +1,5 @@
+import RoutingKit
+
 extension Parameters {
     /// Grabs the named parameter from the parameter bag.
     /// If the parameter does not exist, `Abort(.internalServerError)` is thrown.

--- a/Sources/Vapor/Routing/Request+WebSocket.swift
+++ b/Sources/Vapor/Routing/Request+WebSocket.swift
@@ -1,3 +1,6 @@
+import NIOCore
+import WebSocketKit
+
 extension Request {
      public func webSocket(
          maxFrameSize: WebSocketMaxFrameSize = .`default`,

--- a/Sources/Vapor/Routing/Route.swift
+++ b/Sources/Vapor/Routing/Route.swift
@@ -1,3 +1,6 @@
+import NIOHTTP1
+import RoutingKit
+
 public final class Route: CustomStringConvertible {
     public var method: HTTPMethod
     public var path: [PathComponent]

--- a/Sources/Vapor/Routing/RoutesBuilder+Group.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Group.swift
@@ -1,3 +1,5 @@
+import RoutingKit
+
 extension RoutesBuilder {
     // MARK: Path
     

--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -1,4 +1,7 @@
-/// Determines how an incoming HTTP request's body is collected. 
+import RoutingKit
+import NIOHTTP1
+
+/// Determines how an incoming HTTP request's body is collected.
 public enum HTTPBodyStreamStrategy {
     /// The HTTP request's body will be collected into memory up to a maximum size
     /// before the route handler is called. The application's configured default max body

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -1,3 +1,6 @@
+import RoutingKit
+import WebSocketKit
+
 public struct WebSocketMaxFrameSize: ExpressibleByIntegerLiteral {
     let value: Int
 

--- a/Sources/Vapor/Routing/RoutesBuilder.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol RoutesBuilder {
     func add(_ route: Route)
 }

--- a/Sources/Vapor/Security/OTP.swift
+++ b/Sources/Vapor/Security/OTP.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Crypto
 
 /// Supported OTP output sizes.

--- a/Sources/Vapor/Server/Server.swift
+++ b/Sources/Vapor/Server/Server.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 // TODO: Remove these deprecated methods along with ServerStartError in the major release.
 public protocol Server {
     var onShutdown: EventLoopFuture<Void> { get }

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOCore
+
 /// Simple in-memory sessions implementation.
 public struct MemorySessions: SessionDriver {
     public let storage: Storage

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// Capable of managing CRUD operations for `Session`s.
 public protocol SessionDriver {
     func createSession(

--- a/Sources/Vapor/Sessions/SessionsConfiguration.swift
+++ b/Sources/Vapor/Sessions/SessionsConfiguration.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Configuration options for sessions.
 public struct SessionsConfiguration {
     /// Creates a new `HTTPCookieValue` for the supplied value `String`.

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// Uses HTTP cookies to save and restore sessions for connecting clients.
 ///
 /// If a cookie matching the configured cookie name is found on an incoming request,

--- a/Sources/Vapor/URLEncodedForm/DateFormatter+threadSpecific.swift
+++ b/Sources/Vapor/URLEncodedForm/DateFormatter+threadSpecific.swift
@@ -1,3 +1,4 @@
+import Foundation
 import NIO
 
 fileprivate final class ISO8601 {

--- a/Sources/Vapor/URLEncodedForm/DateFormatter+threadSpecific.swift
+++ b/Sources/Vapor/URLEncodedForm/DateFormatter+threadSpecific.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOPosix
 
 fileprivate final class ISO8601 {
     fileprivate static let threadSpecific: ThreadSpecificVariable<ISO8601DateFormatter> = .init()

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormData.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormData.swift
@@ -1,3 +1,5 @@
+import Logging
+
 /// Keeps track if the string was percent encoded or not.
 /// Prevents double encoding/double decoding
 enum URLQueryFragment: ExpressibleByStringLiteral, Equatable {

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import Foundation
+import NIOHTTP1
+
 /// Decodes instances of `Decodable` types from `application/x-www-form-urlencoded` `Data`.
 ///
 ///     print(data) // "name=Vapor&age=3"

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -1,3 +1,7 @@
+import Foundation
+import NIOHTTP1
+import NIOCore
+
 /// Encodes `Encodable` instances to `application/x-www-form-urlencoded` data.
 ///
 ///     print(user) /// User

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormError.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormError.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 /// Errors thrown while encoding/decoding `application/x-www-form-urlencoded` data.
 enum URLEncodedFormError: Error {
     case malformedKey(key: Substring)

--- a/Sources/Vapor/URLEncodedForm/URLQueryFragmentConvertible.swift
+++ b/Sources/Vapor/URLEncodedForm/URLQueryFragmentConvertible.swift
@@ -1,4 +1,4 @@
-import struct Foundation.Decimal
+import Foundation
 
 /// Capable of converting to / from `URLQueryFragment`.
 protocol URLQueryFragmentConvertible {

--- a/Sources/Vapor/Utilities/AnyResponse.swift
+++ b/Sources/Vapor/Utilities/AnyResponse.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 /// A type erased response useful for routes that can return more than one type.
 ///
 ///     router.get("foo") { req -> AnyResponse in

--- a/Sources/Vapor/Utilities/DataProtocol+Copy.swift
+++ b/Sources/Vapor/Utilities/DataProtocol+Copy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension DataProtocol {
     func copyBytes() -> [UInt8] {
         Array(self)

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -3,6 +3,7 @@ import Glibc
 #else
 import Darwin.C
 #endif
+import Logging
 
 /// `DirectoryConfiguration` represents a configured working directory.
 /// It can also be used to derive a working directory automatically.

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -3,6 +3,9 @@ import Glibc
 #else
 import Darwin
 #endif
+import Logging
+import NIOCore
+import NIOPosix
 
 /// Reads dotenv (`.env`) files and loads them into the current process.
 ///

--- a/Sources/Vapor/Utilities/File.swift
+++ b/Sources/Vapor/Utilities/File.swift
@@ -1,3 +1,6 @@
+import Foundation
+import NIOCore
+
 /// Represents a single file.
 public struct File: Codable, Equatable {
     /// Name of the file, including extension.

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -1,4 +1,7 @@
-import NIO
+import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
 import Logging
 
 extension Request {

--- a/Sources/Vapor/Utilities/LifecycleHandler.swift
+++ b/Sources/Vapor/Utilities/LifecycleHandler.swift
@@ -1,5 +1,3 @@
-import NIO
-
 public protocol LifecycleHandler {
     func willBoot(_ application: Application) throws
     func didBoot(_ application: Application) throws

--- a/Sources/Vapor/Utilities/OptionalType.swift
+++ b/Sources/Vapor/Utilities/OptionalType.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension EventLoopFuture where Value: OptionalType {
     /// Unwraps an `Optional` value contained inside a Future's expectation.
     /// If the optional resolves to `nil` (`.none`), the supplied error will be thrown instead.

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -1,3 +1,4 @@
+import Foundation
 import NIO
 
 /// An internal helper that formats cookie dates as RFC1123

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIOPosix
+import NIOCore
 
 /// An internal helper that formats cookie dates as RFC1123
 private final class RFC1123 {

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOPosix
 
 /// An internal helper that formats cookie dates as RFC1123
 private final class RFC1123 {

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -1,3 +1,5 @@
+import Logging
+
 /// A container providing arbitrary storage for extensions of an existing type, designed to obviate
 /// the problem of being unable to add stored properties to a type in an extension. Each stored item
 /// is keyed by a type conforming to ``StorageKey`` protocol.

--- a/Sources/Vapor/Utilities/String+IsIPAddress.swift
+++ b/Sources/Vapor/Utilities/String+IsIPAddress.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension String {
     func isIPAddress() -> Bool {
         // We need some scratch space to let inet_pton write into.

--- a/Sources/Vapor/Utilities/Thread.swift
+++ b/Sources/Vapor/Utilities/Thread.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Thread {
     /// Convenience wrapper around `Thread.detachNewThread`.
     public static func async(_ work: @escaping () -> ()) {

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct Validations {
     var storage: [Validation]
     

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -1,3 +1,5 @@
+import NIOHTTP1
+
 public struct ValidationsResult {
     public let results: [ValidationResult]
     

--- a/Sources/Vapor/Validation/Validators/CharacterSet.swift
+++ b/Sources/Vapor/Validation/Validators/CharacterSet.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Validator where T == String {
     /// Validates that all characters in a `String` are ASCII (bytes 0..<128).
     public static var ascii: Validator {

--- a/Sources/Vapor/Validation/Validators/URL.swift
+++ b/Sources/Vapor/Validation/Validators/URL.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Validator where T == String {
     /// Validates whether a `String` is a valid URL.
     ///

--- a/Sources/Vapor/View/PlaintextRenderer.swift
+++ b/Sources/Vapor/View/PlaintextRenderer.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import NIOPosix
+import Logging
+
 public struct PlaintextRenderer: ViewRenderer {
     public let eventLoopGroup: EventLoopGroup
     private let fileio: NonBlockingFileIO

--- a/Sources/Vapor/View/View.swift
+++ b/Sources/Vapor/View/View.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 public struct View: ResponseEncodable {
     public var data: ByteBuffer
 

--- a/Sources/Vapor/View/ViewRenderer.swift
+++ b/Sources/Vapor/View/ViewRenderer.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 public protocol ViewRenderer {
     func `for`(_ request: Request) -> ViewRenderer
     func render<E>(_ name: String, _ context: E) -> EventLoopFuture<View>

--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,2 +1,6 @@
+#if !BUILDING_DOCC
+
 @_exported import XCTest
 @_exported import Vapor
+
+#endif

--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,2 +1,2 @@
-@_exported import XCTest
-@_exported import Vapor
+//@_exported import XCTest
+//@_exported import Vapor

--- a/Sources/XCTVapor/Exports.swift
+++ b/Sources/XCTVapor/Exports.swift
@@ -1,2 +1,2 @@
-//@_exported import XCTest
-//@_exported import Vapor
+@_exported import XCTest
+@_exported import Vapor

--- a/Sources/XCTVapor/Utilities.swift
+++ b/Sources/XCTVapor/Utilities.swift
@@ -1,3 +1,5 @@
+import NIOCore
+
 extension ByteBuffer {
     public var string: String {
         .init(decoding: self.readableBytesView, as: UTF8.self)

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -1,3 +1,9 @@
+import AsyncHTTPClient
+import NIOCore
+import NIOHTTP1
+import XCTest
+import Vapor
+
 extension Application: XCTApplicationTester {
     public func performTest(request: XCTHTTPRequest) throws -> XCTHTTPResponse {
          try self.testable().performTest(request: request)

--- a/Sources/XCTVapor/XCTHTTPRequest.swift
+++ b/Sources/XCTVapor/XCTHTTPRequest.swift
@@ -1,3 +1,7 @@
+import NIOCore
+import NIOHTTP1
+import Vapor
+
 public struct XCTHTTPRequest {
     public var method: HTTPMethod
     public var url: URI

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -1,3 +1,8 @@
+import NIOCore
+import NIOHTTP1
+import Vapor
+import XCTest
+
 public struct XCTHTTPResponse {
     public var status: HTTPStatus
     public var headers: HTTPHeaders

--- a/Sources/XCTVapor/XCTVaporTests.swift
+++ b/Sources/XCTVapor/XCTVaporTests.swift
@@ -1,3 +1,6 @@
+import Vapor
+import XCTest
+
 /**
  We recommend configuring this in your test’s `class func setUp()`
  */

--- a/Tests/AsyncTests/AsyncAuthTests.swift
+++ b/Tests/AsyncTests/AsyncAuthTests.swift
@@ -1,5 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import Vapor
+import XCTest
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncAuthenticationTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncCacheTests.swift
+++ b/Tests/AsyncTests/AsyncCacheTests.swift
@@ -1,5 +1,8 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncCacheTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -1,6 +1,10 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import Vapor
 import XCTest
+import XCTVapor
+import NIOCore
+import Logging
+import NIOEmbedded
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncClientTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -78,6 +78,7 @@ final class AsyncClientTests: XCTestCase {
 
     func testBoilerplateClient() async throws {
         let app = Application(.testing)
+        app.http.server.configuration.port = 0
         defer { app.shutdown() }
 
         app.get("foo") { req async throws -> String in
@@ -95,8 +96,15 @@ final class AsyncClientTests: XCTestCase {
         app.environment.arguments = ["serve"]
         try app.boot()
         try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
 
-        let res = try await app.client.get("http://localhost:8080/foo")
+        let res = try await app.client.get("http://localhost:\(port)/foo")
         XCTAssertEqual(res.body?.string, "bar")
 
         try await app.running?.onStop.get()

--- a/Tests/AsyncTests/AsyncMiddlewareTests.swift
+++ b/Tests/AsyncTests/AsyncMiddlewareTests.swift
@@ -1,5 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncMiddlewareTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncPasswordTests.swift
+++ b/Tests/AsyncTests/AsyncPasswordTests.swift
@@ -1,5 +1,7 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncPasswordTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncRequestTests.swift
+++ b/Tests/AsyncTests/AsyncRequestTests.swift
@@ -1,5 +1,8 @@
 #if compiler(>=5.7) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 fileprivate extension String {
     static func randomDigits(length: Int = 999) -> String {

--- a/Tests/AsyncTests/AsyncRouteTests.swift
+++ b/Tests/AsyncTests/AsyncRouteTests.swift
@@ -1,5 +1,8 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
+import NIOHTTP1
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncRouteTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -1,5 +1,8 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
+import XCTest
+import Vapor
+import NIOHTTP1
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncSessionTests: XCTestCase {

--- a/Tests/AsyncTests/AsyncWebSocketTests.swift
+++ b/Tests/AsyncTests/AsyncWebSocketTests.swift
@@ -81,12 +81,21 @@ final class AsyncWebSocketTests: XCTestCase {
             ws.send("foo")
             ws.close(promise: nil)
         }
+        app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
 
         try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+        
         let promise = app.eventLoopGroup.next().makePromise(of: String.self)
         WebSocket.connect(
-            to: "ws://localhost:8080/foo",
+            to: "ws://localhost:\(port)/foo",
             on: app.eventLoopGroup.next()
         ) { ws in
             // do nothing
@@ -103,7 +112,7 @@ final class AsyncWebSocketTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.http.server.configuration.port = 8080
+        app.http.server.configuration.port = 0
 
         app.get("foo") { req in
             return req.webSocket { req, ws in
@@ -115,9 +124,17 @@ final class AsyncWebSocketTests: XCTestCase {
         app.environment.arguments = ["serve"]
 
         try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+        
         let promise = app.eventLoopGroup.next().makePromise(of: String.self)
         WebSocket.connect(
-            to: "ws://localhost:8080/foo",
+            to: "ws://localhost:\(port)/foo",
             on: app.eventLoopGroup.next()
         ) { ws in
             ws.onText { ws, string in

--- a/Tests/AsyncTests/AsyncWebSocketTests.swift
+++ b/Tests/AsyncTests/AsyncWebSocketTests.swift
@@ -1,6 +1,10 @@
 #if compiler(>=5.5) && canImport(_Concurrency)
 import XCTVapor
 import Vapor
+import XCTest
+import WebSocketKit
+import NIOCore
+import NIOPosix
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncWebSocketTests: XCTestCase {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -11,6 +11,7 @@ final class ApplicationTests: XCTestCase {
         let app = Application(test)
         defer { app.shutdown() }
         app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
         try app.start()
         guard let running = app.running else {
             XCTFail("app started without setting 'running'")
@@ -112,9 +113,17 @@ final class ApplicationTests: XCTestCase {
         }
 
         app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
         try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
 
-        let res = try app.client.get("http://localhost:8080/hello").wait()
+        let res = try app.client.get("http://localhost:\(port)/hello").wait()
         XCTAssertEqual(res.body?.string, "Hello, world!")
     }
 

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -2,6 +2,8 @@ import Vapor
 import XCTVapor
 import AsyncHTTPClient
 import XCTest
+import NIOCore
+import NIOEmbedded
 
 final class ApplicationTests: XCTestCase {
     func testApplicationStop() throws {

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -1,4 +1,8 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOPosix
 
 final class AuthenticationTests: XCTestCase {
     func testBearerAuthenticator() throws {

--- a/Tests/VaporTests/BaseNTests.swift
+++ b/Tests/VaporTests/BaseNTests.swift
@@ -1,6 +1,8 @@
 import XCTVapor
 import Algorithms
+import XCTest
 import Vapor
+import NIOCore
 
 final class Base32Tests: XCTestCase {
     func testBase32() throws {

--- a/Tests/VaporTests/BodyStreamStateTests.swift
+++ b/Tests/VaporTests/BodyStreamStateTests.swift
@@ -1,5 +1,6 @@
 @testable import Vapor
 import XCTest
+import NIOCore
 
 final class BodyStreamStateTests: XCTestCase {
     func testSynchronous() throws {

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class CacheTests: XCTestCase {
     func testInMemoryCache() throws {

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -106,10 +106,18 @@ final class ClientTests: XCTestCase {
         }
 
         app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
         try app.boot()
         try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
 
-        let res = try app.client.get("http://localhost:8080/foo").wait()
+        let res = try app.client.get("http://localhost:\(port)/foo").wait()
         XCTAssertEqual(res.body?.string, "bar")
 
         try app.running?.onStop.wait()

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -1,5 +1,9 @@
-import Vapor
 import XCTest
+import Vapor
+import NIOCore
+import Logging
+import AsyncHTTPClient
+import NIOEmbedded
 
 final class ClientTests: XCTestCase {
     func testClientConfigurationChange() throws {

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -1,4 +1,9 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOHTTP1
+import NIOEmbedded
 
 final class ContentTests: XCTestCase {
     func testContent() throws {

--- a/Tests/VaporTests/DotEnvTests.swift
+++ b/Tests/VaporTests/DotEnvTests.swift
@@ -1,5 +1,8 @@
 @testable import Vapor
 import XCTVapor
+import XCTest
+import NIOPosix
+import NIOCore
 
 final class DotEnvTests: XCTestCase {
     func testReadFile() throws {

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class EndpointCacheTests: XCTestCase {
     func testEndpointCacheNoCache() throws {

--- a/Tests/VaporTests/EnvironmentSecretTests.swift
+++ b/Tests/VaporTests/EnvironmentSecretTests.swift
@@ -1,5 +1,6 @@
 @testable import Vapor
 import XCTVapor
+import XCTest
 
 final class EnvironmentSecretTests: XCTestCase {
     func testNonExistingSecretFile() throws {

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Vapor
+import Logging
 
 final class ErrorTests: XCTestCase {
     func testPrintable() throws {

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -1,4 +1,8 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOHTTP1
 
 final class FileTests: XCTestCase {
     func testStreamFile() throws {

--- a/Tests/VaporTests/HTTPCacheTests.swift
+++ b/Tests/VaporTests/HTTPCacheTests.swift
@@ -1,5 +1,6 @@
 import Vapor
 import XCTest
+import NIOHTTP1
 
 class HTTPCacheTests: XCTestCase {
     func testNoStoreWithExpires() {

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -1,5 +1,6 @@
 @testable import Vapor
 import XCTest
+import NIOHTTP1
 
 final class HTTPHeaderTests: XCTestCase {
     func testValue() throws {

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -1,4 +1,6 @@
 import XCTVapor
+import Vapor
+import XCTest
 
 final class LoggingTests: XCTestCase {
     func testChangeRequestLogLevel() throws {

--- a/Tests/VaporTests/MetricsTests.swift
+++ b/Tests/VaporTests/MetricsTests.swift
@@ -2,6 +2,7 @@ import XCTVapor
 import Vapor
 import Metrics
 @testable import CoreMetrics
+import XCTest
 
 class MetricsTests: XCTestCase {
     func testMetricsIncreasesCounter() {

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class MiddlewareTests: XCTestCase {
     final class OrderMiddleware: Middleware {

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class PasswordTests: XCTestCase {
     func testSyncBCryptService() throws {

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -1,5 +1,7 @@
 @testable import Vapor
 import XCTest
+import NIOEmbedded
+import NIOCore
 
 final class PipelineTests: XCTestCase {
     func testEchoHandlers() throws {

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -1,4 +1,8 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOHTTP1
 
 final class QueryTests: XCTestCase {
     func testQuery() throws {

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class RequestTests: XCTestCase {
     

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -1,4 +1,8 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOHTTP1
 
 final class RouteTests: XCTestCase {
     func testParameter() throws {

--- a/Tests/VaporTests/SecurityTests.swift
+++ b/Tests/VaporTests/SecurityTests.swift
@@ -1,5 +1,6 @@
 import Vapor
 import XCTest
+import Crypto
 
 final class OTPTests: XCTestCase {
     /// Basic TOTP tests using some RFC 6238 test vectors.

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1,7 +1,8 @@
 import Vapor
 import XCTest
-import protocol AsyncHTTPClient.HTTPClientResponseDelegate
-import NIO
+import AsyncHTTPClient
+import NIOCore
+import NIOPosix
 import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOSSL

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -29,6 +29,7 @@ final class ServiceTests: XCTestCase {
     func testLifecycle() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
+        app.http.server.configuration.port = 0
 
         app.lifecycle.use(Hello())
         app.environment.arguments = ["serve"]

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class ServiceTests: XCTestCase {
     func testReadOnly() throws {

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -1,4 +1,8 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import NIOHTTP1
 
 final class SessionTests: XCTestCase {
     func testSessionDestroy() throws {

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -1,6 +1,6 @@
 @testable import Vapor
 import XCTest
-import NIO
+import NIOPosix
 
 final class URLEncodedFormTests: XCTestCase {
     // MARK: Codable

--- a/Tests/VaporTests/Utilities/ByteBuffer+Helpers.swift
+++ b/Tests/VaporTests/Utilities/ByteBuffer+Helpers.swift
@@ -1,4 +1,4 @@
-import Vapor
+import NIOCore
 
 extension ByteBuffer {
     init(string: String) {

--- a/Tests/VaporTests/Utilities/ResponderClient.swift
+++ b/Tests/VaporTests/Utilities/ResponderClient.swift
@@ -1,4 +1,5 @@
 import Vapor
+import NIOCore
 
 struct ResponderClient: Client {
     let responder: Responder

--- a/Tests/VaporTests/UtilityTests.swift
+++ b/Tests/VaporTests/UtilityTests.swift
@@ -1,5 +1,6 @@
 import XCTVapor
 @testable import Vapor
+import XCTest
 
 final class UtilityTests: XCTestCase {
     func testHexEncoding() throws {

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -1,5 +1,6 @@
-import Vapor
 import XCTest
+import Vapor
+import NIOCore
 
 class ValidationTests: XCTestCase {
     func testValidate() throws {

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -1,4 +1,7 @@
 import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
 
 final class ViewTests: XCTestCase {
     func testViewResponse() throws {

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -1,6 +1,8 @@
 import Vapor
 import NIOConcurrencyHelpers
 import XCTest
+import WebSocketKit
+import NIOPosix
 
 final class WebSocketTests: XCTestCase {
     func testWebSocketClient() throws {


### PR DESCRIPTION
Fixes up the imports in Vapor so it will build without exporting everything.

This allows us to avoid exports when building documentation and future proofs us.

Also run this through CI to avoid PRs breaking the docs
