### PR TITLE
The swift-backtrace library is no longer needed in 5.9

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -30,9 +30,6 @@ let package = Package(
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.5.0"),
         
-        // 💥 Backtraces for Swift on Linux
-        .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
-        
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
         
@@ -71,7 +68,6 @@ let package = Package(
             dependencies: [
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "AsyncKit", package: "async-kit"),
-                .product(name: "Backtrace", package: "swift-backtrace"),
                 .target(name: "CVaporBcrypt"),
                 .target(name: "CVaporURLParser"),
                 .product(name: "ConsoleKit", package: "console-kit"),

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -315,15 +315,13 @@ struct TestError: AbortError, DebuggableError {
     }
 
     var source: ErrorSource?
-    var stackTrace: StackTrace?
 
     init(
         file: String = #fileID,
         function: String = #function,
         line: UInt = #line,
         column: UInt = #column,
-        range: Range<UInt>? = nil,
-        stackTrace: StackTrace? = .capture(skip: 1)
+        range: Range<UInt>? = nil
     ) {
         self.source = .init(
             file: file,
@@ -332,7 +330,6 @@ struct TestError: AbortError, DebuggableError {
             column: column,
             range: range
         )
-        self.stackTrace = stackTrace
     }
 }
 

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,4 +1,4 @@
-#if swift(<5.9) || os(Windows)
+#if swift(<5.9)
 import Backtrace
 #endif
 import NIOConcurrencyHelpers
@@ -115,7 +115,7 @@ public final class Application: Sendable {
         _ environment: Environment = .development,
         _ eventLoopGroupProvider: EventLoopGroupProvider = .createNew
     ) {
-        #if swift(<5.9) || os(Windows)
+        #if swift(<5.9)
         Backtrace.install()
         #endif
         self._environment = .init(environment)

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,4 +1,6 @@
+#if swift(<5.9) || os(Windows)
 import Backtrace
+#endif
 import NIOConcurrencyHelpers
 import NIOCore
 import Logging
@@ -113,7 +115,9 @@ public final class Application: Sendable {
         _ environment: Environment = .development,
         _ eventLoopGroupProvider: EventLoopGroupProvider = .createNew
     ) {
+        #if swift(<5.9) || os(Windows)
         Backtrace.install()
+        #endif
         self._environment = .init(environment)
         self.eventLoopGroupProvider = eventLoopGroupProvider
         switch eventLoopGroupProvider {

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -55,6 +55,7 @@ public struct Abort: AbortError, DebuggableError {
     public var source: ErrorSource?
 
     /// Stack trace at point of error creation.
+    @available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
     public var stackTrace: StackTrace?
 
     /// Create a new `Abort`, capturing current source location info.
@@ -68,8 +69,34 @@ public struct Abort: AbortError, DebuggableError {
         function: String = #function,
         line: UInt = #line,
         column: UInt = #column,
+        range: Range<UInt>? = nil
+    ) {
+        self.identifier = identifier ?? status.code.description
+        self.headers = headers
+        self.status = status
+        self.reason = reason ?? status.reasonPhrase
+        self.source = ErrorSource(
+            file: file,
+            function: function,
+            line: line,
+            column: column,
+            range: range
+        )
+    }
+
+    @available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
+    public init(
+        _ status: HTTPResponseStatus,
+        headers: HTTPHeaders = [:],
+        reason: String? = nil,
+        identifier: String? = nil,
+        suggestedFixes: [String] = [],
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line,
+        column: UInt = #column,
         range: Range<UInt>? = nil,
-        stackTrace: StackTrace? = .capture(skip: 1)
+        stackTrace: StackTrace?
     ) {
         self.identifier = identifier ?? status.code.description
         self.headers = headers

--- a/Sources/Vapor/Error/DebuggableError.swift
+++ b/Sources/Vapor/Error/DebuggableError.swift
@@ -29,6 +29,7 @@ public protocol DebuggableError: LocalizedError, CustomDebugStringConvertible, C
     var source: ErrorSource? { get }
 
     /// Stack trace from which this error originated (must set this from the error's init)
+    @available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
     var stackTrace: StackTrace? { get }
 
     /// A `String` array describing the possible causes of the error.
@@ -102,6 +103,7 @@ extension DebuggableError {
         nil
     }
 
+    @available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
     public var stackTrace: StackTrace? {
         nil
     }
@@ -187,9 +189,6 @@ extension DebuggableError {
 
             if !self.gitHubIssues.isEmpty {
                 print.append("See these GitHub issues for discussion on this topic:\(self.gitHubIssues.bulletedList)")
-            }
-            if let stackTrace = self.stackTrace {
-                print.append("Stack trace:\n\(stackTrace)")
             }
         case .short:
             if self.possibleCauses.count > 0 {

--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -1,123 +1,37 @@
 import Foundation
-#if (swift(<5.9) && os(Linux)) || os(Windows)
-import Backtrace
-import CBacktrace
-#endif
 import NIOConcurrencyHelpers
 
+@available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
 extension Optional where Wrapped == StackTrace {
-    public static func capture(skip: Int = 0) -> Self {
-        StackTrace.capture(skip: 1 + skip)
-    }
+    public static func capture(skip: Int = 0) -> Self { StackTrace() }
 }
 
+@available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
 public struct StackTrace: Sendable {
-    public static var isCaptureEnabled: Bool {
-        get {
-            _isCaptureEnabled.withLockedValue {
-                $0
-            }
-        }
-        set {
-            _isCaptureEnabled.withLockedValue {
-                $0 = newValue
-            }
-        }
-    }
-    private static let _isCaptureEnabled: NIOLockedValueBox<Bool> = .init(true)
-
-    public static func capture(skip: Int = 0) -> Self? {
-        guard Self.isCaptureEnabled else {
-            return nil
-        }
-        let frames = Self.captureRaw().dropFirst(1 + skip)
-        return .init(rawFrames: .init(frames))
-    }
-
-    #if (swift(<5.9) && os(Linux)) || os(Windows)
-    private static let state = backtrace_create_state(CommandLine.arguments[0], /* supportThreading: */ 1, nil, nil)
-    #endif
-
-    static func captureRaw() -> [RawFrame] {
-        #if (swift(<5.9) && os(Linux)) || os(Windows)
-        final class Context {
-            var frames: [RawFrame] = []
-        }
-        let context = Context()
-        backtrace_full(self.state, /* skip: */ 1, { data, pc, filename, lineno, function in
-            let frame = RawFrame(
-                file: filename.flatMap { String(cString: $0) } ?? "unknown",
-                mangledFunction: function.flatMap { String(cString: $0) } ?? "unknown"
-            )
-            Unmanaged<Context>.fromOpaque(data!).takeUnretainedValue().frames.append(frame)
-            return 0
-        }, { _, cMessage, _ in
-            let message = cMessage.flatMap { String(cString: $0) } ?? "unknown"
-            fatalError("Failed to capture Linux stacktrace: \(message)")
-        }, Unmanaged.passUnretained(context).toOpaque())
-        return context.frames
-        #else
-        return Thread.callStackSymbols.dropFirst(1).map { line in
-            let parts = line.split(
-                separator: " ",
-                maxSplits: 3,
-                omittingEmptySubsequences: true
-            )
-            let file = parts.count > 1 ? String(parts[1]) : "unknown"
-            let functionPart = parts.count > 3 ? (parts[3].split(separator: "+").first.map({ String($0) }) ?? "unknown") : "unknown"
-            let mangledFunction = functionPart.trimmingCharacters(in: .whitespaces)
-            return .init(file: file, mangledFunction: mangledFunction)
-        }
-        #endif
-    }
-
     public struct Frame: Sendable {
         public var file: String
         public var function: String
     }
-
-    public var frames: [Frame] {
-        self.rawFrames.map { frame in
-            Frame(
-                file: frame.file,
-                function: _stdlib_demangleName(frame.mangledFunction)
-            )
-        }
+    public static var isCaptureEnabled: Bool {
+        get { false }
+        set { }
     }
-
-    struct RawFrame: Sendable {
-        var file: String
-        var mangledFunction: String
-    }
-
-    let rawFrames: [RawFrame]
-
-    public func description(max: Int = 16) -> String {
-        return self.frames[..<min(self.frames.count, max)].readable
-    }
+    public static func capture(skip: Int = 0) -> Self? { nil }
+    public var frames: [Frame] { [] }
+    public func description(max: Int = 16) -> String { "" }
 }
 
+@available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
 extension StackTrace: CustomStringConvertible {
-    public var description: String {
-        self.description()
-    }
+    public var description: String { self.description() }
 }
 
+@available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
 extension StackTrace.Frame: CustomStringConvertible {
-    public var description: String {
-        "\(self.file) \(self.function)"
-    }
+    public var description: String { "\(self.file) \(self.function)" }
 }
 
+@available(*, deprecated, message: "Captured stack traces are no longer supported by Vapor")
 extension Collection where Element == StackTrace.Frame, Index: BinaryInteger {
-    var readable: String {
-        let maxIndexWidth = self.indices.max(by: { String($0).count < String($1).count }).map { String($0).count } ?? 0
-        let maxFileWidth = self.max(by: { $0.file.count < $1.file.count })?.file.count ?? 0
-        return self.enumerated().map { i, frame in
-            let indexPad = String(repeating: " ", count: Swift.max(0, maxIndexWidth - String(i).count))
-            let filePad = String(repeating: " ", count: Swift.max(0, maxFileWidth - frame.file.count))
-            
-            return "\(i)\(indexPad) \(frame.file)\(filePad) \(frame.function)"
-        }.joined(separator: "\n")
-    }
+    var readable: String { "" }
 }

--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(Linux)
+#if swift(<5.9) || os(Windows)
 import Backtrace
 import CBacktrace
 #endif
@@ -34,12 +34,12 @@ public struct StackTrace: Sendable {
         return .init(rawFrames: .init(frames))
     }
 
-    #if os(Linux)
+    #if swift(<5.9) || os(Windows)
     private static let state = backtrace_create_state(CommandLine.arguments[0], /* supportThreading: */ 1, nil, nil)
     #endif
 
     static func captureRaw() -> [RawFrame] {
-        #if os(Linux)
+        #if swift(<5.9) || os(Windows)
         final class Context {
             var frames: [RawFrame] = []
         }

--- a/Sources/Vapor/Error/StackTrace.swift
+++ b/Sources/Vapor/Error/StackTrace.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if swift(<5.9) || os(Windows)
+#if (swift(<5.9) && os(Linux)) || os(Windows)
 import Backtrace
 import CBacktrace
 #endif
@@ -34,12 +34,12 @@ public struct StackTrace: Sendable {
         return .init(rawFrames: .init(frames))
     }
 
-    #if swift(<5.9) || os(Windows)
+    #if (swift(<5.9) && os(Linux)) || os(Windows)
     private static let state = backtrace_create_state(CommandLine.arguments[0], /* supportThreading: */ 1, nil, nil)
     #endif
 
     static func captureRaw() -> [RawFrame] {
-        #if swift(<5.9) || os(Windows)
+        #if (swift(<5.9) && os(Linux)) || os(Windows)
         final class Context {
             var frames: [RawFrame] = []
         }

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -5,11 +5,6 @@ extension LoggingSystem {
     public static func bootstrap(from environment: inout Environment, _ factory: (Logger.Level) -> (String) -> LogHandler) throws {
         let level = try Logger.Level.detect(from: &environment)
 
-        // Disable stack traces if log level > trace.
-        if level > .trace {
-            StackTrace.isCaptureEnabled = false
-        }
-
         // Bootstrap logger with a factory created by the factoryfactory.
         return LoggingSystem.bootstrap(factory(level))
     }

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -166,13 +166,7 @@ private struct NotFoundResponder: Responder {
     }
 }
 
-struct RouteNotFound: Error {
-    let stackTrace: StackTrace?
-
-    init() {
-        self.stackTrace = StackTrace.capture(skip: 1)
-    }
-}
+struct RouteNotFound: Error {}
 
 extension RouteNotFound: AbortError {    
     var status: HTTPResponseStatus {

--- a/Tests/AsyncTests/AsyncMiddlewareTests.swift
+++ b/Tests/AsyncTests/AsyncMiddlewareTests.swift
@@ -85,7 +85,6 @@ final class AsyncMiddlewareTests: XCTestCase {
             XCTAssertEqual(res.headers[.vary], ["origin"])
             XCTAssertEqual(res.headers[.accessControlAllowOrigin], ["foo"])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], ["origin"])
-            print(res.headers)
         }
     }
 
@@ -105,7 +104,6 @@ final class AsyncMiddlewareTests: XCTestCase {
             XCTAssertEqual(res.headers[.vary], [])
             XCTAssertEqual(res.headers[.accessControlAllowOrigin], [""])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], [""])
-            print(res.headers)
         }
     }
 }

--- a/Tests/VaporTests/BcryptTests.swift
+++ b/Tests/VaporTests/BcryptTests.swift
@@ -22,11 +22,8 @@ final class BcryptTests: XCTestCase {
     }
 
     func testInvalidSalt() throws {
-        do {
-            _ = try Bcrypt.verify("", created: "foo")
-            XCTFail("Should have failed")
-        } catch let error as BcryptError {
-            print(error)
+        XCTAssertThrowsError(try Bcrypt.verify("", created: "foo")) {
+            XCTAssert($0 is BcryptError)
         }
     }
 

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -400,7 +400,6 @@ final class ContentTests: XCTestCase {
             return User(name: "Vapor", age: 3, luckyNumbers: [5, 7])
         }
         try app.testable().test(.GET, "/urlencodedform") { res in
-            debugPrint(res)
             XCTAssertEqual(res.status.code, 200)
             XCTAssertEqual(res.headers.contentType, .urlEncodedForm)
             XCTAssertContains(res.body.string, "luckyNumbers[]=5")

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -4,7 +4,6 @@ import Logging
 
 final class ErrorTests: XCTestCase {
     func testPrintable() throws {
-        print(FooError.noFoo.debugDescription)
         let expectedPrintable = """
         FooError.noFoo: You do not have a `foo`.
         Here are some possible causes:

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -93,7 +93,6 @@ final class FileTests: XCTestCase {
             
             let range = upperRange - lowerRange + 1
             let length = Int(contentLength!)!
-            print("\(range) : \(length)")
 
             XCTAssertTrue(range == length)
         }
@@ -125,7 +124,6 @@ final class FileTests: XCTestCase {
             
             let range = upperRange - lowerRange + 1
             let length = Int(contentLength!)!
-            print("\(range) : \(length)")
 
             XCTAssertTrue(range == length)
         }
@@ -157,7 +155,6 @@ final class FileTests: XCTestCase {
             
             let range = upperRange - lowerRange + 1
             let length = Int(contentLength!)!
-            print("\(range) : \(length)")
 
             XCTAssertTrue(range == length)
         }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -219,7 +219,6 @@ final class HTTPHeaderTests: XCTestCase {
                 """
             )
         ])
-        print(headers.cookie!.all.keys)
         XCTAssertEqual(headers.cookie?["vapor-session"]?.string, "0FuTYcHmGw7Bz1G4HiF+EA==")
         XCTAssertEqual(headers.cookie?["vapor-session"]?.sameSite, .lax)
         XCTAssertEqual(headers.cookie?["_ga"]?.string, "GA1.1.500315824.1585154561")

--- a/Tests/VaporTests/MetricsTests.swift
+++ b/Tests/VaporTests/MetricsTests.swift
@@ -32,7 +32,6 @@ class MetricsTests: XCTestCase {
             XCTAssertEqual(resData.id, 1)
             XCTAssertEqual(metrics.counters.count, 1)
             let counter = metrics.counters["http_requests_total"] as! TestCounter
-            print(counter.dimensions)
             let pathDimension = try XCTUnwrap(counter.dimensions.first(where: { $0.0 == "path"}))
             XCTAssertEqual(pathDimension.1, "/users/:userID")
             XCTAssertNil(counter.dimensions.first(where: { $0.0 == "path" && $0.1 == "/users/1" }))

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -89,7 +89,6 @@ final class MiddlewareTests: XCTestCase {
             XCTAssertEqual(res.headers[.vary], ["origin"])
             XCTAssertEqual(res.headers[.accessControlAllowOrigin], ["foo"])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], ["origin"])
-            print(res.headers)
         }
     }
 
@@ -109,7 +108,6 @@ final class MiddlewareTests: XCTestCase {
             XCTAssertEqual(res.headers[.vary], [])
             XCTAssertEqual(res.headers[.accessControlAllowOrigin], [""])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], [""])
-            print(res.headers)
         }
     }
     

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -177,7 +177,6 @@ final class QueryTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("urlencodedform") { req -> HTTPStatus in
-            debugPrint(req)
             let foo = try req.query.decode(User.self)
             XCTAssertEqual(foo.name, "Vapor")
             XCTAssertEqual(foo.age, 3)

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -61,7 +61,6 @@ final class RouteTests: XCTestCase {
         defer { app.shutdown() }
 
         app.routes.get("json") { req -> [String: String] in
-            print(req)
             return ["foo": "bar"]
         }
 

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -483,7 +483,6 @@ final class URLEncodedFormTests: XCTestCase {
     func testCodable() throws {
         let a = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [], nums: [], isCool: true)
         let body = try URLEncodedFormEncoder().encode(a)
-        print(body)
         let b = try! URLEncodedFormDecoder().decode(User.self, from: body)
         XCTAssertEqual(a, b)
     }

--- a/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
+++ b/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
@@ -90,14 +90,12 @@ internal class TestCounter: CounterHandler, Equatable {
         self.lock.withLock {
             self.values.append((Date(), amount))
         }
-        print("adding \(amount) to \(self.label)")
     }
 
     func reset() {
         self.lock.withLock {
             self.values = []
         }
-        print("resetting \(self.label)")
     }
 
     public static func == (lhs: TestCounter, rhs: TestCounter) -> Bool {
@@ -129,7 +127,6 @@ internal class TestRecorder: RecorderHandler, Equatable {
         self.lock.withLock {
             values.append((Date(), value))
         }
-        print("recording \(value) in \(self.label)")
     }
 
     public static func == (lhs: TestRecorder, rhs: TestRecorder) -> Bool {
@@ -173,7 +170,6 @@ internal class TestTimer: TimerHandler, Equatable {
         self.lock.withLock {
             values.append((Date(), duration))
         }
-        print("recording \(duration) \(self.label)")
     }
 
     public static func == (lhs: TestTimer, rhs: TestTimer) -> Bool {


### PR DESCRIPTION
Per https://github.com/swift-server/swift-backtrace/pull/68.