### PR TITLE
Make Response Sendable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
@@ -131,3 +131,12 @@ let package = Package(
         ]),
     ]
 )
+
+
+//if ProcessInfo.processInfo.environment["STRICT_CONCURRENCY"] == "true" {
+    for target in package.targets {
+        if !target.isTest {
+            target.swiftSettings = [.unsafeFlags(["-Xfrontend", "-strict-concurrency=complete"])]
+        }
+    }
+//}

--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -1,6 +1,6 @@
 import NIOCore
 
-public enum BodyStreamResult {
+public enum BodyStreamResult: Sendable {
     /// A normal data chunk.
     /// There will be 0 or more of these.
     case buffer(ByteBuffer)
@@ -39,7 +39,7 @@ extension BodyStreamResult: CustomDebugStringConvertible {
     }
 }
 
-public protocol BodyStreamWriter {
+public protocol BodyStreamWriter: Sendable {
     var eventLoop: EventLoop { get }
     func write(_ result: BodyStreamResult, promise: EventLoopPromise<Void>?)
 }

--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -39,7 +39,7 @@ extension BodyStreamResult: CustomDebugStringConvertible {
     }
 }
 
-public protocol BodyStreamWriter: Sendable {
+public protocol BodyStreamWriter {
     var eventLoop: EventLoop { get }
     func write(_ result: BodyStreamResult, promise: EventLoopPromise<Void>?)
 }

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -28,7 +28,7 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
             self.errorCaught(context: context, error: error)
         case .success(let response):
             if request.method == .HEAD {
-                response.forHeadRequest = true
+                response.forHeadRequest.withLockedValue { $0 = true }
             }
             self.serialize(response, for: request, context: context)
         }

--- a/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerResponseEncoder.swift
@@ -34,7 +34,7 @@ final class HTTPServerResponseEncoder: ChannelOutboundHandler, RemovableChannelH
         ))), promise: nil)
 
         
-        if response.status == .noContent || response.forHeadRequest {
+        if response.status == .noContent || response.forHeadRequest.withLockedValue({ $0 }) {
             // don't send bodies for 204 (no content) responses
             // or HEAD requests
             context.fireUserInboundEventTriggered(ResponseEndSentEvent())

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -105,7 +105,7 @@ public final class Response: Sendable, CustomStringConvertible {
 
     // MARK: Content
 
-    private struct _ContentContainer: ContentContainer {
+    private struct _ContentContainer: Sendable, ContentContainer {
         let response: Response
 
         var contentType: HTTPMediaType? {

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -1,26 +1,48 @@
 import NIOCore
 import NIOHTTP1
 import NIOFoundationCompat
+import NIOConcurrencyHelpers
 
 /// An HTTP response from a server back to the client.
 ///
 ///     let res = Response(status: .ok)
 ///
 /// See `HTTPClient` and `HTTPServer`.
-public final class Response: CustomStringConvertible {
+public final class Response: Sendable, CustomStringConvertible {
     /// Maximum streaming body size to use for `debugPrint(_:)`.
     private let maxDebugStreamingBodySize: Int = 1_000_000
 
     /// The HTTP version that corresponds to this response.
-    public var version: HTTPVersion
+    public var version: HTTPVersion {
+        get {
+            self._version.withLockedValue { $0 }
+        }
+        set {
+            self._version.withLockedValue { $0 = newValue }
+        }
+    }
     
     /// The HTTP response status.
-    public var status: HTTPResponseStatus
+    public var status: HTTPResponseStatus {
+        get {
+            return _status.withLockedValue { $0 }
+        }
+        set {
+            _status.withLockedValue { $0 = newValue }
+        }
+    }
     
     /// The header fields for this HTTP response.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.
-    public var headers: HTTPHeaders
+    public var headers: HTTPHeaders {
+        get {
+            return _headers.withLockedValue { $0 }
+        }
+        set {
+            _headers.withLockedValue { $0 = newValue }
+        }
+    }
     
     /// The `Body`. Updating this property will also update the associated transport headers.
     ///
@@ -29,17 +51,37 @@ public final class Response: CustomStringConvertible {
     /// Also be sure to set this message's `contentType` property to a `MediaType` that correctly
     /// represents the `Body`.
     public var body: Body {
-        didSet { self.headers.updateContentLength(self.body.count) }
+        get {
+            return _body.withLockedValue { $0 }
+        }
+        set {
+            _body.withLockedValue { $0 = newValue }
+            self.headers.updateContentLength(newValue.count)
+        }
     }
 
     // If `true`, don't serialize the body.
-    var forHeadRequest: Bool
+    let forHeadRequest: NIOLockedValueBox<Bool>
     
     /// Optional Upgrade behavior to apply to this response.
     /// currently, websocket upgrades are the only defined case.
-    public var upgrader: Upgrader?
+    public var upgrader: Upgrader? {
+        get {
+            return _upgrader.withLockedValue { $0 }
+        }
+        set {
+            _upgrader.withLockedValue { $0 = newValue }
+        }
+    }
 
-    public var storage: Storage
+    public var storage: Storage {
+        get {
+            return _storage.withLockedValue { $0 }
+        }
+        set {
+            _storage.withLockedValue { $0 = newValue }
+        }
+    }
     
     /// Get and set `HTTPCookies` for this `Response`.
     /// This accesses the `"Set-Cookie"` header.
@@ -110,6 +152,13 @@ public final class Response: CustomStringConvertible {
         }
     }
     
+    private let _version: NIOLockedValueBox<HTTPVersion>
+    private let _status: NIOLockedValueBox<HTTPStatus>
+    private let _headers: NIOLockedValueBox<HTTPHeaders>
+    private let _body: NIOLockedValueBox<Body>
+    private let _upgrader: NIOLockedValueBox<Upgrader?>
+    private let _storage: NIOLockedValueBox<Storage>
+    
     // MARK: Init
     
     /// Creates a new `Response`.
@@ -146,13 +195,14 @@ public final class Response: CustomStringConvertible {
         version: HTTPVersion,
         headersNoUpdate headers: HTTPHeaders,
         body: Body
-    ) {
-        self.status = status
-        self.version = version
-        self.headers = headers
-        self.body = body
-        self.storage = .init()
-        self.forHeadRequest = false
+    ) {        
+        self._status = .init(status)
+        self._version = .init(version)
+        self._headers = .init(headers)
+        self._body = .init(body)
+        self._storage = .init(.init())
+        self.forHeadRequest = .init(false)
+        self._upgrader = .init(nil)
     }
 }
 

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -3,7 +3,7 @@ import WebSocketKit
 import NIOCore
 import NIOHTTP1
 
-public struct WebSocketMaxFrameSize: ExpressibleByIntegerLiteral {
+public struct WebSocketMaxFrameSize: Sendable, ExpressibleByIntegerLiteral {
     let value: Int
 
     public init(integerLiteral value: Int) {

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -112,6 +112,7 @@ protocol AnyStorageValue: Sendable {
 }
 
 /// A key used to store values in a ``Storage`` must conform to this protocol.
+@preconcurrency
 public protocol StorageKey {
     /// The type of the stored value associated with this key type.
     associatedtype Value: Sendable

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -3,14 +3,15 @@ import Logging
 /// A container providing arbitrary storage for extensions of an existing type, designed to obviate
 /// the problem of being unable to add stored properties to a type in an extension. Each stored item
 /// is keyed by a type conforming to ``StorageKey`` protocol.
-public struct Storage {
+public struct Storage: Sendable {
     /// The internal storage area.
     var storage: [ObjectIdentifier: AnyStorageValue]
 
     /// A container for a stored value and an associated optional `deinit`-like closure.
-    struct Value<T>: AnyStorageValue {
+    @preconcurrency
+    struct Value<T: Sendable>: AnyStorageValue {
         var value: T
-        var onShutdown: ((T) throws -> ())?
+        var onShutdown: (@Sendable (T) throws -> ())?
         func shutdown(logger: Logger) {
             do {
                 try self.onShutdown?(self.value)
@@ -82,7 +83,7 @@ public struct Storage {
     public mutating func set<Key>(
         _ key: Key.Type,
         to value: Key.Value?,
-        onShutdown: ((Key.Value) throws -> ())? = nil
+        onShutdown: (@Sendable (Key.Value) throws -> ())? = nil
     )
         where Key: StorageKey
     {
@@ -106,12 +107,12 @@ public struct Storage {
 
 /// ``Storage`` uses this protocol internally to generically invoke shutdown closures for arbitrarily-
 /// typed key values.
-protocol AnyStorageValue {
+protocol AnyStorageValue: Sendable {
     func shutdown(logger: Logger)
 }
 
 /// A key used to store values in a ``Storage`` must conform to this protocol.
 public protocol StorageKey {
     /// The type of the stored value associated with this key type.
-    associatedtype Value
+    associatedtype Value: Sendable
 }

--- a/Tests/AsyncTests/AsyncServerTests.swift
+++ b/Tests/AsyncTests/AsyncServerTests.swift
@@ -1,0 +1,93 @@
+import XCTVapor
+@testable import Vapor
+import AsyncHTTPClient
+
+final class AsyncServerTests: XCTestCase {
+    func testDoesNotHitAssertionWhenWritingOffEventLoop() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        final class Context {
+            var server: [String]
+            var client: [String]
+            init() {
+                self.server = []
+                self.client = []
+            }
+        }
+        let context = Context()
+
+        app.on(.POST, "echo", body: .stream) { request -> Response in
+            Response(body: .init(stream: { writer in
+                request.body.drain { body in
+                    switch body {
+                    case .buffer(let buffer):
+                        context.server.append(buffer.string)
+                        return app.eventLoopGroup.next().makeFutureWithTask {
+                            Task {
+                                writer.write(.buffer(buffer))
+                            }
+                        }
+                    case .error(let error):
+                        return writer.write(.error(error))
+                    case .end:
+                        return writer.write(.end)
+                    }
+                }
+            }))
+        }
+
+        app.http.server.configuration.port = 0
+        app.environment.arguments = ["serve"]
+        try app.start()
+        
+        guard let localAddress = app.http.server.shared.localAddress, let port = localAddress.port else {
+            XCTFail("couldn't get port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        let request = try HTTPClient.Request(
+            url: "http://localhost:\(port)/echo",
+            method: .POST,
+            headers: [
+                "transfer-encoding": "chunked"
+            ],
+            body: .stream(length: nil, { stream in
+                stream.write(.byteBuffer(.init(string: "foo"))).flatMap {
+                    stream.write(.byteBuffer(.init(string: "bar")))
+                }.flatMap {
+                    stream.write(.byteBuffer(.init(string: "baz")))
+                }
+            })
+        )
+
+        final class ResponseDelegate: HTTPClientResponseDelegate {
+            typealias Response = HTTPClient.Response
+
+            let context: Context
+            init(context: Context) {
+                self.context = context
+            }
+
+            func didReceiveBodyPart(
+                task: HTTPClient.Task<HTTPClient.Response>,
+                _ buffer: ByteBuffer
+            ) -> EventLoopFuture<Void> {
+                self.context.client.append(buffer.string)
+                return task.eventLoop.makeSucceededFuture(())
+            }
+
+            func didFinishRequest(task: HTTPClient.Task<HTTPClient.Response>) throws -> HTTPClient.Response {
+                .init(host: "", status: .ok, version: .init(major: 1, minor: 1), headers: [:], body: nil)
+            }
+        }
+        let response = ResponseDelegate(context: context)
+        _ = try app.http.client.shared.execute(
+            request: request,
+            delegate: response
+        ).wait()
+
+        XCTAssertEqual(context.server, ["foo", "bar", "baz"])
+        XCTAssertEqual(context.client, ["foo", "bar", "baz"])
+    }
+}


### PR DESCRIPTION
Makes `Response` `Sendable` as well as the types that it uses.

> **Note:** `Storage` and therefore anything put into `Storage` is now annotated as `Storage`. For most things, this should be fine but for anything that can't be `Sendable` like Fluent's `Model` you may need to either wrap these in a `NIOLoopBound` or find another solution