### PR TITLE
Support Crypto 3.0.0 in the other package manifest

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.0.0"),
         
         // 🔑 Hashing (SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
         
         // 🚍 High-performance trie-node router.
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.5.0"),


### PR DESCRIPTION
Fixes an oversight made by both Tim and myself in #3070. Full credit to @gregcotten for catching the omission.

<img src="https://github.com/vapor/vapor/assets/1130717/9815ff60-b69f-4875-bf21-4cb522e43d5f" alt="Vapor Heart" width="16"> Thanks, Greg! <img src="https://github.com/vapor/vapor/assets/1130717/9815ff60-b69f-4875-bf21-4cb522e43d5f" alt="Vapor Heart" width="16">