### PR TITLE
Revert "`Logger.report()` should handle `LocalizedError`, `DecodingError`, and `EncodingError` identically to other errors"

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,4 +11,4 @@ jobs:
      with:
        package_name: vapor
        modules: Vapor,XCTVapor
-       pathsToInvalidate: /vapor/* /xctvapor/*
+       pathsToInvalidate: /vapor /xctvapor

--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -1,0 +1,11 @@
+name: issue-to-project-board-workflow
+on:
+  # Trigger when an issue gets labeled or deleted
+  issues:
+    types: [reopened, closed, labeled, unlabeled, assigned, unassigned]
+
+jobs:
+  update_project_boards:
+    name: Update project boards
+    uses: vapor/ci/.github/workflows/update-project-boards-for-issue.yml@reusable-workflows
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,14 @@ jobs:
           - provider: vapor/apns
             ref: 3.0.0
     runs-on: ubuntu-latest
-    container: swift:5.9-jammy
+    container: swift:5.8-jammy
     steps: 
       - name: Check out Vapor
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: vapor
       - name: Check out provider
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with: 
           repository: ${{ matrix.provider }}
           path: provider
@@ -45,4 +45,6 @@ jobs:
   unit-tests:
      uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
      with:
+       with_coverage: true
        with_tsan: false
+       with_public_api_check: true

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -28,12 +28,24 @@ extension Logger {
             reason = abort.reason
             source = nil
             level = .warning
+        case let encoding as EncodingError:
+            reason = "\(encoding)"
+            source = nil
+            level = .warning
+        case let decoding as DecodingError:
+            reason = "\(decoding)"
+            source = nil
+            level = .warning
+        case let localized as LocalizedError:
+            reason = localized.localizedDescription
+            source = nil
+            level = .warning
         default:
             reason = String(reflecting: error)
             source = nil
             level = .warning
         }
-
+        
         self.log(
             level: level,
             .init(stringLiteral: reason),


### PR DESCRIPTION
Reverts vapor/vapor#3068

The best practice is to use `localizedDescription` for reporting errors in UI and logs. The reason why you might see a default string is that the author of whichever error type is being reported didn’t both make the type conform to `LocalizedError` and implement `errorDescription` as an instance property of type `String?`. Whatever string is returned in an `errorDescription` implementation in a `LocalizedError`-conforming type is automatically used as the value of `localizedDescription`, even in contexts in which the type is statically bound to implementations on `any Error`.

There’s no need to handle `LocalizedError` specially to take advantage of this behavior. I would suggest that a separate pull request remove the undesirable special handling without the collateral damage of ignoring `localizedDescription` entirely.

See [my comment](https://github.com/apple/swift/issues/68102#issuecomment-1728355333) on the relevant issue in `apple/swift`.