### PR TITLE
Update SwiftNIO HTTP/2 for CVE-2023-44487

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.20.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
         
         // HTTP/2 support for SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.20.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
         
         // Useful code around SwiftNIO.
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),


### PR DESCRIPTION
See [the forum post](https://forums.swift.org/t/swift-nio-http2-security-update-cve-2023-44487-http-2-dos/67764/1) for more details