### PR TITLE
Make Storage Sendable

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -174,15 +174,14 @@ public final class Application: Sendable {
     }
 
     public func boot() throws {
-        self.isBooted.withLockedValue { booted in
+        try self.isBooted.withLockedValue { booted in
             guard !booted else {
                 return
             }
             booted = true
+            try self.lifecycle.handlers.forEach { try $0.willBoot(self) }
+            try self.lifecycle.handlers.forEach { try $0.didBoot(self) }
         }
-        
-        try self.lifecycle.handlers.forEach { try $0.willBoot(self) }
-        try self.lifecycle.handlers.forEach { try $0.didBoot(self) }
     }
     
     public func shutdown() {

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -6,16 +6,41 @@ import ConsoleKit
 import NIOPosix
 
 /// Core type representing a Vapor application.
-public final class Application {
-    public var environment: Environment
-    public let eventLoopGroupProvider: EventLoopGroupProvider
-    public let eventLoopGroup: EventLoopGroup
-    public var storage: Storage
-    public private(set) var didShutdown: Bool
-    public var logger: Logger
-    var isBooted: Bool
+public final class Application: Sendable {
+    public var environment: Environment {
+        get {
+            self._environment.withLockedValue { $0 }
+        }
+        set {
+            self._environment.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    public var storage: Storage {
+        get {
+            self._storage.withLockedValue { $0 }
+        }
+        set {
+            self._storage.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    public var didShutdown: Bool {
+        get {
+            self._didShutdown.withLockedValue { $0 }
+        }
+    }
+    
+    public var logger: Logger {
+        get {
+            self._logger.withLockedValue { $0 }
+        }
+        set {
+            self._logger.withLockedValue { $0 = newValue }
+        }
+    }
 
-    public struct Lifecycle {
+    public struct Lifecycle: Sendable {
         var handlers: [LifecycleHandler]
         init() {
             self.handlers = []
@@ -26,7 +51,14 @@ public final class Application {
         }
     }
 
-    public var lifecycle: Lifecycle
+    public var lifecycle: Lifecycle {
+        get {
+            self._lifecycle.withLockedValue { $0 }
+        }
+        set {
+            self._lifecycle.withLockedValue { $0 = newValue }
+        }
+    }
 
     public final class Locks {
         public let main: NIOLock
@@ -44,23 +76,40 @@ public final class Application {
         }
     }
 
-    public var locks: Locks
+    public var locks: Locks {
+        get {
+            self._locks.withLockedValue { $0 }
+        }
+        set {
+            self._locks.withLockedValue { $0 = newValue }
+        }
+    }
 
     public var sync: NIOLock {
         self.locks.main
     }
     
-    public enum EventLoopGroupProvider {
+    public enum EventLoopGroupProvider: Sendable {
         case shared(EventLoopGroup)
         case createNew
     }
+    
+    public let eventLoopGroupProvider: EventLoopGroupProvider
+    public let eventLoopGroup: EventLoopGroup
+    internal let isBooted: NIOLockedValueBox<Bool>
+    private let _environment: NIOLockedValueBox<Environment>
+    private let _storage: NIOLockedValueBox<Storage>
+    private let _didShutdown: NIOLockedValueBox<Bool>
+    private let _logger: NIOLockedValueBox<Logger>
+    private let _lifecycle: NIOLockedValueBox<Lifecycle>
+    private let _locks: NIOLockedValueBox<Locks>
 
     public init(
         _ environment: Environment = .development,
         _ eventLoopGroupProvider: EventLoopGroupProvider = .createNew
     ) {
         Backtrace.install()
-        self.environment = environment
+        self._environment = .init(environment)
         self.eventLoopGroupProvider = eventLoopGroupProvider
         switch eventLoopGroupProvider {
         case .shared(let group):
@@ -68,12 +117,13 @@ public final class Application {
         case .createNew:
             self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         }
-        self.locks = .init()
-        self.didShutdown = false
-        self.logger = .init(label: "codes.vapor.application")
-        self.storage = .init(logger: self.logger)
-        self.lifecycle = .init()
-        self.isBooted = false
+        self._locks = .init(.init())
+        self._didShutdown = .init(false)
+        let logger = Logger(label: "codes.vapor.application")
+        self._logger = .init(logger)
+        self._storage = .init(.init(logger: logger))
+        self._lifecycle = .init(.init())
+        self.isBooted = .init(false)
         self.core.initialize()
         self.caches.initialize()
         self.views.initialize()
@@ -119,10 +169,13 @@ public final class Application {
     }
 
     public func boot() throws {
-        guard !self.isBooted else {
-            return
+        self.isBooted.withLockedValue { booted in
+            guard !booted else {
+                return
+            }
+            booted = true
         }
-        self.isBooted = true
+        
         try self.lifecycle.handlers.forEach { try $0.willBoot(self) }
         try self.lifecycle.handlers.forEach { try $0.didBoot(self) }
     }
@@ -151,7 +204,7 @@ public final class Application {
             }
         }
 
-        self.didShutdown = true
+        self._didShutdown.withLockedValue { $0 = true }
         self.logger.trace("Application shutdown complete")
     }
     

--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 /// Capable of being authenticated.
-public protocol Authenticatable { }
+public protocol Authenticatable: Sendable { }
 
 /// Helper for creating authentication middleware.
 ///

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -27,7 +27,7 @@ extension Authenticatable {
 
 
 private final class GuardAuthenticationMiddleware<A>: Middleware
-    where A: Authenticatable
+    where A: Authenticatable & Sendable
 {
     /// Error to throw when guard fails.
     private let error: Error

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -20,7 +20,7 @@ extension Authenticatable {
 
 
 private final class RedirectMiddleware<A>: Middleware
-    where A: Authenticatable
+    where A: Authenticatable & Sendable
 {
     let makePath: @Sendable (Request) -> String
     

--- a/Sources/Vapor/Cache/Application+Cache.swift
+++ b/Sources/Vapor/Cache/Application+Cache.swift
@@ -19,9 +19,9 @@ extension Application {
 
     public struct Caches: Sendable {
         public struct Provider {
-            let run: (Application) -> ()
+            let run: @Sendable (Application) -> ()
 
-            public init(_ run: @escaping (Application) -> ()) {
+            public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }

--- a/Sources/Vapor/Cache/Application+Cache.swift
+++ b/Sources/Vapor/Cache/Application+Cache.swift
@@ -18,7 +18,7 @@ extension Application {
     }
 
     public struct Caches: Sendable {
-        public struct Provider {
+        public struct Provider: Sendable {
             let run: @Sendable (Application) -> ()
 
             public init(_ run: @Sendable @escaping (Application) -> ()) {

--- a/Sources/Vapor/Cache/CacheExpirationTime.swift
+++ b/Sources/Vapor/Cache/CacheExpirationTime.swift
@@ -1,5 +1,5 @@
 /// Defines the lifetime of an entry in a cache.
-public enum CacheExpirationTime {
+public enum CacheExpirationTime: Sendable {
     case seconds(Int)
     case minutes(Int)
     case hours(Int)

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -37,7 +37,7 @@ private struct MemoryCacheKey: LockKey, StorageKey {
     typealias Value = MemoryCacheStorage
 }
 
-private final class MemoryCacheStorage {
+private actor MemoryCacheStorage: Sendable {
     struct CacheEntryBox<T> {
         var expiresAt: Date?
         var value: T
@@ -98,22 +98,25 @@ private struct MemoryCache: Cache {
     }
     
     func get<T>(_ key: String, as type: T.Type) -> EventLoopFuture<T?>
-        where T: Decodable
+        where T: Decodable & Sendable
     {
-        self.eventLoop.makeSucceededFuture(self.storage.get(key))
+        self.eventLoop.makeFutureWithTask {
+            await self.storage.get(key)
+        }
     }
     
     func set<T>(_ key: String, to value: T?) -> EventLoopFuture<Void>
-        where T: Encodable
+        where T: Encodable & Sendable
     {
         self.set(key, to: value, expiresIn: nil)
     }
     
     func set<T>(_ key: String, to value: T?, expiresIn expirationTime: CacheExpirationTime?) -> EventLoopFuture<Void>
-        where T: Encodable
+        where T: Encodable & Sendable
     {
-        self.storage.set(key, to: value, expiresIn: expirationTime)
-        return self.eventLoop.makeSucceededFuture(())
+        self.eventLoop.makeFutureWithTask {
+            await self.storage.set(key, to: value, expiresIn: expirationTime)
+        }
     }
     
     func `for`(_ request: Request) -> MemoryCache {

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -2,7 +2,7 @@ import NIOCore
 import Logging
 import NIOHTTP1
 
-public protocol Client {
+public protocol Client: Sendable {
     var eventLoop: EventLoop { get }
     var byteBufferAllocator: ByteBufferAllocator { get }
     func delegating(to eventLoop: EventLoop) -> Client

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -2,7 +2,7 @@ import NIOCore
 import NIOHTTP1
 import Foundation
 
-public struct ClientRequest {
+public struct ClientRequest: Sendable {
     public var method: HTTPMethod
     public var url: URI
     public var headers: HTTPHeaders

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -6,7 +6,7 @@ import ConsoleKit
 ///     $ swift run Run serve
 ///     Server starting on http://localhost:8080
 ///
-public final class ServeCommand: Command {
+public final class ServeCommand: Command, Sendable {
     public struct Signature: CommandSignature {
         @Option(name: "hostname", short: "H", help: "Set the hostname the server will run on.")
         var hostname: String?

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -1,5 +1,6 @@
 import Foundation
-import ConsoleKit
+@preconcurrency import ConsoleKit
+import NIOConcurrencyHelpers
 
 /// Boots the application's server. Listens for `SIGINT` and `SIGTERM` for graceful shutdown.
 ///
@@ -7,7 +8,7 @@ import ConsoleKit
 ///     Server starting on http://localhost:8080
 ///
 public final class ServeCommand: Command, Sendable {
-    public struct Signature: CommandSignature {
+    public struct Signature: CommandSignature, Sendable {
         @Option(name: "hostname", short: "H", help: "Set the hostname the server will run on.")
         var hostname: String?
         

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -112,7 +112,7 @@ private final class _PlaintextEncoder: Encoder, SingleValueEncodingContainer {
         func nestedUnkeyedContainer(forKey: K) -> UnkeyedEncodingContainer { self }
         func superEncoder() -> Encoder { self }
         func superEncoder(forKey: K) -> Encoder { self }
-        func container<K: CodingKey>(keyedBy: K.Type) -> KeyedEncodingContainer<K> { .init(FailureEncoder<K>()) }
+        func container<Key: CodingKey>(keyedBy: Key.Type) -> KeyedEncodingContainer<Key> { .init(FailureEncoder<Key>()) }
         func unkeyedContainer() -> UnkeyedEncodingContainer { self }
         func singleValueContainer() -> SingleValueEncodingContainer { self }
     }

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -1,16 +1,17 @@
-import ConsoleKit
+@preconcurrency import ConsoleKit
 import NIOCore
 import NIOPosix
+import NIOConcurrencyHelpers
 
 extension Application {
     public var console: Console {
-        get { self.core.storage.console }
-        set { self.core.storage.console = newValue }
+        get { self.core.storage.console.withLockedValue { $0 } }
+        set { self.core.storage.console.withLockedValue { $0 = newValue } }
     }
 
     public var commands: Commands {
-        get { self.core.storage.commands }
-        set { self.core.storage.commands = newValue }
+        get { self.core.storage.commands.withLockedValue { $0 } }
+        set { self.core.storage.commands.withLockedValue { $0 = newValue } }
     }
 
     /// The application thread pool. Vapor provides a thread pool with 64 threads by default.
@@ -25,16 +26,18 @@ extension Application {
     ///
     /// - Warning: Can only be set during application setup/initialization.
     public var threadPool: NIOThreadPool {
-        get { self.core.storage.threadPool }
+        get { self.core.storage.threadPool.withLockedValue { $0 } }
         set {
             guard !self.isBooted else {
                 self.logger.critical("Cannot replace thread pool after application has booted")
                 fatalError("Cannot replace thread pool after application has booted")
             }
             
-            try! self.core.storage.threadPool.syncShutdownGracefully()
-            self.core.storage.threadPool = newValue
-            self.core.storage.threadPool.start()
+            self.core.storage.threadPool.withLockedValue({
+                try! $0.syncShutdownGracefully()
+                $0 = newValue
+                $0.start()
+            })
         }
     }
     
@@ -47,37 +50,39 @@ extension Application {
     }
 
     public var running: Running? {
-        get { self.core.storage.running.current }
-        set { self.core.storage.running.current = newValue }
+        get { self.core.storage.running.current.withLockedValue { $0 } }
+        set { self.core.storage.running.current.withLockedValue { $0 = newValue } }
     }
 
     public var directory: DirectoryConfiguration {
-        get { self.core.storage.directory }
-        set { self.core.storage.directory = newValue }
+        get { self.core.storage.directory.withLockedValue { $0 } }
+        set { self.core.storage.directory.withLockedValue { $0 = newValue } }
     }
 
     internal var core: Core {
         .init(application: self)
     }
 
-    public struct Core {
-        final class Storage {
-            var console: Console
-            var commands: Commands
-            var threadPool: NIOThreadPool
-            var allocator: ByteBufferAllocator
-            var running: Application.Running.Storage
-            var directory: DirectoryConfiguration
+    public struct Core: Sendable {
+        final class Storage: Sendable {
+            let console: NIOLockedValueBox<Console>
+            let commands: NIOLockedValueBox<Commands>
+            let threadPool: NIOLockedValueBox<NIOThreadPool>
+            let allocator: ByteBufferAllocator
+            let running: Application.Running.Storage
+            let directory: NIOLockedValueBox<DirectoryConfiguration>
 
             init() {
-                self.console = Terminal()
-                self.commands = Commands()
-                self.commands.use(BootCommand(), as: "boot")
-                self.threadPool = NIOThreadPool(numberOfThreads: 64)
-                self.threadPool.start()
+                self.console = .init(Terminal())
+                var commands = Commands()
+                commands.use(BootCommand(), as: "boot")
+                self.commands = .init(commands)
+                let threadPool = NIOThreadPool(numberOfThreads: 64)
+                threadPool.start()
+                self.threadPool = .init(threadPool)
                 self.allocator = .init()
                 self.running = .init()
-                self.directory = .detect()
+                self.directory = .init(.detect())
             }
         }
 

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -28,7 +28,7 @@ extension Application {
     public var threadPool: NIOThreadPool {
         get { self.core.storage.threadPool.withLockedValue { $0 } }
         set {
-            guard !self.isBooted else {
+            guard !self.isBooted.withLockedValue({ $0 }) else {
                 self.logger.critical("Cannot replace thread pool after application has booted")
                 fatalError("Cannot replace thread pool after application has booted")
             }

--- a/Sources/Vapor/Core/Running.swift
+++ b/Sources/Vapor/Core/Running.swift
@@ -1,10 +1,13 @@
 import NIOCore
+import NIOConcurrencyHelpers
 
 extension Application {
-    public struct Running {
-        final class Storage {
-            var current: Running?
-            init() { }
+    public struct Running: Sendable {
+        final class Storage: Sendable {
+            let current: NIOLockedValueBox<Running?>
+            init() {
+                self.current = .init(nil)
+            }
         }
 
         public static func start(using promise: EventLoopPromise<Void>) -> Self {

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -10,12 +10,11 @@ public enum EndpointCacheError: Swift.Error {
 }
 
 /// Handles the complexities of HTTP caching.
-public final class EndpointCache<T> where T: Decodable {
-    private var cached: T?
-    private var request: EventLoopFuture<T>?
-    private var headers: HTTPHeaders?
-    private var cacheUntil: Date?
-
+public final class EndpointCache<T>: Sendable where T: Decodable & Sendable {
+    private let cached: NIOLockedValueBox<T?>
+    private let request: NIOLockedValueBox<EventLoopFuture<T>?>
+    private let headers: NIOLockedValueBox<HTTPHeaders?>
+    private let cacheUntil: NIOLockedValueBox<Date?>
     private let sync: NIOLock
     private let uri: URI
 
@@ -25,6 +24,10 @@ public final class EndpointCache<T> where T: Decodable {
     public init(uri: URI) {
         self.uri = uri
         self.sync = .init()
+        self.request = .init(nil)
+        self.cacheUntil = .init(nil)
+        self.headers = .init(nil)
+        self.cached = .init(nil)
     }
 
     /// Downloads the resource.
@@ -44,16 +47,17 @@ public final class EndpointCache<T> where T: Decodable {
         self.sync.lock()
         defer { self.sync.unlock() }
 
-        if let cached = self.cached, let cacheUntil = self.cacheUntil, Date() < cacheUntil {
+        if let cached = self.cached.withLockedValue({ $0 }), let cacheUntil = self.cacheUntil.withLockedValue({ $0 }), Date() < cacheUntil {
             // If no-cache was set on the header, you *always* have to validate with the server.
             // must-revalidate does not require checking with the server until after it expires.
-            if self.headers == nil || self.headers?.cacheControl == nil || self.headers?.cacheControl?.noCache == false {
+            let cachedHeaders = self.headers.withLockedValue { $0 }
+            if cachedHeaders == nil || cachedHeaders?.cacheControl == nil || cachedHeaders?.cacheControl?.noCache == false {
                 return eventLoop.makeSucceededFuture(cached)
             }
         }
 
         // Don't make a new request if one is already running.
-        if let request = self.request {
+        if let request = self.request.withLockedValue({ $0 }) {
             // The current request may be happening on a different event loop.
             return request.hop(to: eventLoop)
         }
@@ -61,14 +65,14 @@ public final class EndpointCache<T> where T: Decodable {
         logger?.debug("Requesting data from \(self.uri)")
 
         let request = self.download(on: eventLoop, using: client, logger: logger)
-        self.request = request
+        self.request.withLockedValue { $0 = request }
 
         // Once the request finishes, clear the current request and return the data.
         return request.map { data in
             // Synchronize access to shared state
             self.sync.lock()
             defer { self.sync.unlock() }
-            self.request = nil
+            self.request.withLockedValue { $0 = nil }
 
             return data
         }
@@ -77,14 +81,16 @@ public final class EndpointCache<T> where T: Decodable {
     private func download(on eventLoop: EventLoop, using client: Client, logger: Logger?) -> EventLoopFuture<T> {
         // https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.3.4
         var headers: HTTPHeaders = [:]
-        if let eTag = self.headers?.first(name: .eTag) {
-            headers.add(name: .ifNoneMatch, value: eTag)
-        }
+        self.headers.withLockedValue { cachedHeaders in
+            if let eTag = cachedHeaders?.first(name: .eTag) {
+                headers.add(name: .ifNoneMatch, value: eTag)
+            }
 
-        if let lastModified = self.headers?.lastModified {
-            // TODO: If using HTTP/1.0 then this should be .ifUnmodifiedSince instead. Don't know
-            // how to determine that right now.
-            headers.add(name: .ifModifiedSince, value: lastModified.serialize())
+            if let lastModified = cachedHeaders?.lastModified {
+                // TODO: If using HTTP/1.0 then this should be .ifUnmodifiedSince instead. Don't know
+                // how to determine that right now.
+                headers.add(name: .ifModifiedSince, value: lastModified.serialize())
+            }
         }
 
         // Cache-Control max-age is calculated against the request date.
@@ -107,15 +113,17 @@ public final class EndpointCache<T> where T: Decodable {
                 // The server *shouldn't* give an expiration with no-store, but...
                 self.clearCache()
             } else {
-                self.headers = response.headers
-                self.cacheUntil = self.headers?.expirationDate(requestSentAt: requestSentAt)
+                self.headers.withLockedValue { headers in
+                    headers = response.headers
+                    self.cacheUntil.withLockedValue { $0 = headers?.expirationDate(requestSentAt: requestSentAt) }
+                }
             }
 
             switch response.status {
             case .notModified:
                 logger?.debug("Cached data is still valid.")
 
-                guard let cached = self.cached else {
+                guard let cached = self.cached.withLockedValue({ $0 }) else {
                     // This shouldn't actually be possible, but just in case.
                     self.clearCache()
                     return self.download(on: eventLoop, using: client, logger: logger)
@@ -134,8 +142,10 @@ public final class EndpointCache<T> where T: Decodable {
                     return eventLoop.makeFailedFuture(EndpointCacheError.contentDecodeFailure(error))
                 }
 
-                if self.cacheUntil != nil {
-                    self.cached = data
+                self.cacheUntil.withLockedValue { cachedDate in
+                    if cachedDate != nil {
+                        self.cached.withLockedValue { $0 = data }
+                    }
                 }
 
                 return eventLoop.makeSucceededFuture(data)
@@ -149,11 +159,11 @@ public final class EndpointCache<T> where T: Decodable {
             self.sync.lock()
             defer { self.sync.unlock() }
 
-            guard let headers = self.headers, let cached = self.cached else {
+            guard let headers = self.headers.withLockedValue({ $0 }), let cached = self.cached.withLockedValue({ $0 }) else {
                 return eventLoop.makeFailedFuture(error)
             }
 
-            if let cacheControl = headers.cacheControl, let cacheUntil = self.cacheUntil {
+            if let cacheControl = headers.cacheControl, let cacheUntil = self.cacheUntil.withLockedValue({ $0 }) {
                 if let staleIfError = cacheControl.staleIfError,
                     cacheUntil.addingTimeInterval(Double(staleIfError)) > Date() {
                     // Can use the data for staleIfError seconds past expiration when the server is non-responsive
@@ -173,8 +183,8 @@ public final class EndpointCache<T> where T: Decodable {
     }
 
     private func clearCache() {
-        self.cached = nil
-        self.headers = nil
-        self.cacheUntil = nil
+        self.cached.withLockedValue { $0 = nil }
+        self.headers.withLockedValue { $0 = nil }
+        self.cacheUntil.withLockedValue { $0 = nil }
     }
 }

--- a/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
+++ b/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
@@ -11,7 +11,7 @@ extension Application.HTTP {
         .init(application: self.application)
     }
     
-    public struct Server {
+    public struct Server: Sendable {
         let application: Application
 
         public var shared: HTTPServer {
@@ -29,7 +29,7 @@ extension Application.HTTP {
             }
         }
 
-        struct Key: StorageKey {
+        struct Key: StorageKey, Sendable {
             typealias Value = HTTPServer
         }
 
@@ -48,7 +48,7 @@ extension Application.HTTP {
             }
         }
 
-        struct ConfigurationKey: StorageKey {
+        struct ConfigurationKey: StorageKey, Sendable {
             typealias Value = HTTPServer.Configuration
         }
     }

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -6,8 +6,9 @@ import NIOHTTPCompression
 import NIOSSL
 import Logging
 import NIOPosix
+import NIOConcurrencyHelpers
 
-public enum HTTPVersionMajor: Equatable, Hashable {
+public enum HTTPVersionMajor: Equatable, Hashable, Sendable {
     case one
     case two
 }
@@ -156,7 +157,9 @@ public final class HTTPServer: Server, Sendable {
         public var shutdownTimeout: TimeAmount
 
         /// An optional callback that will be called instead of using swift-nio-ssl's regular certificate verification logic.
-        public var customCertificateVerifyCallback: NIOSSLCustomVerificationCallback?
+        /// This is the same as `NIOSSLCustomVerificationCallback` but just marked as `Sendable`
+        @preconcurrency
+        public var customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)?
 
         public init(
             hostname: String = Self.defaultHostname,
@@ -228,36 +231,31 @@ public final class HTTPServer: Server, Sendable {
     }
     
     public var onShutdown: EventLoopFuture<Void> {
-        guard let connection = self.connection else {
+        guard let connection = self.connection.withLockedValue({ $0 }) else {
             fatalError("Server has not started yet")
         }
         return connection.channel.closeFuture
     }
 
     public var configuration: Configuration {
-        get { _configuration }
+        get { _configuration.withLockedValue { $0 } }
         set {
-            guard !didStart else {
-                _configuration.logger.warning("Cannot modify server configuration after server has been started.")
+            guard !didStart.withLockedValue({ $0 }) else {
+                _configuration.withLockedValue({ $0 }).logger.warning("Cannot modify server configuration after server has been started.")
                 return
             }
-            _configuration = newValue
+            self.application.storage[Application.HTTP.Server.ConfigurationKey.self] = newValue
+            _configuration.withLockedValue { $0 = newValue }
         }
     }
 
     private let responder: Responder
-    private var _configuration: Configuration {
-        willSet {
-            self.application.storage[Application.HTTP.Server.ConfigurationKey.self] = newValue
-        }
-    }
+    private let _configuration: NIOLockedValueBox<Configuration>
     private let eventLoopGroup: EventLoopGroup
-    
-    private var connection: HTTPServerConnection?
-    private var didShutdown: Bool
-    private var didStart: Bool
-
-    private var application: Application
+    private let connection: NIOLockedValueBox<HTTPServerConnection?>
+    private let didShutdown: NIOLockedValueBox<Bool>
+    private let didStart: NIOLockedValueBox<Bool>
+    private let application: Application
     
     public init(
         application: Application,
@@ -267,10 +265,11 @@ public final class HTTPServer: Server, Sendable {
     ) {
         self.application = application
         self.responder = responder
-        self._configuration = configuration
+        self._configuration = .init(configuration)
         self.eventLoopGroup = eventLoopGroup
-        self.didStart = false
-        self.didShutdown = false
+        self.didStart = .init(false)
+        self.didShutdown = .init(false)
+        self.connection = .init(nil)
     }
     
     public func start(address: BindAddress?) throws {
@@ -298,19 +297,21 @@ public final class HTTPServer: Server, Sendable {
         self.configuration.logger.notice("Server starting on \(addressDescription)")
 
         // start the actual HTTPServer
-        self.connection = try HTTPServerConnection.start(
-            application: self.application,
-            responder: self.responder,
-            configuration: configuration,
-            on: self.eventLoopGroup
-        ).wait()
+        try self.connection.withLockedValue {
+            $0 = try HTTPServerConnection.start(
+                application: self.application,
+                responder: self.responder,
+                configuration: configuration,
+                on: self.eventLoopGroup
+            ).wait()
+        }
 
         self.configuration = configuration
-        self.didStart = true
+        self.didStart.withLockedValue { $0 = true }
     }
     
     public func shutdown() {
-        guard let connection = self.connection else {
+        guard let connection = self.connection.withLockedValue({ $0 }) else {
             return
         }
         self.configuration.logger.debug("Requesting HTTP server shutdown")
@@ -320,19 +321,21 @@ public final class HTTPServer: Server, Sendable {
             self.configuration.logger.error("Could not stop HTTP server: \(error)")
         }
         self.configuration.logger.debug("HTTP server shutting down")
-        self.didShutdown = true
+        self.didShutdown.withLockedValue { $0 = true }
     }
 
     public var localAddress: SocketAddress? {
-        return self.connection?.channel.localAddress
+        return self.connection.withLockedValue({ $0 })?.channel.localAddress
     }
     
     deinit {
-        assert(!self.didStart || self.didShutdown, "HTTPServer did not shutdown before deinitializing")
+        let started = self.didStart.withLockedValue { $0 }
+        let shutdown = self.didShutdown.withLockedValue { $0 }
+        assert(!started || shutdown, "HTTPServer did not shutdown before deinitializing")
     }
 }
 
-private final class HTTPServerConnection {
+private final class HTTPServerConnection: Sendable {
     let channel: Channel
     let quiesce: ServerQuiescingHelper
     

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -357,7 +357,9 @@ private final class HTTPServerConnection: Sendable {
             }
             
             // Set the handlers that are applied to the accepted Channels
-            .childChannelInitializer { [weak application] channel in
+            .childChannelInitializer { channel in
+//            .childChannelInitializer { [weak application] channel in
+#warning("We were storing a weak reference to the applicaiton at this point - why")
                 // add TLS handlers if configured
                 if var tlsConfiguration = configuration.tlsConfiguration {
                     // prioritize http/2
@@ -382,7 +384,7 @@ private final class HTTPServerConnection: Sendable {
                                 mode: .server,
                                 inboundStreamInitializer: { channel in
                                     channel.pipeline.addVaporHTTP2Handlers(
-                                        application: application!,
+                                        application: application,
                                         responder: responder,
                                         configuration: configuration
                                     )
@@ -390,7 +392,7 @@ private final class HTTPServerConnection: Sendable {
                             ).map { _ in }
                         }, http1ChannelConfigurator: { channel in
                             channel.pipeline.addVaporHTTP1Handlers(
-                                application: application!,
+                                application: application,
                                 responder: responder,
                                 configuration: configuration
                             )
@@ -401,7 +403,7 @@ private final class HTTPServerConnection: Sendable {
                         fatalError("Plaintext HTTP/2 (h2c) not yet supported.")
                     }
                     return channel.pipeline.addVaporHTTP1Handlers(
-                        application: application!,
+                        application: application,
                         responder: responder,
                         configuration: configuration
                     )

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -12,13 +12,13 @@ public enum HTTPVersionMajor: Equatable, Hashable {
     case two
 }
 
-public final class HTTPServer: Server {
+public final class HTTPServer: Server, Sendable {
     /// Engine server config struct.
     ///
     ///     let serverConfig = HTTPServerConfig.default(port: 8123)
     ///     services.register(serverConfig)
     ///
-    public struct Configuration {
+    public struct Configuration: Sendable {
         public static let defaultHostname = "127.0.0.1"
         public static let defaultPort = 8080
         
@@ -78,7 +78,7 @@ public final class HTTPServer: Server {
         public var responseCompression: CompressionConfiguration
 
         /// Supported HTTP compression options.
-        public struct CompressionConfiguration {
+        public struct CompressionConfiguration: Sendable {
             /// Disables compression. This is the default.
             public static var disabled: Self {
                 .init(storage: .disabled)
@@ -110,7 +110,7 @@ public final class HTTPServer: Server {
         public var requestDecompression: DecompressionConfiguration
 
         /// Supported HTTP decompression options.
-        public struct DecompressionConfiguration {
+        public struct DecompressionConfiguration: Sendable {
             /// Disables decompression. This is the default option.
             public static var disabled: Self {
                 .init(storage: .disabled)

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -116,12 +116,12 @@ public protocol Upgrader {
 }
 
 /// Handles upgrading an HTTP connection to a WebSocket
-public struct WebSocketUpgrader: Upgrader {
+public struct WebSocketUpgrader: Upgrader, Sendable {
     var maxFrameSize: WebSocketMaxFrameSize
-    var shouldUpgrade: (() -> EventLoopFuture<HTTPHeaders?>)
-    var onUpgrade: (WebSocket) -> ()
+    var shouldUpgrade: (@Sendable () -> EventLoopFuture<HTTPHeaders?>)
+    var onUpgrade: @Sendable (WebSocket) -> ()
     
-    public init(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: @escaping (() -> EventLoopFuture<HTTPHeaders?>), onUpgrade: @escaping (WebSocket) -> ()) {
+    public init(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: @escaping (@Sendable () -> EventLoopFuture<HTTPHeaders?>), onUpgrade: @Sendable @escaping (WebSocket) -> ()) {
         self.maxFrameSize = maxFrameSize
         self.shouldUpgrade = shouldUpgrade
         self.onUpgrade = onUpgrade

--- a/Sources/Vapor/Passwords/Application+Password.swift
+++ b/Sources/Vapor/Passwords/Application+Password.swift
@@ -16,7 +16,7 @@ extension Application {
         }
 
         public var sync: PasswordHasher {
-            guard let makeVerifier = self.application.passwords.storage.makeVerifier.withLockedValue({ $0 }) else {
+            guard let makeVerifier = self.application.passwords.storage.makeVerifier.withLockedValue({ $0.factory }) else {
                 fatalError("No password verifier configured. Configure with app.passwords.use(...)")
             }
             return makeVerifier(self.application)

--- a/Sources/Vapor/Passwords/Application+Password.swift
+++ b/Sources/Vapor/Passwords/Application+Password.swift
@@ -16,7 +16,7 @@ extension Application {
         }
 
         public var sync: PasswordHasher {
-            guard let makeVerifier = self.application.passwords.storage.makeVerifier else {
+            guard let makeVerifier = self.application.passwords.storage.makeVerifier.withLockedValue({ $0 }) else {
                 fatalError("No password verifier configured. Configure with app.passwords.use(...)")
             }
             return makeVerifier(self.application)

--- a/Sources/Vapor/Passwords/Application+Passwords.swift
+++ b/Sources/Vapor/Passwords/Application+Passwords.swift
@@ -27,13 +27,16 @@ extension Application {
         public func use(
             _ makeVerifier: @Sendable @escaping (Application) -> (PasswordHasher)
         ) {
-            self.storage.makeVerifier.withLockedValue { $0 = makeVerifier }
+            self.storage.makeVerifier.withLockedValue { $0 = .init(factory: makeVerifier) }
         }
 
         final class Storage: Sendable {
-            let makeVerifier: NIOLockedValueBox<(@Sendable (Application) -> PasswordHasher)?>
+            struct PasswordsFactory {
+                let factory: (@Sendable (Application) -> PasswordHasher)?
+            }
+            let makeVerifier: NIOLockedValueBox<PasswordsFactory>
             init() {
-                self.makeVerifier = .init(nil)
+                self.makeVerifier = .init(.init(factory: nil))
             }
         }
 

--- a/Sources/Vapor/Routing/Request+WebSocket.swift
+++ b/Sources/Vapor/Routing/Request+WebSocket.swift
@@ -5,10 +5,10 @@ import NIOHTTP1
 extension Request {
      public func webSocket(
          maxFrameSize: WebSocketMaxFrameSize = .`default`,
-         shouldUpgrade: @escaping ((Request) -> EventLoopFuture<HTTPHeaders?>) = {
+         shouldUpgrade: @escaping (@Sendable (Request) -> EventLoopFuture<HTTPHeaders?>) = {
              $0.eventLoop.makeSucceededFuture([:])
          },
-         onUpgrade: @escaping (Request, WebSocket) -> ()
+         onUpgrade: @Sendable @escaping (Request, WebSocket) -> ()
      ) -> Response {
          let res = Response(status: .switchingProtocols)
          res.upgrader = WebSocketUpgrader(maxFrameSize: maxFrameSize, shouldUpgrade: {

--- a/Sources/Vapor/Routing/Routes.swift
+++ b/Sources/Vapor/Routing/Routes.swift
@@ -1,4 +1,4 @@
-public final class Routes: RoutesBuilder, CustomStringConvertible {
+public final class Routes: RoutesBuilder, CustomStringConvertible, Sendable {
     public var all: [Route]
     
     /// Default value used by `HTTPBodyStreamStrategy.collect` when `maxSize` is `nil`.

--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -2,7 +2,7 @@ import RoutingKit
 import NIOHTTP1
 
 /// Determines how an incoming HTTP request's body is collected.
-public enum HTTPBodyStreamStrategy {
+public enum HTTPBodyStreamStrategy: Sendable {
     /// The HTTP request's body will be collected into memory up to a maximum size
     /// before the route handler is called. The application's configured default max body
     /// size will be used unless otherwise specified.

--- a/Sources/Vapor/Server/Server.swift
+++ b/Sources/Vapor/Server/Server.swift
@@ -20,7 +20,7 @@ public protocol Server {
     func shutdown()
 }
 
-public enum BindAddress: Equatable {
+public enum BindAddress: Equatable, Sendable {
     case hostname(_ hostname: String?, port: Int?)
     case unixDomainSocket(path: String)
 }

--- a/Sources/Vapor/Sessions/Application+Sessions.swift
+++ b/Sources/Vapor/Sessions/Application+Sessions.swift
@@ -1,30 +1,33 @@
+import NIOConcurrencyHelpers
+
 extension Application {
     public var sessions: Sessions {
         .init(application: self)
     }
 
-    public struct Sessions {
-        public struct Provider {
+    public struct Sessions: Sendable {
+        public struct Provider: Sendable {
             public static var memory: Self {
                 .init {
                     $0.sessions.use { $0.sessions.memory }
                 }
             }
 
-            let run: (Application) -> ()
+            let run: @Sendable (Application) -> ()
 
-            public init(_ run: @escaping (Application) -> ()) {
+            public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
 
-        final class Storage {
+        final class Storage: Sendable {
             let memory: MemorySessions.Storage
-            var makeDriver: ((Application) -> SessionDriver)?
-            var configuration: SessionsConfiguration
+            let makeDriver: NIOLockedValueBox<(@Sendable (Application) -> SessionDriver)?>
+            let configuration: NIOLockedValueBox<SessionsConfiguration>
             init() {
                 self.memory = .init()
-                self.configuration = .default()
+                self.configuration = .init(.default())
+                self.makeDriver = .init(nil)
             }
         }
 
@@ -36,10 +39,10 @@ extension Application {
 
         public var configuration: SessionsConfiguration {
             get {
-                self.storage.configuration
+                self.storage.configuration.withLockedValue { $0 }
             }
             nonmutating set {
-                self.storage.configuration = newValue
+                self.storage.configuration.withLockedValue { $0 = newValue }
             }
         }
 
@@ -51,7 +54,7 @@ extension Application {
         }
 
         public var driver: SessionDriver {
-            guard let makeDriver = self.storage.makeDriver else {
+            guard let makeDriver = self.storage.makeDriver.withLockedValue({ $0 }) else {
                 fatalError("No driver configured. Configure with app.sessions.use(...)")
             }
             return makeDriver(self.application)
@@ -65,8 +68,8 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeDriver: @escaping (Application) -> (SessionDriver)) {
-            self.storage.makeDriver = makeDriver
+        public func use(_ makeDriver: @Sendable @escaping (Application) -> (SessionDriver)) {
+            self.storage.makeDriver.withLockedValue { $0 = makeDriver }
         }
 
         var storage: Storage {

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -1,15 +1,25 @@
 import Foundation
 import NIOCore
+import NIOConcurrencyHelpers
 
 /// Simple in-memory sessions implementation.
-public struct MemorySessions: SessionDriver {
+public struct MemorySessions: SessionDriver, Sendable {
     public let storage: Storage
     
-    public final class Storage {
-        public var sessions: [SessionID: SessionData]
+    public final class Storage: Sendable {
+        public var sessions: [SessionID: SessionData] {
+            get {
+                self._sessions.withLockedValue { $0 }
+            }
+            set {
+                self._sessions.withLockedValue { $0 = newValue }
+            }
+        }
+        
         public let queue: DispatchQueue
+        private let _sessions: NIOLockedValueBox<[SessionID: SessionData]>
         public init() {
-            self.sessions = [:]
+            self._sessions = .init([:])
             self.queue = DispatchQueue(label: "MemorySessions.Storage")
         }
     }

--- a/Sources/Vapor/Sessions/Session.swift
+++ b/Sources/Vapor/Sessions/Session.swift
@@ -1,32 +1,51 @@
+import NIOConcurrencyHelpers
+
 /// Sessions are a method for associating data with a client accessing your app.
 ///
 /// Each session has a unique identifier that is used to look it up with each request
 /// to your app. This is usually done via HTTP cookies.
 ///
 /// See `Request.session()` and `SessionsMiddleware` for more information.
-public final class Session {
+public final class Session: Sendable {
     /// This session's unique identifier. Usually a cookie value.
-    public var id: SessionID?
+    public var id: SessionID? {
+        get {
+            self._id.withLockedValue { $0 }
+        }
+        set {
+            self._id.withLockedValue { $0 = newValue }
+        }
+    }
 
     /// This session's data.
-    public var data: SessionData
+    public var data: SessionData {
+        get {
+            self._data.withLockedValue { $0 }
+        }
+        set {
+            self._data.withLockedValue { $0 = newValue }
+        }
+    }
 
     /// `true` if this session is still valid.
-    var isValid: Bool
+    let isValid: NIOLockedValueBox<Bool>
+    
+    private let _id: NIOLockedValueBox<SessionID?>
+    private let _data: NIOLockedValueBox<SessionData>
 
     /// Create a new `Session`.
     ///
     /// Normally you will use `Request.session()` to do this.
     public init(id: SessionID? = nil, data: SessionData = .init()) {
-        self.id = id
-        self.data = data
-        self.isValid = true
+        self._id = .init(id)
+        self._data = .init(data)
+        self.isValid = .init(true)
     }
 
     /// Invalidates the current session, removing persisted data from the session driver
     /// and invalidating the cookie.
     public func destroy() {
-        self.isValid = false
+        self.isValid.withLockedValue { $0 = false }
     }
 }
 

--- a/Sources/Vapor/Sessions/SessionCache.swift
+++ b/Sources/Vapor/Sessions/SessionCache.swift
@@ -1,14 +1,16 @@
+import NIOConcurrencyHelpers
+
 /// Singleton service cache for a `Session`. Used with a message's private container.
-internal final class SessionCache {
+internal final class SessionCache: Sendable {
     /// Set to `true` when passing through middleware.
-    var middlewareFlag: Bool
+    let middlewareFlag: NIOLockedValueBox<Bool>
 
     /// The cached session.
-    var session: Session?
+    let session: NIOLockedValueBox<Session?>
 
     /// Creates a new `SessionCache`.
     init(session: Session? = nil) {
-        self.session = session
-        self.middlewareFlag = false
+        self.session = .init(session)
+        self.middlewareFlag = .init(false)
     }
 }

--- a/Sources/Vapor/Sessions/SessionData.swift
+++ b/Sources/Vapor/Sessions/SessionData.swift
@@ -11,7 +11,7 @@
 ///     // creates a copy of the data as of this point
 ///     let snapshot = data.snapshot
 ///     client.storeUsingDictionary(snapshot)
-public struct SessionData {
+public struct SessionData: Sendable {
     /// A copy of the current data in the container.
     public var snapshot: [String: String] { self.storage }
 

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 /// Capable of managing CRUD operations for `Session`s.
-public protocol SessionDriver {
+public protocol SessionDriver: Sendable {
     func createSession(
         _ data: SessionData,
         for request: Request

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -62,7 +62,7 @@ public final class SessionsMiddleware: Middleware {
 
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) -> EventLoopFuture<Response> {
-        if let session = request._sessionCache.session.withLockedValue({ $0 }), session.isValid {
+        if let session = request._sessionCache.session.withLockedValue({ $0 }), session.isValid.withLockedValue({ $0 }) {
             // A session exists or has been created. we must
             // set a cookie value on the response
             let createOrUpdate: EventLoopFuture<SessionID>

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -34,7 +34,7 @@ public final class SessionsMiddleware: Middleware {
 
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // Signal middleware has been added.
-        request._sessionCache.middlewareFlag = true
+        request._sessionCache.middlewareFlag.withLockedValue { $0 = true }
 
         // Check for an existing session
         if let cookieValue = request.cookies[self.configuration.cookieName] {
@@ -43,10 +43,10 @@ public final class SessionsMiddleware: Middleware {
             return self.session.readSession(id, for: request).flatMap { data in
                 if let data = data {
                     // Session found, restore data and id.
-                    request._sessionCache.session = .init(id: id, data: data)
+                    request._sessionCache.session.withLockedValue { $0 = .init(id: id, data: data) }
                 } else {
                     // Session id not found, create new session.
-                    request._sessionCache.session = .init()
+                    request._sessionCache.session.withLockedValue { $0 = .init() }
                 }
                 return next.respond(to: request).flatMap { res in
                     return self.addCookies(to: res, for: request)
@@ -62,7 +62,7 @@ public final class SessionsMiddleware: Middleware {
 
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) -> EventLoopFuture<Response> {
-        if let session = request._sessionCache.session, session.isValid {
+        if let session = request._sessionCache.session.withLockedValue({ $0 }), session.isValid {
             // A session exists or has been created. we must
             // set a cookie value on the response
             let createOrUpdate: EventLoopFuture<SessionID>

--- a/Sources/Vapor/Utilities/ByteCount.swift
+++ b/Sources/Vapor/Utilities/ByteCount.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// let bytes: ByteCount = "2kb"
 /// print(bytes.value) // 2048
-public struct ByteCount: Equatable {
+public struct ByteCount: Equatable, Sendable {
     /// The value in Bytes
     public let value: Int
 

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -11,7 +11,7 @@ import Logging
 ///     let dirConfig = DirectoryConfiguration.detect()
 ///     print(dirConfig.workingDirectory) // "/path/to/workdir"
 ///
-public struct DirectoryConfiguration {
+public struct DirectoryConfiguration: Sendable {
     /// Path to the current working directory.
     public var workingDirectory: String
     public var resourcesDirectory: String

--- a/Sources/Vapor/Utilities/LifecycleHandler.swift
+++ b/Sources/Vapor/Utilities/LifecycleHandler.swift
@@ -1,4 +1,4 @@
-public protocol LifecycleHandler {
+public protocol LifecycleHandler: Sendable {
     func willBoot(_ application: Application) throws
     func didBoot(_ application: Application) throws
     func shutdown(_ application: Application)

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -3,14 +3,14 @@ import Logging
 /// A container providing arbitrary storage for extensions of an existing type, designed to obviate
 /// the problem of being unable to add stored properties to a type in an extension. Each stored item
 /// is keyed by a type conforming to ``StorageKey`` protocol.
-public struct Storage {
+public struct Storage: Sendable {
     /// The internal storage area.
     var storage: [ObjectIdentifier: AnyStorageValue]
 
     /// A container for a stored value and an associated optional `deinit`-like closure.
-    struct Value<T>: AnyStorageValue {
+    struct Value<T: Sendable>: AnyStorageValue {
         var value: T
-        var onShutdown: ((T) throws -> ())?
+        var onShutdown: (@Sendable (T) throws -> ())?
         func shutdown(logger: Logger) {
             do {
                 try self.onShutdown?(self.value)
@@ -82,7 +82,7 @@ public struct Storage {
     public mutating func set<Key>(
         _ key: Key.Type,
         to value: Key.Value?,
-        onShutdown: ((Key.Value) throws -> ())? = nil
+        onShutdown: (@Sendable (Key.Value) throws -> ())? = nil
     )
         where Key: StorageKey
     {
@@ -106,12 +106,12 @@ public struct Storage {
 
 /// ``Storage`` uses this protocol internally to generically invoke shutdown closures for arbitrarily-
 /// typed key values.
-protocol AnyStorageValue {
+protocol AnyStorageValue: Sendable {
     func shutdown(logger: Logger)
 }
 
 /// A key used to store values in a ``Storage`` must conform to this protocol.
 public protocol StorageKey {
     /// The type of the stored value associated with this key type.
-    associatedtype Value
+    associatedtype Value: Sendable
 }

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -126,10 +126,11 @@ final class AsyncClientTests: XCTestCase {
         let app = Application(.testing)
         app.http.server.configuration.port = 0
         defer { app.shutdown() }
+        let remotePort = self.remoteAppPort!
 
         app.get("foo") { req async throws -> String in
             do {
-                let response = try await req.client.get("http://localhost:\(self.remoteAppPort!)/status/201")
+                let response = try await req.client.get("http://localhost:\(remotePort)/status/201")
                 XCTAssertEqual(response.status.code, 201)
                 req.application.running?.stop()
                 return "bar"
@@ -181,18 +182,23 @@ final class AsyncClientTests: XCTestCase {
 }
 
 
-final class CustomClient: Client {
+final class CustomClient: Client, Sendable {
     var eventLoop: EventLoop {
         EmbeddedEventLoop()
     }
-    var requests: [ClientRequest]
+    let _requests: NIOLockedValueBox<[ClientRequest]>
+    var requests: [ClientRequest] {
+        get {
+            self._requests.withLockedValue { $0 }
+        }
+    }
 
     init() {
-        self.requests = []
+        self._requests = .init([])
     }
 
     func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
-        self.requests.append(request)
+        self._requests.withLockedValue { $0.append(request) }
         return self.eventLoop.makeSucceededFuture(ClientResponse())
     }
 
@@ -226,16 +232,43 @@ extension Application.Clients.Provider {
 }
 
 
-final class TestLogHandler: LogHandler {
+private final class TestLogHandler: LogHandler {
+    
     subscript(metadataKey key: String) -> Logger.Metadata.Value? {
-        get { self.lock.withLock { self.metadata[key] } }
-        set { self.lock.withLockVoid { self.metadata[key] = newValue } }
+        get { self.metadata[key] }
+        set { self.metadata[key] = newValue }
     }
 
-    let lock: NIOLock
-    var metadata: Logger.Metadata
-    var logLevel: Logger.Level
-    var messages: [Logger.Message]
+    var metadata: Logger.Metadata {
+        get {
+            self._metadata.withLockedValue { $0 }
+        }
+        set {
+            self._metadata.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    var logLevel: Logger.Level {
+        get {
+            _logLevel
+        }
+        set {
+            // We don't use this anywhere
+        }
+    }
+    
+    var messages: [Logger.Message] {
+        get {
+            self._messages.withLockedValue { $0 }
+        }
+        set {
+            self._messages.withLockedValue { $0 = newValue }
+        }
+    }
+    
+    let _logLevel: Logger.Level
+    let _metadata: NIOLockedValueBox<Logger.Metadata>
+    let _messages: NIOLockedValueBox<[Logger.Message]>
 
     var logger: Logger {
         .init(label: "test") { label in
@@ -244,10 +277,9 @@ final class TestLogHandler: LogHandler {
     }
 
     init() {
-        self.lock = .init()
-        self.metadata = [:]
-        self.logLevel = .trace
-        self.messages = []
+        self._metadata = .init([:])
+        self._logLevel = .trace
+        self._messages = .init([])
     }
 
     func log(
@@ -259,24 +291,19 @@ final class TestLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
-        self.lock.withLockVoid {
-            self.messages.append(message)
-        }
+        self._messages.withLockedValue { $0.append(message) }
     }
 
     func read() -> [String] {
-        self.lock.withLock { () -> [Logger.Message] in
-            let copy = self.messages
-            self.messages = []
-            return copy
-        }.map(\.description)
+        self._messages.withLockedValue {
+            let copy = $0
+            $0 = []
+            return copy.map(\.description)
+        }
     }
 
     func getMetadata() -> Logger.Metadata {
-        self.lock.withLock { () -> Logger.Metadata in
-            let copy = self.metadata
-            return copy
-        }
+        self._metadata.withLockedValue { $0 }
     }
 }
 

--- a/Tests/AsyncTests/AsyncMiddlewareTests.swift
+++ b/Tests/AsyncTests/AsyncMiddlewareTests.swift
@@ -3,53 +3,68 @@ import XCTest
 import Vapor
 
 final class AsyncMiddlewareTests: XCTestCase {
+    actor OrderStore {
+        var order: [String] = []
+        
+        func addOrder(_ orderValue: String) {
+            self.order.append(orderValue)
+        }
+        
+        func getOrder() -> [String] {
+            self.order
+        }
+    }
+    
     final class OrderMiddleware: AsyncMiddleware {
-        static var order: [String] = []
         let pos: String
-        init(_ pos: String) {
+        let store: OrderStore
+        init(_ pos: String, store: OrderStore) {
             self.pos = pos
+            self.store = store
         }
         func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-            OrderMiddleware.order.append(pos)
+            await store.addOrder(pos)
             return try await next.respond(to: request)
         }
     }
 
-    func testMiddlewareOrder() throws {
+    func testMiddlewareOrder() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        OrderMiddleware.order = []
+        let store = OrderStore()
         app.grouped(
-            OrderMiddleware("a"), OrderMiddleware("b"), OrderMiddleware("c")
+            OrderMiddleware("a", store: store), OrderMiddleware("b", store: store), OrderMiddleware("c", store: store)
         ).get("order") { req -> String in
             return "done"
         }
 
-        try app.testable().test(.GET, "/order") { res in
+        try await app.testable().test(.GET, "/order") { res in
+            let order = await store.getOrder()
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(OrderMiddleware.order, ["a", "b", "c"])
+            XCTAssertEqual(order, ["a", "b", "c"])
             XCTAssertEqual(res.body.string, "done")
         }
     }
 
-    func testPrependingMiddleware() throws {
+    func testPrependingMiddleware() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        OrderMiddleware.order = []
-        app.middleware.use(OrderMiddleware("b"));
-        app.middleware.use(OrderMiddleware("c"));
-        app.middleware.use(OrderMiddleware("a"), at: .beginning);
-        app.middleware.use(OrderMiddleware("d"), at: .end);
+        let store = OrderStore()
+        app.middleware.use(OrderMiddleware("b", store: store))
+        app.middleware.use(OrderMiddleware("c", store: store))
+        app.middleware.use(OrderMiddleware("a", store: store), at: .beginning)
+        app.middleware.use(OrderMiddleware("d", store: store), at: .end)
 
         app.get("order") { req -> String in
             return "done"
         }
 
-        try app.testable().test(.GET, "/order") { res in
+        try await app.testable().test(.GET, "/order") { res in
+            let order = await store.getOrder()
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(OrderMiddleware.order, ["a", "b", "c", "d"])
+            XCTAssertEqual(order, ["a", "b", "c", "d"])
             XCTAssertEqual(res.body.string, "done")
         }
     }

--- a/Tests/AsyncTests/AsyncSessionTests.swift
+++ b/Tests/AsyncTests/AsyncSessionTests.swift
@@ -4,29 +4,36 @@ import Vapor
 import NIOHTTP1
 
 final class AsyncSessionTests: XCTestCase {
-    func testSessionDestroy() throws {
-        final class MockKeyedCache: AsyncSessionDriver {
-            static var ops: [String] = []
+    func testSessionDestroy() async throws {
+        actor MockKeyedCache: AsyncSessionDriver {
+            var ops: [String] = []
             init() { }
 
+            func getOps() -> [String] {
+                ops
+            }
+            
+            func resetOps() {
+                self.ops = []
+            }
 
             func createSession(_ data: SessionData, for request: Request) async throws -> SessionID {
-                Self.ops.append("create \(data)")
+                self.ops.append("create \(data)")
                 return .init(string: "a")
             }
 
             func readSession(_ sessionID: SessionID, for request: Request) async throws -> SessionData? {
-                Self.ops.append("read \(sessionID)")
+                self.ops.append("read \(sessionID)")
                 return SessionData()
             }
 
             func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) async throws -> SessionID {
-                Self.ops.append("update \(sessionID) to \(data)")
+                self.ops.append("update \(sessionID) to \(data)")
                 return sessionID
             }
 
             func deleteSession(_ sessionID: SessionID, for request: Request) async throws {
-                Self.ops.append("delete \(sessionID)")
+                self.ops.append("delete \(sessionID)")
                 return
             }
         }
@@ -48,14 +55,15 @@ final class AsyncSessionTests: XCTestCase {
             return "del"
         }
 
-        try app.testable().test(.GET, "/set") { res in
+        try await app.testable().test(.GET, "/set") { res in
             XCTAssertEqual(res.body.string, "set")
             cookie = res.headers.setCookie?["vapor-session"]
             XCTAssertNotNil(cookie)
-            XCTAssertEqual(MockKeyedCache.ops, [
+            let ops = await cache.ops
+            XCTAssertEqual(ops, [
                 #"create SessionData(storage: ["foo": "bar"])"#,
             ])
-            MockKeyedCache.ops = []
+            await cache.resetOps()
         }
 
         XCTAssertEqual(cookie?.string, "a")
@@ -64,9 +72,10 @@ final class AsyncSessionTests: XCTestCase {
         var cookies = HTTPCookies()
         cookies["vapor-session"] = cookie
         headers.cookie = cookies
-        try app.testable().test(.GET, "/del", headers: headers) { res in
+        try await app.testable().test(.GET, "/del", headers: headers) { res in
             XCTAssertEqual(res.body.string, "del")
-            XCTAssertEqual(MockKeyedCache.ops, [
+            let ops = await cache.ops
+            XCTAssertEqual(ops, [
                 #"read SessionID(string: "a")"#,
                 #"delete SessionID(string: "a")"#
             ])

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -4,53 +4,71 @@ import Vapor
 import NIOCore
 
 final class MiddlewareTests: XCTestCase {
+    actor OrderStore {
+        var order: [String] = []
+        
+        func addOrder(_ orderValue: String) {
+            self.order.append(orderValue)
+        }
+        
+        func getOrder() -> [String] {
+            self.order
+        }
+    }
+    
     final class OrderMiddleware: Middleware {
-        static var order: [String] = []
         let pos: String
-        init(_ pos: String) {
+        let store: OrderStore
+        init(_ pos: String, store: OrderStore) {
             self.pos = pos
+            self.store = store
         }
         func respond(to req: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-            OrderMiddleware.order.append(pos)
-            return next.respond(to: req)
+            req.eventLoop.makeFutureWithTask {
+                await self.store.addOrder(self.pos)
+            }.flatMap {
+                next.respond(to: req)
+            }
         }
     }
 
-    func testMiddlewareOrder() throws {
+    func testMiddlewareOrder() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        OrderMiddleware.order = []
+        let store = OrderStore()
         app.grouped(
-            OrderMiddleware("a"), OrderMiddleware("b"), OrderMiddleware("c")
+            OrderMiddleware("a", store: store), OrderMiddleware("b", store: store), OrderMiddleware("c", store: store)
         ).get("order") { req -> String in
             return "done"
         }
 
-        try app.testable().test(.GET, "/order") { res in
+        try await app.testable().test(.GET, "/order") { res in
+            let order = await store.getOrder()
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(OrderMiddleware.order, ["a", "b", "c"])
+            XCTAssertEqual(order, ["a", "b", "c"])
             XCTAssertEqual(res.body.string, "done")
         }
     }
 
-    func testPrependingMiddleware() throws {
+    func testPrependingMiddleware() async throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        OrderMiddleware.order = []
-        app.middleware.use(OrderMiddleware("b"));
-        app.middleware.use(OrderMiddleware("c"));
-        app.middleware.use(OrderMiddleware("a"), at: .beginning);
-        app.middleware.use(OrderMiddleware("d"), at: .end);
+        let store = OrderStore()
+        app.middleware.use(OrderMiddleware("b", store: store))
+        app.middleware.use(OrderMiddleware("c", store: store))
+        app.middleware.use(OrderMiddleware("a", store: store), at: .beginning)
+        app.middleware.use(OrderMiddleware("d", store: store), at: .end)
 
         app.get("order") { req -> String in
             return "done"
         }
 
-        try app.testable().test(.GET, "/order") { res in
+        try await app.testable().test(.GET, "/order") { res in
+            let order = await store.getOrder()
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(OrderMiddleware.order, ["a", "b", "c", "d"])
+            XCTAssertEqual(order, ["a", "b", "c", "d"])
             XCTAssertEqual(res.body.string, "done")
         }
     }


### PR DESCRIPTION
Make Vapor's `Storage` and `Application` `Sendable`. This is a key piece in allowing `Request` and `Response` to be `Sendable`.

Note that types that are stored in `Storage` should now be `Sendable`. If you get any warnings, you may need to update your code for this new change.