### PR TITLE
Allow specifying a timeout for client requests

### DIFF
--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -7,6 +7,7 @@ public struct ClientRequest {
     public var url: URI
     public var headers: HTTPHeaders
     public var body: ByteBuffer?
+    public var timeout: TimeAmount?
     private let byteBufferAllocator: ByteBufferAllocator
 
     public init(
@@ -14,12 +15,14 @@ public struct ClientRequest {
         url: URI = "/",
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
+        timeout: TimeAmount? = nil,
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()
     ) {
         self.method = method
         self.url = url
         self.headers = headers
         self.body = body
+        self.timeout = timeout
         self.byteBufferAllocator = byteBufferAllocator
     }
 }

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -15,7 +15,7 @@ public struct ClientRequest {
         url: URI = "/",
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        timeout: TimeAmount? = nil,
+        timeout: TimeAmount?,
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()
     ) {
         self.method = method
@@ -24,6 +24,21 @@ public struct ClientRequest {
         self.body = body
         self.timeout = timeout
         self.byteBufferAllocator = byteBufferAllocator
+    }
+
+    public init(
+        method: HTTPMethod = .GET,
+        url: URI = "/",
+        headers: HTTPHeaders = [:],
+        body: ByteBuffer? = nil,
+        byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()
+    ) {
+        self.init(method: method,
+                  url: url,
+                  headers: headers,
+                  body: body,
+                  timeout: nil,
+                  byteBufferAllocator: byteBufferAllocator)
     }
 }
 

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -38,6 +38,7 @@ private struct EventLoopHTTPClient: Client {
             return self.http.execute(
                 request: request,
                 eventLoop: .delegate(on: self.eventLoop),
+                deadline: client.timeout.map { .now() + $0 },
                 logger: logger
             ).map { response in
                 let client = ClientResponse(


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

Adds a `timeout` property to `ClientRequest`, which is forwarded to `HTTPClient` by `EventLoopHTTPClient`.
To use it, the `beforeSend` closure can be used:

```swift
request.client.get("http://example.com") {
    $0.timeout = .seconds(5)
}
```