### PR TITLE
Lazily start thread pool on access

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -147,7 +147,6 @@ public final class Application: Sendable {
         self.clients.use(.http)
         self.commands.use(self.servers.command, as: "serve", isDefault: true)
         self.commands.use(RoutesCommand(), as: "routes")
-        DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
     }
     
     /// Starts the Application using the `start()` method, then waits for any running tasks to complete
@@ -183,6 +182,7 @@ public final class Application: Sendable {
                 return
             }
             booted = true
+            DotEnvFile.load(for: self.environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
             try self.lifecycle.handlers.forEach { try $0.willBoot(self) }
             try self.lifecycle.handlers.forEach { try $0.didBoot(self) }
         }


### PR DESCRIPTION
Addresses #3003 by lazily starting the thread pool on first access, and deferring first access to the thread pool outside of `Application`'s `init`.

The only downside of this approach is that we're now deferring loading the environment until we call `Application`'s `boot()` method. I'm hoping this is an acceptable compromise in return for allowing consumers to reduce the number of threads consumed by Vapor.

This approach is similar to #3008 but attempts to increase the likelihood of acceptance by reducing the potential side-effects of the change.