### PR TITLE
Fix imports

### DIFF
--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -3,6 +3,7 @@ import NIOCore
 import NIOHTTP1
 import WebSocketKit
 import RoutingKit
+import Foundation
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Request {

--- a/Sources/Vapor/Routing/Request+WebSocket.swift
+++ b/Sources/Vapor/Routing/Request+WebSocket.swift
@@ -1,5 +1,6 @@
 import NIOCore
 import WebSocketKit
+import NIOHTTP1
 
 extension Request {
      public func webSocket(

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -1,5 +1,7 @@
 import RoutingKit
 import WebSocketKit
+import NIOCore
+import NIOHTTP1
 
 public struct WebSocketMaxFrameSize: ExpressibleByIntegerLiteral {
     let value: Int


### PR DESCRIPTION
With the recent release of WebSocketKit some stuff we were relying on is no longer exported so we need to explicitly import them now (as we should) when building our DocC archives
