### PR TITLE
Remove hardcoded ports in tests

### DIFF
--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -51,7 +51,19 @@ extension Application {
             defer { try! client.syncShutdown() }
             var path = request.url.path
             path = path.hasPrefix("/") ? path : "/\(path)"
-            var url = "http://\(self.hostname):\(self.port)\(path)"
+            
+            let actualPort: Int
+            
+            if self.port == 0 {
+                guard let portAllocated = app.http.server.shared.localAddress?.port else {
+                    throw Abort(.internalServerError, reason: "Failed to get port from local address")
+                }
+                actualPort = portAllocated
+            } else {
+                actualPort = self.port
+            }
+            
+            var url = "http://\(self.hostname):\(actualPort)\(path)"
             if let query = request.url.query {
                 url += "?\(query)"
             }

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -13,6 +13,7 @@ extension Application: XCTApplicationTester {
 extension Application {
     public enum Method {
         case inMemory
+        // TODO: Default to Port 0 in the next major release
         public static var running: Method {
             return .running(hostname:"localhost", port: 8080)
         }

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -68,10 +68,15 @@ final class AsyncClientTests: XCTestCase {
             $0.redirect(to: "foo")
         }
 
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
 
-        let res = try await app.client.get("http://localhost:8080/redirect")
+        let res = try await app.client.get("http://localhost:\(port)/redirect")
 
         XCTAssertEqual(res.status, .seeOther)
     }
@@ -86,13 +91,18 @@ final class AsyncClientTests: XCTestCase {
             $0.redirect(to: "foo")
         }
 
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
 
-        _ = try await app.client.get("http://localhost:8080/redirect")
+        _ = try await app.client.get("http://localhost:\(port)/redirect")
 
         app.http.client.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
-        let res = try await app.client.get("http://localhost:8080/redirect")
+        let res = try await app.client.get("http://localhost:\(port)/redirect")
         XCTAssertEqual(res.status, .seeOther)
     }
 

--- a/Tests/AsyncTests/AsyncRouteTests.swift
+++ b/Tests/AsyncTests/AsyncRouteTests.swift
@@ -75,7 +75,7 @@ final class AsyncRouteTests: XCTestCase {
             [testMarkerHeaderKey: testMarkerHeaderValue]
         }, onUpgrade: { _, _ in })
 
-        try app.testable(method: .running).test(.GET, "customshouldupgrade", beforeRequest: { req in
+        try app.testable(method: .running(port: 0)).test(.GET, "customshouldupgrade", beforeRequest: { req in
             req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketVersion, value: "13")
             req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketKey, value: "zyFJtLIpI2ASsmMHJ4Cf0A==")
             req.headers.replaceOrAdd(name: .connection, value: "Upgrade")

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -72,10 +72,15 @@ final class ClientTests: XCTestCase {
             $0.redirect(to: "foo")
         }
 
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
 
-        let res = try app.client.get("http://localhost:8080/redirect").wait()
+        let res = try app.client.get("http://localhost:\(port)/redirect").wait()
 
         XCTAssertEqual(res.status, .seeOther)
     }
@@ -90,13 +95,18 @@ final class ClientTests: XCTestCase {
             $0.redirect(to: "foo")
         }
 
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
 
-        _ = try app.client.get("http://localhost:8080/redirect").wait()
+        _ = try app.client.get("http://localhost:\(port)/redirect").wait()
         
         app.http.client.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
-        let res = try app.client.get("http://localhost:8080/redirect").wait()
+        let res = try app.client.get("http://localhost:\(port)/redirect").wait()
         XCTAssertEqual(res.status, .seeOther)
     }
 

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -19,7 +19,7 @@ final class FileTests: XCTestCase {
             }
         }
 
-        try app.testable(method: .running).test(.GET, "/file-stream") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream") { res in
             let test = "the quick brown fox"
             XCTAssertNotNil(res.headers.first(name: .eTag))
             XCTAssertContains(res.body.string, test)
@@ -36,7 +36,7 @@ final class FileTests: XCTestCase {
 
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .connection, value: "close")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             let test = "the quick brown fox"
             XCTAssertNotNil(res.headers.first(name: .eTag))
             XCTAssertContains(res.body.string, test)
@@ -62,7 +62,7 @@ final class FileTests: XCTestCase {
             }
         }
 
-        try app.testable(method: .running).test(.GET, "/file-stream") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream") { res in
             XCTAssertTrue(res.body.string.isEmpty)
         }
     }
@@ -83,7 +83,7 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.tail(value: 20)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             
             let contentRange = res.headers.first(name: "content-range")
             let contentLength = res.headers.first(name: "content-length")
@@ -114,7 +114,7 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.start(value: 20)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             
             let contentRange = res.headers.first(name: "content-range")
             let contentLength = res.headers.first(name: "content-length")
@@ -145,7 +145,7 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 20, end: 25)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             
             let contentRange = res.headers.first(name: "content-range")
             let contentLength = res.headers.first(name: "content-length")
@@ -176,7 +176,7 @@ final class FileTests: XCTestCase {
 
         var headers = HTTPHeaders()
         headers.range = .init(unit: .bytes, ranges: [.within(start: 0, end: 0)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .partialContent)
 
             XCTAssertEqual(res.headers.first(name: .contentLength), "1")
@@ -203,12 +203,12 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.within(start: -20, end: 25)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
 
         headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 10, end: 100000000)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
     }
@@ -229,12 +229,12 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.start(value: -20)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
 
         headerRequest.range = .init(unit: .bytes, ranges: [.start(value: 100000000)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
     }
@@ -255,12 +255,12 @@ final class FileTests: XCTestCase {
         
         var headerRequest = HTTPHeaders()
         headerRequest.range = .init(unit: .bytes, ranges: [.tail(value: -20)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
 
         headerRequest.range = .init(unit: .bytes, ranges: [.tail(value: 100000000)])
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headerRequest) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
     }
@@ -404,42 +404,42 @@ final class FileTests: XCTestCase {
 
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .range, value: "bytes=0-9223372036854775807")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=-1-10")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=100-10")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=10--100")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=9223372036854775808-")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=922337203-")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=-922337203")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=-9223372036854775808")
-        try app.testable(method: .running).test(.GET, "/file-stream", headers: headers) { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -41,7 +41,7 @@ final class RequestTests: XCTestCase {
             return peerAddress.description
         }
 
-        try app.testable(method: .running).test(.GET, "remote") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
             XCTAssertEqual(res.body.string, "[IPv4]192.0.2.60:80")
         }
     }
@@ -58,7 +58,7 @@ final class RequestTests: XCTestCase {
             return peerAddress.description
         }
 
-        try app.testable(method: .running).test(.GET, "remote") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
             XCTAssertEqual(res.body.string, "[IPv4]5.6.7.8:80")
         }
     }
@@ -108,7 +108,7 @@ final class RequestTests: XCTestCase {
             $0.remoteAddress?.description ?? "n/a"
         }
         
-        try app.testable(method: .running).test(.GET, "remote") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
             XCTAssertContains(res.body.string, "IP")
         }
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -233,23 +233,28 @@ final class RequestTests: XCTestCase {
             $0.redirect(to: "foo", redirectType: .permanentPost)
         }
         
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
+        
         XCTAssertEqual(
-            try app.client.get("http://localhost:8080/redirect_normal").wait().status,
+            try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,
             .seeOther
         )
         XCTAssertEqual(
-            try app.client.get("http://localhost:8080/redirect_permanent").wait().status,
+            try app.client.get("http://localhost:\(port)/redirect_permanent").wait().status,
             .movedPermanently
         )
         XCTAssertEqual(
-            try app.client.post("http://localhost:8080/redirect_temporary").wait().status,
+            try app.client.post("http://localhost:\(port)/redirect_temporary").wait().status,
             .temporaryRedirect
         )
         XCTAssertEqual(
-            try app.client.post("http://localhost:8080/redirect_permanentPost").wait().status,
+            try app.client.post("http://localhost:\(port)/redirect_permanentPost").wait().status,
             .permanentRedirect
         )
     }
@@ -272,19 +277,24 @@ final class RequestTests: XCTestCase {
             $0.redirect(to: "foo", type: .temporary)
         }
         
-        try app.server.start(address: .hostname("localhost", port: 8080))
+        try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
+        
         XCTAssertEqual(
-            try app.client.get("http://localhost:8080/redirect_normal").wait().status,
+            try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,
             .seeOther
         )
         XCTAssertEqual(
-            try app.client.get("http://localhost:8080/redirect_permanent").wait().status,
+            try app.client.get("http://localhost:\(port)/redirect_permanent").wait().status,
             .movedPermanently
         )
         XCTAssertEqual(
-            try app.client.post("http://localhost:8080/redirect_temporary").wait().status,
+            try app.client.post("http://localhost:\(port)/redirect_temporary").wait().status,
             .temporaryRedirect
         )
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -75,7 +75,7 @@ final class RequestTests: XCTestCase {
         }
 
         let ipV4Hostname = "127.0.0.1"
-        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "remote") { res in
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "remote") { res in
             XCTAssertContains(res.body.string, "[IPv4]\(ipV4Hostname)")
         }
     }
@@ -94,7 +94,7 @@ final class RequestTests: XCTestCase {
         }
 
         let ipV4Hostname = "127.0.0.1"
-        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "remote") { res in
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "remote") { res in
             XCTAssertEqual(res.body.string, "[IPv4]192.0.2.60:80")
         }
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -14,7 +14,7 @@ final class RequestTests: XCTestCase {
         }
         
         let ipV4Hostname = "127.0.0.1"
-        try app.testable(method: .running(hostname: ipV4Hostname, port: 8080)).test(.GET, "vapor/is/fun") { res in
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "vapor/is/fun") { res in
             XCTAssertEqual(res.body.string, ipV4Hostname)
         }
     }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -237,7 +237,7 @@ final class RouteTests: XCTestCase {
             return "hi"
         }
 
-        try app.testable(method: .running).test(.HEAD, "/hello") { res in
+        try app.testable(method: .running(port: 0)).test(.HEAD, "/hello") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.headers.first(name: .contentLength), "0")
             XCTAssertEqual(res.body.readableBytes, 0)
@@ -253,7 +253,7 @@ final class RouteTests: XCTestCase {
             return "hi"
         }
 
-        try app.testable(method: .running).test(.HEAD, "/hello/joe") { res in
+        try app.testable(method: .running(port: 0)).test(.HEAD, "/hello/joe") { res in
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.headers.first(name: .contentLength), "2")
             XCTAssertEqual(res.body.readableBytes, 0)
@@ -272,7 +272,7 @@ final class RouteTests: XCTestCase {
             return Response(status: .found)
         }
 
-        try app.testable(method: .running).test(.HEAD, "/hello") { res in
+        try app.testable(method: .running(port: 0)).test(.HEAD, "/hello") { res in
             XCTAssertEqual(res.status, .found)
             XCTAssertEqual(res.headers.first(name: .contentLength), "0")
             XCTAssertEqual(res.body.readableBytes, 0)
@@ -308,7 +308,7 @@ final class RouteTests: XCTestCase {
             throw Abort(.noContent)
         }
 
-        try app.testable(method: .running).test(.GET, "/no-content") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/no-content") { res in
             XCTAssertEqual(res.status.code, 204)
             XCTAssertEqual(res.body.readableBytes, 0)
         }
@@ -325,7 +325,7 @@ final class RouteTests: XCTestCase {
             "b"
         }
 
-        try app.testable(method: .running).test(.GET, "/api/addresses/") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/api/addresses/") { res in
             XCTAssertEqual(res.body.string, "a")
         }.test(.GET, "/api/addresses/search/test") { res in
             XCTAssertEqual(res.body.string, "b")
@@ -384,7 +384,7 @@ final class RouteTests: XCTestCase {
 
         var buffer = ByteBufferAllocator().buffer(capacity: 0)
         buffer.writeBytes(Array(repeating: 0, count: 500_000))
-        try app.testable(method: .running).test(.POST, "/default", body: buffer) { res in
+        try app.testable(method: .running(port: 0)).test(.POST, "/default", body: buffer) { res in
             XCTAssertEqual(res.status, .payloadTooLarge)
         }.test(.POST, "/1kb", body: buffer) { res in
             XCTAssertEqual(res.status, .payloadTooLarge)
@@ -406,7 +406,7 @@ final class RouteTests: XCTestCase {
             return req.eventLoop.future([testMarkerHeaderKey: testMarkerHeaderValue])
         }, onUpgrade: { _, _ in })
         
-        try app.testable(method: .running).test(.GET, "customshouldupgrade", beforeRequest: { req in
+        try app.testable(method: .running(port: 0)).test(.GET, "customshouldupgrade", beforeRequest: { req in
             req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketVersion, value: "13")
             req.headers.replaceOrAdd(name: HTTPHeaders.Name.secWebSocketKey, value: "zyFJtLIpI2ASsmMHJ4Cf0A==")
             req.headers.replaceOrAdd(name: .connection, value: "Upgrade")
@@ -425,7 +425,7 @@ final class RouteTests: XCTestCase {
             return req.client.get("http://localhost/status/2 1").map { $0.description }
         }
         
-        try app.testable(method: .running).test(.GET, "/client") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/client") { res in
             XCTAssertEqual(res.status.code, 500)
         }
     }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -533,10 +533,14 @@ final class ServerTests: XCTestCase {
             }))
         }
         
-        let port = 1337
-        app.http.server.configuration.port = port
+        app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
         try app.start()
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port")
+            return
+        }
         
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/echo",
@@ -591,10 +595,14 @@ final class ServerTests: XCTestCase {
             "hello, world"
         }
         
-        let port = 1337
-        app.http.server.configuration.port = port
+        app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
         try app.start()
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port")
+            return
+        }
         
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/echo",
@@ -743,10 +751,14 @@ final class ServerTests: XCTestCase {
             "world"
         }
         
-        let port = 1337
-        app.http.server.configuration.port = port
+        app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
         try app.start()
+        
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port")
+            return
+        }
         
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/hello",

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -407,7 +407,7 @@ final class ServerTests: XCTestCase {
         
         var buffer = ByteBufferAllocator().buffer(capacity: payload.count)
         buffer.writeBytes(payload)
-        try app.testable(method: .running).test(.POST, "payload", body: buffer) { res in
+        try app.testable(method: .running(port: 0)).test(.POST, "payload", body: buffer) { res in
             XCTAssertEqual(res.status, .ok)
         }
     }
@@ -431,7 +431,7 @@ final class ServerTests: XCTestCase {
             return promise.futureResult
         }
         
-        try app.testable(method: .running).test(.POST, "drain", beforeRequest: { req in
+        try app.testable(method: .running(port: 0)).test(.POST, "drain", beforeRequest: { req in
             try req.content.encode(["hello": "world"])
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
@@ -491,7 +491,7 @@ final class ServerTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 10_000_000)
         buffer.writeString(String(repeating: "a", count: 10_000_000))
         
-        try app.testable(method: .running).test(.POST, "upload", beforeRequest: { req in
+        try app.testable(method: .running(port: 0)).test(.POST, "upload", beforeRequest: { req in
             req.body = buffer
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .badRequest)


### PR DESCRIPTION
Resolves #3052 and #2568 

Tests can now be run in parallel and pass