### PR TITLE
Fix issue with AnySendableHashable in Route

### DIFF
--- a/Sources/Vapor/Routing/Route.swift
+++ b/Sources/Vapor/Routing/Route.swift
@@ -54,10 +54,10 @@ public final class Route: CustomStringConvertible, Sendable {
         var responder: Responder
         var requestType: Any.Type
         var responseType: Any.Type
-        var userInfo: [AnySendableHashable: Sendable]
+        var userInfo: [String: Sendable]
     }
     
-    public var userInfo: [AnySendableHashable: Sendable] {
+    public var userInfo: [String: Sendable] {
         get {
             self.sendableBox.withLockedValue { $0.userInfo }
         }


### PR DESCRIPTION
Fixes a regression when using the `userInfo` dictionary which required the use of `AnySendableHashable`. Passing in `String`s (as opposed to string literals) would fail to compile as we don't have access to all the fancy stuff that `AnyHashable` does.

This fixes it to require `Strings` which is technically a source-breaking change but all known examples use `String` as the key and it was a potential DoS attack vector if this wasn't safe across concurrent environments.