### PR TITLE
Support range-requests beyond EOF. Return up to EOF.

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -262,11 +262,12 @@ extension HTTPHeaders.Range.Value {
             }
             return .withinWithLimit(start: (limit - end), end: limit - 1, limit: limit)
         case .within(let start, let end):
-            guard start >= 0, end >= 0, start < end, start <= limit, end <= limit else {
+            guard start >= 0, end >= 0, start < end, start <= limit else {
                 throw Abort(.badRequest)
             }
             
-            return .withinWithLimit(start: start, end: end, limit: limit)
+            let myEnd = min(end, limit)
+            return .withinWithLimit(start: start, end: myEnd, limit: limit)
         }
     }
 }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -265,6 +265,7 @@ public struct FileIO {
 extension HTTPHeaders.Range.Value {
     
     fileprivate func asByteBufferBounds(withMaxSize size: Int, logger: Logger) throws -> (offset: Int64, byteCount: Int) {
+
         switch self {
             case .start(let value):
                 guard value <= size, value >= 0 else {
@@ -279,7 +280,7 @@ extension HTTPHeaders.Range.Value {
                 }
                 return (offset: numericCast(size - value), byteCount: value)
             case .within(let start, let end):
-                guard start >= 0, end >= 0, start < end, start <= size, end <= size else {
+                guard start >= 0, end >= 0, start < end, start <= size else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
@@ -288,7 +289,8 @@ extension HTTPHeaders.Range.Value {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
-                return (offset: numericCast(start), byteCount: byteCount)
+                let myByteCount = end <= size ? byteCount : byteCount - (end - size)
+                return (offset: numericCast(start), byteCount: myByteCount)
         }
     }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Allow byte range requests to exceed EOF.

<!-- When this PR is merged, the title and body will be -->
Support HTTP/1.1 range requests past end-of-file.
 
<!-- used to generate a release automatically. -->
