### PR TITLE
Update Minimum Swift Version to 5.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - provider: vapor/apns
             ref: 3.0.0
     runs-on: ubuntu-latest
-    container: swift:5.7-jammy
+    container: swift:5.8
     steps: 
       - name: Check out Vapor
         uses: actions/checkout@v3

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5.2
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         <img src="https://github.com/vapor/vapor/actions/workflows/test.yml/badge.svg?branch=main" alt="Continuous Integration">
     </a>
     <a href="https://swift.org">
-        <img src="https://img.shields.io/badge/swift-5.5-brightgreen.svg" alt="Swift 5.5">
+        <img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6">
     </a>
     <a href="https://twitter.com/codevapor">
         <img src="https://img.shields.io/badge/twitter-codevapor-5AA9E7.svg" alt="Twitter">

--- a/Sources/Vapor/Utilities/BasicCodingKey.swift
+++ b/Sources/Vapor/Utilities/BasicCodingKey.swift
@@ -1,4 +1,4 @@
-#if swift(>=5.6) && os(Linux)
+#if os(Linux)
 public typealias CodingKeyRepresentable = Swift.CodingKeyRepresentable
 #else
 /// This is an unwelcome stand-in for the ``Swift/CodingKeyRepresentable`` protocol that appeared in Swift 5.6.


### PR DESCRIPTION
Inline with the Swift version support and NIO's supported version, this sets the minimum supported Swift version to 5.6 now that Swift 5.8 is released.

This is also the first step in adopting `Sendable` properly across Vapor
