### PR TITLE
Fix `Range: bytes=0-0` header not working properly

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -263,7 +263,7 @@ extension HTTPHeaders.Range.Value {
             }
             return .withinWithLimit(start: (limit - end), end: limit - 1, limit: limit)
         case .within(let start, let end):
-            guard start >= 0, end >= 0, start < end, start <= limit, end <= limit else {
+            guard start >= 0, end >= 0, start <= end, start <= limit, end <= limit else {
                 throw Abort(.badRequest)
             }
             

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -289,7 +289,7 @@ extension HTTPHeaders.Range.Value {
                 }
                 return (offset: numericCast(size - value), byteCount: value)
             case .within(let start, let end):
-                guard start >= 0, end >= 0, start < end, start <= size, end <= size else {
+                guard start >= 0, end >= 0, start <= end, start <= size, end <= size else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -162,6 +162,33 @@ final class FileTests: XCTestCase {
             XCTAssertTrue(range == length)
         }
     }
+
+    func testStreamFileContentHeadersOnlyFirstByte() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        app.get("file-stream") { req in
+            return req.fileio.streamFile(at: #file) { result in
+                do {
+                    try result.get()
+                } catch {
+                    XCTFail("File Stream should have succeeded")
+                }
+            }
+        }
+
+        var headers = HTTPHeaders()
+        headers.range = .init(unit: .bytes, ranges: [.within(start: 0, end: 0)])
+        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+            XCTAssertEqual(res.status, .partialContent)
+
+            XCTAssertEqual(res.headers.first(name: .contentLength), "1")
+            let range = res.headers.first(name: .contentRange)!.split(separator: "/").first!.split(separator: " ").last!
+            XCTAssertEqual(range, "0-0")
+
+            XCTAssertEqual(res.body.readableBytes, 1)
+        }
+    }
     
     func testStreamFileContentHeadersWithinFail() throws {
         let app = Application(.testing)


### PR DESCRIPTION
This aims to fix the bug found in https://discord.com/channels/431917998102675485/519613337638797315/1104341522473812039, which returned a `Bad Response` rather then returning the first byte of the requested content when the `Range: bytes=0-0` request header was used