### PR TITLE
Pass X-Request-Id if present

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -421,6 +421,8 @@ extension HTTPHeaders {
         public static let xForwardedHost = Name("X-Forwarded-Host")
         /// X-Forwarded-Proto header.
         public static let xForwardedProto = Name("X-Forwarded-Proto")
+        /// X-Request-Id header.
+        public static let xRequestId = Name("X-Request-Id")
     }
     
     /// Add a header name/value pair to the block.

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -250,7 +250,7 @@ public final class Request: CustomStringConvertible {
         self.storage = .init()
         self.isKeepAlive = true
         self.logger = logger
-        if let requestId = self.headers["X_REQUEST_ID"].first {
+        if let requestId = self.headers[.xRequestId].first {
             self.logger[metadataKey: "request-id"] = .string(requestId)
         } else {
             self.logger[metadataKey: "request-id"] = .string(UUID().uuidString)

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -250,16 +250,11 @@ public final class Request: CustomStringConvertible {
         self.storage = .init()
         self.isKeepAlive = true
         self.logger = logger
-<<<<<<< Updated upstream
-        self.logger[metadataKey: "request-id"] = .string(id)
-=======
         if let requestId = self.headers["X_REQUEST_ID"].first {
             self.logger[metadataKey: "request-id"] = .string(requestId)
         } else {
             self.logger[metadataKey: "request-id"] = .string(UUID().uuidString)
         }
-
->>>>>>> Stashed changes
         self.byteBufferAllocator = byteBufferAllocator
     }
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -250,7 +250,16 @@ public final class Request: CustomStringConvertible {
         self.storage = .init()
         self.isKeepAlive = true
         self.logger = logger
+<<<<<<< Updated upstream
         self.logger[metadataKey: "request-id"] = .string(id)
+=======
+        if let requestId = self.headers["X_REQUEST_ID"].first {
+            self.logger[metadataKey: "request-id"] = .string(requestId)
+        } else {
+            self.logger[metadataKey: "request-id"] = .string(UUID().uuidString)
+        }
+
+>>>>>>> Stashed changes
         self.byteBufferAllocator = byteBufferAllocator
     }
 }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -201,6 +201,13 @@ final class HTTPHeaderTests: XCTestCase {
         )
     }
 
+    func testXRequestId() throws {
+        var headers = HTTPHeaders()
+        let xRequestId = UUID().uuidString
+        headers.replaceOrAdd(name: .xRequestId, value: xRequestId)
+        XCTAssertEqual(headers.first(name: "X-Request-Id"), xRequestId)
+    }
+
     func testContentDisposition() throws {
         let headers = HTTPHeaders([
             ("Content-Disposition", #"form-data; name="fieldName"; filename="filename.jpg""#)


### PR DESCRIPTION
Pass the value from the X-Request-Id to the logger context

- pass the X-Request-Id header value if present, pass generated UUID if the header not present

Mentioned:
- https://github.com/vapor/vapor/issues/2508

Why:
 - We needed a way to trace router -> web -> worker on the logger on the heroku and we found this https://devcenter.heroku.com/articles/http-request-id

Inspiration:
- https://api.rubyonrails.org/classes/ActionDispatch/RequestId.html
- https://http.dev/x-request-id