### PR TITLE
Fix AHC Dependency Mismatch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
 
         // Sugary extensions for the SwiftNIO library
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
 
         // 💻 APIs for creating interactive CLI tools.
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
 
         // Sugary extensions for the SwiftNIO library
-        .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
 
         // 💻 APIs for creating interactive CLI tools.
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         
         // Sugary extensions for the SwiftNIO library
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),


### PR DESCRIPTION
[4.84.1](https://github.com/vapor/vapor/releases/tag/4.84.1) migrated the use of AHC to the new singletons API but didn't bump the version required leading to build errors for some users. This fixes that