### PR TITLE
Fix NIOLoopBound issues

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -18,7 +18,8 @@ final class HTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let box = NIOLoopBound((context, self), eventLoop: context.eventLoop)
         let request = self.unwrapInboundIn(data)
-        self.responder.respond(to: request).whenComplete { response in
+        // hop(to:) is required here to ensure we're on the correct event loop
+        self.responder.respond(to: request).hop(to: context.eventLoop).whenComplete { response in
             let (context, handler) = box.value
             handler.serialize(response, for: request, context: context)
         }

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -5,10 +5,21 @@ import NIOEmbedded
 import NIOCore
 
 final class PipelineTests: XCTestCase {
+    var app: Application!
+    var eventLoopGroup: EventLoopGroup!
+    
+    override func setUp() async throws {
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 8)
+        app = Application(.testing, .shared(eventLoopGroup))
+    }
+    
+    override func tearDown() async throws {
+        app.shutdown()
+        try await eventLoopGroup.shutdownGracefully()
+    }
+    
+    
     func testEchoHandlers() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.on(.POST, "echo", body: .stream) { request -> Response in
             Response(body: .init(stream: { writer in
                 request.body.drain { body in
@@ -59,9 +70,6 @@ final class PipelineTests: XCTestCase {
     }
 
     func testEOFFraming() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.on(.POST, "echo", body: .stream) { request -> Response in
             Response(body: .init(stream: { writer in
                 request.body.drain { body in
@@ -89,9 +97,6 @@ final class PipelineTests: XCTestCase {
     }
 
     func testBadStreamLength() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.on(.POST, "echo", body: .stream) { request -> Response in
             Response(body: .init(stream: { writer in
                 writer.write(.buffer(.init(string: "a")), promise: nil)
@@ -117,9 +122,6 @@ final class PipelineTests: XCTestCase {
     }
     
     func testInvalidHttp() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         let channel = EmbeddedChannel()
         try channel.connect(to: .init(unixDomainSocketPath: "/foo")).wait()
         try channel.pipeline.addVaporHTTP1Handlers(
@@ -139,6 +141,70 @@ final class PipelineTests: XCTestCase {
         }
         XCTAssertEqual(channel.isActive, false)
         try XCTAssertNil(channel.readOutbound(as: ByteBuffer.self)?.string)
+    }
+    
+    func testReturningResponseOnDifferentEventLoopDosentCrashLoopBoundBox() async throws {
+        struct ResponseThing: ResponseEncodable {
+            let eventLoop: EventLoop
+            
+            func encodeResponse(for request: Vapor.Request) -> NIOCore.EventLoopFuture<Vapor.Response> {
+                let response = Response(status: .ok)
+                return eventLoop.future(response)
+            }
+        }
+        
+        let eventLoop = app!.eventLoopGroup.next()
+        app.get("dont-crash") { req in
+            return ResponseThing(eventLoop: eventLoop)
+        }
+        
+        try app.test(.GET, "dont-crash") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+
+        app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
+        try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        let res = try await app.client.get("http://localhost:\(port)/dont-crash")
+        XCTAssertEqual(res.status, .ok)
+    }
+    
+    func testReturningResponseFromMiddlewareOnDifferentEventLoopDosentCrashLoopBoundBox() async throws {
+        struct WrongEventLoopMiddleware: Middleware {
+            func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+                next.respond(to: request).hop(to: request.application.eventLoopGroup.next())
+            }
+        }
+        
+        app.grouped(WrongEventLoopMiddleware()).get("dont-crash") { req in
+            return "OK"
+        }
+        
+        try app.test(.GET, "dont-crash") { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+
+        app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
+        try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        let res = try await app.client.get("http://localhost:\(port)/dont-crash")
+        XCTAssertEqual(res.status, .ok)
     }
 
     override class func setUp() {


### PR DESCRIPTION
Fixes a number of issues where `NIOLoopBound` and `NIOLoopBoundBox` were used without ensuring we were on the correct event loop before accessing them. This could lead to precondition crashes