### PR TITLE
Remove Sendable requirements on Authenticatable

### DIFF
--- a/Sources/Vapor/Authentication/AuthenticationCache.swift
+++ b/Sources/Vapor/Authentication/AuthenticationCache.swift
@@ -101,7 +101,7 @@ extension Request.Authentication {
 // types (e.g. Fluent 4 models can never be Sendable because they're reference types with mutable values
 // required by protocols and property wrappers). This allows us to store the Authenticatable type in a
 // safe-most-of-the-time way. This does introduce an edge case where type could be stored and mutated in
-// multiple places. But given how Vapor and its users use Authentication this should almost always never
+// multiple places. But given how Vapor and its users use Authentication this should almost never
 // occur and it was decided the trade-off was acceptable
 // As the name implies, the usage of this is unsafe because it disables the sendable checking of the
 // compiler and does not add any synchronisation.

--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 /// Capable of being authenticated.
-public protocol Authenticatable: Sendable { }
+public protocol Authenticatable { }
 
 /// Helper for creating authentication middleware.
 ///

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -27,7 +27,7 @@ extension Authenticatable {
 
 
 private final class GuardAuthenticationMiddleware<A>: Middleware
-    where A: Authenticatable & Sendable
+    where A: Authenticatable
 {
     /// Error to throw when guard fails.
     private let error: Error

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -20,7 +20,7 @@ extension Authenticatable {
 
 
 private final class RedirectMiddleware<A>: Middleware
-    where A: Authenticatable & Sendable
+    where A: Authenticatable
 {
     let makePath: @Sendable (Request) -> String
     


### PR DESCRIPTION
Removes the requirement for `Authenticatable` types to be `Sendable` which was causing issues with Fluent models (and any reference types) and wasn't solvable in a non-breaking way.

This uses an unsafe box to wrap the `Authenticatable` types which removes compiler checking on usage of the box but should not be an issue due to the way Vapor's auth is implemented