### PR TITLE
Add support for Cache-Control header 'immutable' attribute

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
@@ -178,6 +178,7 @@ extension HTTPHeaders {
         }
 
         private static let exactMatch: [String: WritableKeyPath<Self, Bool>] = [
+            "immutable": \.immutable,
             "must-revalidate": \.mustRevalidate,
             "no-cache": \.noCache,
             "no-store": \.noStore,

--- a/Tests/VaporTests/HTTPCacheTests.swift
+++ b/Tests/VaporTests/HTTPCacheTests.swift
@@ -128,4 +128,12 @@ class HTTPCacheTests: XCTestCase {
         XCTAssertNotNil(cache.maxStale?.seconds)
         XCTAssertEqual(cache.maxStale?.seconds, 12)
     }
+
+    func testImmutable() {
+        let headers = HTTPHeaders(dictionaryLiteral: ("Cache-Control", "immutable"))
+        let response = ClientResponse(status: .ok, headers: headers)
+
+        let cache = response.headers.cacheControl!
+        XCTAssertTrue(cache.immutable)
+    }
 }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -419,4 +419,18 @@ final class HTTPHeaderTests: XCTestCase {
         XCTAssertEqual(date.expires.timeIntervalSince1970, 18*3600)
         XCTAssertEqual(date.serialize(), "Thu, 01 Jan 1970 18:00:00 GMT")
     }
+
+    /// Test parse and serialize of `Cache-Control` header
+    func testCacheControlHeader() throws {
+        var headers = HTTPHeaders()
+        headers.cacheControl = HTTPHeaders.CacheControl(immutable: true)
+
+        guard let cacheControl = headers.cacheControl else {
+            XCTFail("HTTPHeaders.CacheControl parsing failed")
+            return
+        }
+
+        XCTAssertEqual(cacheControl.serialize(), "immutable")
+
+    }
 }


### PR DESCRIPTION
Improve parsing of Cache-Control header to parse the `immutable` attribute.