### PR TITLE
Improved error logging

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -5,27 +5,7 @@ on:
     types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
 
 jobs:
-  setup_matrix_input:
-    runs-on: ubuntu-latest
-
-    steps:
-      - id: set-matrix 
-        run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name') || output=""
-
-          echo '======================'
-          echo 'Process incoming data'
-          echo '======================'
-          json=$(echo $output | sed 's/"\s"/","/g')
-          echo $json
-          echo "::set-output name=matrix::$(echo $json)"
-    outputs:
-      issueTags: ${{ steps.set-matrix.outputs.matrix }}
-      
-  Manage_project_issues:
-    needs: setup_matrix_input
-    uses: vapor/ci/.github/workflows/issues-to-project-board.yml@main
-    with:
-      labelsJson: ${{ needs.setup_matrix_input.outputs.issueTags }}
-    secrets: 
-      PROJECT_BOARD_AUTOMATION_PAT: "${{ secrets.PROJECT_BOARD_AUTOMATION_PAT }}"
+  update_project_boards:
+    name: Update project boards
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - provider: vapor/apns
             ref: 3.0.0
     runs-on: ubuntu-latest
-    container: swift:5.8
+    container: swift:5.8-jammy
     steps: 
       - name: Check out Vapor
         uses: actions/checkout@v3
@@ -40,12 +40,11 @@ jobs:
       - name: Run tests
         env:
             SWIFT_DETERMINISTIC_HASHING: 1
-        run: swift test
-        working-directory: provider
+        run: swift test --package-path ./provider
 
   unit-tests:
      uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
      with:
-       with_coverage: false
+       with_coverage: true
        with_tsan: false
        with_public_api_check: true

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -32,12 +32,8 @@ extension Logger {
             reason = localized.localizedDescription
             source = nil
             level = .warning
-        case let convertible as CustomStringConvertible:
-            reason = convertible.description
-            source = nil
-            level = .warning
         default:
-            reason = "\(error)"
+            reason = String(reflecting: error)
             source = nil
             level = .warning
         }


### PR DESCRIPTION
Some kinds of errors provide additional "debug" information, which can give much more detail than the "plain" description of the error. In many cases this debug info can contain sensitive data, such as specifics about a database schema, so Vapor only uses the plain description when sending errors to clients (and in release environments, _all_ details are suppressed).

To date, the plain description has also been used for logging errors. This can make it very difficult for developers to figure out what's going wrong with their code if the error in question only provides meaningful information in its debug data - for example, the PostgreSQL database driver implementation does this rather than relying on a higher-level layer like Vapor to obfuscate potentially sensitive information. This PR changes the logging of errors to include the debug information (and _only_ the logging; the responses sent to clients are unchanged).