### PR TITLE
add `ContentContainer.decode(_:as:)`

### DIFF
--- a/Sources/Vapor/Content/ContentContainer.swift
+++ b/Sources/Vapor/Content/ContentContainer.swift
@@ -34,6 +34,12 @@ extension ContentContainer {
         return content
     }
 
+    /// Use the default decoder for the ``contentType`` passed, to read a value of type `D`
+    /// from the container.
+    public func decode<D: Decodable>(_: D.Type, as contentType: HTTPMediaType) throws -> D {
+        try self.decode(D.self, using: self.configuredDecoder(for: contentType))
+    }
+
     // MARK: - Encoding helpers
 
     /// Serialize a ``Content`` object to the container as its default content type.
@@ -115,8 +121,8 @@ extension ContentContainer {
     }
     
     /// Look up a ``ContentDecoder`` for the container's ``contentType``.
-    private func configuredDecoder() throws -> ContentDecoder {
-        guard let contentType = self.contentType else {
+    private func configuredDecoder(for mediaType: HTTPMediaType? = nil) throws -> ContentDecoder {
+        guard let contentType = mediaType ?? self.contentType else {
             throw Abort(.unsupportedMediaType, reason: "Can't decode data without a content type")
         }
         return try ContentConfiguration.global.requireDecoder(for: contentType)

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -261,13 +261,13 @@ final class RequestTests: XCTestCase {
         app.http.client.configuration.redirectConfiguration = .disallow
 
         app.get("redirect_normal") {
-            $0.redirect(to: "foo", type: .normal)
+            $0.redirect(to: "foo", redirectType: .normal)
         }
         app.get("redirect_permanent") {
-            $0.redirect(to: "foo", type: .permanent)
+            $0.redirect(to: "foo", redirectType: .permanent)
         }
         app.post("redirect_temporary") {
-            $0.redirect(to: "foo", type: .temporary)
+            $0.redirect(to: "foo", redirectType: .temporary)
         }
         
         try app.server.start(address: .hostname("localhost", port: 8080))


### PR DESCRIPTION
This came up in a conversation were both Tim and I were expecting such a function, but realized there it isn't there. 
The fact that we expected it is probably because there is a `ContentContainer.encode(_:as:)`, but no `decode(_:as:)`. 
This should be useful to users that are trying to decode content of a request with a bad/unexpected content-type header.