### PR TITLE
Add numerous missing `@preconcurrency` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         <img src="https://github.com/vapor/vapor/actions/workflows/test.yml/badge.svg?branch=main" alt="Continuous Integration">
     </a>
     <a href="https://swift.org">
-        <img src="https://img.shields.io/badge/swift-5.6-brightgreen.svg" alt="Swift 5.6">
+        <img src="https://img.shields.io/badge/swift-5.7-brightgreen.svg" alt="Swift 5.7">
     </a>
     <a href="https://twitter.com/codevapor">
         <img src="https://img.shields.io/badge/twitter-codevapor-5AA9E7.svg" alt="Twitter">

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -1,5 +1,5 @@
 import class Foundation.Bundle
-import Vapor
+@preconcurrency import Vapor
 import NIOCore
 import NIOHTTP1
 import NIOConcurrencyHelpers

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -1,5 +1,5 @@
 import class Foundation.Bundle
-@preconcurrency import Vapor
+import Vapor
 import NIOCore
 import NIOHTTP1
 import NIOConcurrencyHelpers

--- a/Sources/Vapor/Cache/Application+Cache.swift
+++ b/Sources/Vapor/Cache/Application+Cache.swift
@@ -21,7 +21,7 @@ extension Application {
         public struct Provider: Sendable {
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -46,7 +46,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeCache: @Sendable @escaping (Application) -> (Cache)) {
+        @preconcurrency public func use(_ makeCache: @Sendable @escaping (Application) -> (Cache)) {
             self.storage.makeCache.withLockedValue { $0 = .init(factory: makeCache) }
         }
 

--- a/Sources/Vapor/Client/Application+Clients.swift
+++ b/Sources/Vapor/Client/Application+Clients.swift
@@ -16,7 +16,7 @@ extension Application {
         public struct Provider {
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -43,7 +43,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeClient: @Sendable @escaping (Application) -> (Client)) {
+        @preconcurrency public func use(_ makeClient: @Sendable @escaping (Application) -> (Client)) {
             self.storage.makeClient.withLockedValue { $0 = .init(factory: makeClient) }
         }
 

--- a/Sources/Vapor/HTTP/BasicResponder.swift
+++ b/Sources/Vapor/HTTP/BasicResponder.swift
@@ -14,7 +14,7 @@ public struct BasicResponder: Responder {
     ///
     /// - parameters:
     ///     - closure: Responder closure.
-    public init(
+    @preconcurrency public init(
         closure: @Sendable @escaping (Request) throws -> EventLoopFuture<Response>
     ) {
         self.closure = closure

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -138,7 +138,7 @@ public struct WebSocketUpgrader: Upgrader, Sendable {
     var shouldUpgrade: (@Sendable () -> EventLoopFuture<HTTPHeaders?>)
     var onUpgrade: @Sendable (WebSocket) -> ()
     
-    public init(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: @escaping (@Sendable () -> EventLoopFuture<HTTPHeaders?>), onUpgrade: @Sendable @escaping (WebSocket) -> ()) {
+    @preconcurrency public init(maxFrameSize: WebSocketMaxFrameSize, shouldUpgrade: @escaping (@Sendable () -> EventLoopFuture<HTTPHeaders?>), onUpgrade: @Sendable @escaping (WebSocket) -> ()) {
         self.maxFrameSize = maxFrameSize
         self.shouldUpgrade = shouldUpgrade
         self.onUpgrade = onUpgrade

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -68,7 +68,7 @@ public final class ErrorMiddleware: Middleware {
     ///
     /// - parameters:
     ///     - closure: Error-handling closure. Converts `Error` to `Response`.
-    public init(_ closure: @Sendable @escaping (Request, Error) -> (Response)) {
+    @preconcurrency public init(_ closure: @Sendable @escaping (Request, Error) -> (Response)) {
         self.closure = closure
     }
     

--- a/Sources/Vapor/Passwords/Application+Passwords.swift
+++ b/Sources/Vapor/Passwords/Application+Passwords.swift
@@ -9,7 +9,7 @@ extension Application {
         public struct Provider: Sendable {
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -24,7 +24,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(
+        @preconcurrency public func use(
             _ makeVerifier: @Sendable @escaping (Application) -> (PasswordHasher)
         ) {
             self.storage.makeVerifier.withLockedValue { $0 = .init(factory: makeVerifier) }

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -23,7 +23,7 @@ extension Request {
             }
         }
         
-        public func drain(_ handler: @Sendable @escaping (BodyStreamResult) -> EventLoopFuture<Void>) {
+        @preconcurrency public func drain(_ handler: @Sendable @escaping (BodyStreamResult) -> EventLoopFuture<Void>) {
             switch self.request.bodyStorage {
             case .stream(let stream):
                 stream.read { (result, promise) in

--- a/Sources/Vapor/Responder/Application+Responder.swift
+++ b/Sources/Vapor/Responder/Application+Responder.swift
@@ -16,7 +16,7 @@ extension Application {
 
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -56,7 +56,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ factory: @Sendable @escaping (Application) -> (Vapor.Responder)) {
+        @preconcurrency public func use(_ factory: @Sendable @escaping (Application) -> (Vapor.Responder)) {
             self.storage.factory.withLockedValue { $0 = .init(factory: factory) }
         }
 

--- a/Sources/Vapor/Routing/Request+WebSocket.swift
+++ b/Sources/Vapor/Routing/Request+WebSocket.swift
@@ -3,7 +3,7 @@ import WebSocketKit
 import NIOHTTP1
 
 extension Request {
-     public func webSocket(
+     @preconcurrency public func webSocket(
          maxFrameSize: WebSocketMaxFrameSize = .`default`,
          shouldUpgrade: @escaping (@Sendable (Request) -> EventLoopFuture<HTTPHeaders?>) = {
              $0.eventLoop.makeSucceededFuture([:])

--- a/Sources/Vapor/Server/Application+Servers.swift
+++ b/Sources/Vapor/Server/Application+Servers.swift
@@ -16,7 +16,7 @@ extension Application {
         public struct Provider {
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -47,7 +47,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeServer: @Sendable @escaping (Application) -> (Server)) {
+        @preconcurrency public func use(_ makeServer: @Sendable @escaping (Application) -> (Server)) {
             self.storage.makeServer.withLockedValue { $0 = .init(factory: makeServer) }
         }
 

--- a/Sources/Vapor/Sessions/Application+Sessions.swift
+++ b/Sources/Vapor/Sessions/Application+Sessions.swift
@@ -15,7 +15,7 @@ extension Application {
 
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -71,7 +71,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeDriver: @Sendable @escaping (Application) -> (SessionDriver)) {
+        @preconcurrency public func use(_ makeDriver: @Sendable @escaping (Application) -> (SessionDriver)) {
             self.storage.makeDriver.withLockedValue { $0 = .init(factory: makeDriver) }
         }
 

--- a/Sources/Vapor/Sessions/SessionsConfiguration.swift
+++ b/Sources/Vapor/Sessions/SessionsConfiguration.swift
@@ -17,7 +17,7 @@ public struct SessionsConfiguration: Sendable {
     /// - parameters:
     ///     - cookieName: Name of HTTP cookie, used as a key for the cookie value.
     ///     - cookieFactory: Creates a new `HTTPCookieValue` for the supplied value `String`.
-    public init(cookieName: String, cookieFactory: @Sendable @escaping (SessionID) -> HTTPCookies.Value) {
+    @preconcurrency public init(cookieName: String, cookieFactory: @Sendable @escaping (SessionID) -> HTTPCookies.Value) {
         self.cookieName = cookieName
         self.cookieFactory = cookieFactory
     }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -86,7 +86,7 @@ public struct FileIO: Sendable {
     ///     - chunkSize: Maximum size for the file data chunks.
     ///     - onRead: Closure to be called sequentially for each file data chunk.
     /// - returns: `Future` that will complete when the file read is finished.
-    public func readFile(
+    @preconcurrency public func readFile(
         at path: String,
         chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
         onRead: @Sendable @escaping (ByteBuffer) -> EventLoopFuture<Void>
@@ -122,7 +122,7 @@ public struct FileIO: Sendable {
     ///     - mediaType: HTTPMediaType, if not specified, will be created from file extension.
     ///     - onCompleted: Closure to be run on completion of stream.
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.
-    public func streamFile(
+    @preconcurrency public func streamFile(
         at path: String,
         chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
         mediaType: HTTPMediaType? = nil,

--- a/Sources/Vapor/Utilities/Thread.swift
+++ b/Sources/Vapor/Utilities/Thread.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Thread {
     /// Convenience wrapper around `Thread.detachNewThread`.
-    public static func async(_ work: @Sendable @escaping () -> ()) {
+    @preconcurrency public static func async(_ work: @Sendable @escaping () -> ()) {
         Thread.detachNewThread {
             work()
         }

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -36,7 +36,7 @@ public struct Validations: Sendable {
         self.storage.append(.init(nested: key, required: required, keyed: validations, customFailureDescription: customFailureDescription))
     }
     
-    public mutating func add(
+    @preconcurrency public mutating func add(
         each key: ValidationKey,
         required: Bool = true,
         customFailureDescription: String? = nil,

--- a/Sources/Vapor/Validation/Validator.swift
+++ b/Sources/Vapor/Validation/Validator.swift
@@ -1,6 +1,6 @@
 public struct Validator<T: Decodable & Sendable>: Sendable {
     public let validate: @Sendable (_ data: T) -> ValidatorResult
-    public init(validate: @Sendable @escaping (_ data: T) -> ValidatorResult) {
+    @preconcurrency public init(validate: @Sendable @escaping (_ data: T) -> ValidatorResult) {
         self.validate = validate
     }
 }

--- a/Sources/Vapor/View/Application+Views.swift
+++ b/Sources/Vapor/View/Application+Views.swift
@@ -22,7 +22,7 @@ extension Application {
 
             let run: @Sendable (Application) -> ()
 
-            public init(_ run: @Sendable @escaping (Application) -> ()) {
+            @preconcurrency public init(_ run: @Sendable @escaping (Application) -> ()) {
                 self.run = run
             }
         }
@@ -56,7 +56,7 @@ extension Application {
             provider.run(self.application)
         }
 
-        public func use(_ makeRenderer: @Sendable @escaping (Application) -> (ViewRenderer)) {
+        @preconcurrency public func use(_ makeRenderer: @Sendable @escaping (Application) -> (ViewRenderer)) {
             self.storage.makeRenderer.withLockedValue { $0 = .init(factory: makeRenderer) }
         }
 

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -48,7 +48,7 @@ extension Application {
             try app.server.start(address: .hostname(self.hostname, port: self.port))
             defer { app.server.shutdown() }
             
-            let client = HTTPClient(eventLoopGroupProvider: .createNew)
+            let client = HTTPClient(eventLoopGroup: NIOSingletons.posixEventLoopGroup)
             defer { try! client.syncShutdown() }
             var path = request.url.path
             path = path.hasPrefix("/") ? path : "/\(path)"


### PR DESCRIPTION
It has become standard practice to add `@Sendable` to `@escaping` closures passed as method parameters to improve Concurrency correctness. However, when this is done for pre-existing `public` methods that are _not_ `async`, the result is source incompatibility for some users, as mutable values captured by such closures will cause unexpected build errors. The correct way to suppress this behavior is to mark such methods with the `@preconcurrency` attribute, signaling to the compiler that users may not yet expect the additional restrictions of `@Sendable` to apply without sacrificing correctness for Concurrency-ready code. Unfortunately, Vapor recently added `@Sendable` annotations to many of its APIs without also adding the `@preconcurrency` annotation; this update addresses that oversight.