### PR TITLE
Handle query parameters in FileMiddleware redirects

### DIFF
--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -61,9 +61,11 @@ public final class FileMiddleware: Middleware {
         if isDir.boolValue {
             guard absPath.hasSuffix("/") else {
                 switch directoryAction.kind {
-                case .redirect:
+                case .redirect:                    
+                    var redirectUrl = request.url
+                    redirectUrl.path += "/"
                     return request.eventLoop.future(
-                        request.redirect(to: request.url.path + "/", redirectType: .permanent)
+                        request.redirect(to: redirectUrl.string, redirectType: .permanent)
                     )
                 case .none:
                     return next.respond(to: request)

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -373,6 +373,31 @@ final class FileTests: XCTestCase {
         }
     }
     
+    func testRedirectWithQueryParams() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        app.middleware.use(
+            FileMiddleware(
+                publicDirectory: "/" + path,
+                defaultFile: "index.html",
+                directoryAction: .redirect
+            )
+        )
+
+        try app.test(.GET, "Utilities?vaporTest=test") { res in
+            XCTAssertEqual(res.status, .movedPermanently)
+            XCTAssertEqual(res.headers.first(name: .location), "/Utilities/?vaporTest=test")
+        }.test(.GET, "Utilities/SubUtilities?vaporTest=test") { res in
+            XCTAssertEqual(res.status, .movedPermanently)
+            XCTAssertEqual( res.headers.first(name: .location), "/Utilities/SubUtilities/?vaporTest=test")
+        }.test(.GET, "Utilities/SubUtilities?vaporTest=test#vapor") { res in
+            XCTAssertEqual(res.status, .movedPermanently)
+            XCTAssertEqual( res.headers.first(name: .location), "/Utilities/SubUtilities/?vaporTest=test#vapor")
+        }
+    }
+    
     func testNoRedirect() throws {
         let app = Application(.testing)
         defer { app.shutdown() }


### PR DESCRIPTION
Correctly handle query parameters when using the redirect functionality in `FileMiddleware`.
