### PR TITLE
Make Middleware Async

### DIFF
--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -6,7 +6,7 @@ import NIOCore
 ///
 /// - note: Make sure this middleware is inserted before all your error/abort middlewares,
 ///         so that even the failed request responses contain proper CORS information.
-public final class CORSMiddleware: Middleware {
+public final class CORSMiddleware: AsyncMiddleware {
     /// Option for the allow origin header in responses for CORS requests.
     ///
     /// - none: Disallows any origin.
@@ -122,45 +122,46 @@ public final class CORSMiddleware: Middleware {
     public init(configuration: Configuration = .default()) {
         self.configuration = configuration
     }
-
-    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+    
+    public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         // Check if it's valid CORS request
         guard request.headers[.origin].first != nil else {
-            return next.respond(to: request)
+            return try await next.respond(to: request)
         }
         
         // Determine if the request is pre-flight.
         // If it is, create empty response otherwise get response from the responder chain.
-        let response = request.isPreflight
-            ? request.eventLoop.makeSucceededFuture(.init())
-            : next.respond(to: request)
-        
-        return response.map { response in
-            // Modify response headers based on CORS settings
-            let originBasedAccessControlAllowHeader = self.configuration.allowedOrigin.header(forRequest: request)
-            response.responseBox.withLockedValue { box in
-                box.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: originBasedAccessControlAllowHeader)
-                box.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: self.configuration.allowedHeaders)
-                box.headers.replaceOrAdd(name: .accessControlAllowMethods, value: self.configuration.allowedMethods)
-                
-                if let exposedHeaders = self.configuration.exposedHeaders {
-                    box.headers.replaceOrAdd(name: .accessControlExpose, value: exposedHeaders)
-                }
-                
-                if let cacheExpiration = self.configuration.cacheExpiration {
-                    box.headers.replaceOrAdd(name: .accessControlMaxAge, value: String(cacheExpiration))
-                }
-                
-                if self.configuration.allowCredentials {
-                    box.headers.replaceOrAdd(name: .accessControlAllowCredentials, value: "true")
-                }
-
-                if case .originBased = self.configuration.allowedOrigin, !originBasedAccessControlAllowHeader.isEmpty {
-                    box.headers.add(name: .vary, value: "origin")
-                }
-            }
-            return response
+        let response: Response
+        if request.isPreflight {
+            response = .init()
+        } else {
+            response = try await next.respond(to: request)
         }
+        
+        // Modify response headers based on CORS settings
+        let originBasedAccessControlAllowHeader = self.configuration.allowedOrigin.header(forRequest: request)
+        response.responseBox.withLockedValue { box in
+            box.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: originBasedAccessControlAllowHeader)
+            box.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: self.configuration.allowedHeaders)
+            box.headers.replaceOrAdd(name: .accessControlAllowMethods, value: self.configuration.allowedMethods)
+            
+            if let exposedHeaders = self.configuration.exposedHeaders {
+                box.headers.replaceOrAdd(name: .accessControlExpose, value: exposedHeaders)
+            }
+            
+            if let cacheExpiration = self.configuration.cacheExpiration {
+                box.headers.replaceOrAdd(name: .accessControlMaxAge, value: String(cacheExpiration))
+            }
+            
+            if self.configuration.allowCredentials {
+                box.headers.replaceOrAdd(name: .accessControlAllowCredentials, value: "true")
+            }
+
+            if case .originBased = self.configuration.allowedOrigin, !originBasedAccessControlAllowHeader.isEmpty {
+                box.headers.add(name: .vary, value: "origin")
+            }
+        }
+        return response
     }
 }
 

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -3,7 +3,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Captures all errors and transforms them into an internal server error HTTP response.
-public final class ErrorMiddleware: Middleware {
+public final class ErrorMiddleware: AsyncMiddleware {
     /// Structure of `ErrorMiddleware` default response.
     internal struct ErrorResponse: Codable {
         /// Always `true` to indicate this is a non-typical JSON response.
@@ -76,8 +76,10 @@ public final class ErrorMiddleware: Middleware {
         self.closure = closure
     }
     
-    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        return next.respond(to: request).flatMapErrorThrowing { error in
+    public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        do {
+            return try await next.respond(to: request)
+        } catch {
             return self.closure(request, error)
         }
     }

--- a/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
+++ b/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
@@ -3,15 +3,15 @@ import Logging
 
 /// Emits a log message containing the request method and path to a `Request`'s logger.
 /// The log level of the message is configurable.
-public final class RouteLoggingMiddleware: Middleware {
+public final class RouteLoggingMiddleware: AsyncMiddleware {
     public let logLevel: Logger.Level
     
     public init(logLevel: Logger.Level = .info) {
         self.logLevel = logLevel
     }
     
-    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+    public func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         request.logger.log(level: self.logLevel, "\(request.method) \(request.url.path.removingPercentEncoding ?? request.url.path)")
-        return next.respond(to: request)
+        return try await next.respond(to: request)
     }
 }


### PR DESCRIPTION
Makes all of Vapor's internal middleware async so we can have a full async chain all the way down in anticipation of distributed tracing (and adopting NIO's new AsyncChannel stuff)