### PR TITLE
Fix setting public folder for `FileMiddleware` when using bundles

### DIFF
--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -118,7 +118,7 @@ public final class FileMiddleware: Middleware {
             throw BundleSetupError.publicDirectoryIsNotAFolder
         }
         
-        self.init(publicDirectory: bundleResourceURL.path, defaultFile: defaultFile, directoryAction: directoryAction)
+        self.init(publicDirectory: publicDirectoryURL.path, defaultFile: defaultFile, directoryAction: directoryAction)
     }
     
     /// Possible actions to take when the request doesn't have a trailing slash but matches a directory

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -126,6 +126,21 @@ final class MiddlewareTests: XCTestCase {
         }
     }
     
+    func testFileMiddlewareFromBundleSubfolder() throws {
+        var fileMiddleware: FileMiddleware!
+        
+        XCTAssertNoThrow(fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "SubUtilities"), "FileMiddleware instantiation from Bundle should not fail")
+        
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        app.middleware.use(fileMiddleware)
+        
+        try app.testable().test(.GET, "/index.html") { result in
+            XCTAssertEqual(result.status, .ok)
+            XCTAssertEqual(result.body.string, "<h1>Subdirectory Default</h1>\n")
+        }
+    }
+    
     func testFileMiddlewareFromBundleInvalidPublicDirectory() {
         XCTAssertThrowsError(try FileMiddleware(bundle: .module, publicDirectory: "/totally-real/folder")) { error in
             guard let error = error as? FileMiddleware.BundleSetupError else {


### PR DESCRIPTION
This PR fixes an issue where, if you provided a subfolder within a bundle's resources, the wrong path would be provided to the `FileMiddleware`, causing the resources to not be loaded.

For example, given a bundle with the following structure:

```
App.app/
└── Contents/
    ├── MacOS/
    │   └── App
    └── Resources/
        └── web-app/
            └── Public
                └── index.html
```

If you tried to create an instance of `FileMiddleware` that tried to use `web-app/Public/` as the folder to serve files from, `FileMiddleware` would incorrectly use the resource path of the bundle (`App.app/Resources/`) instead of the full path to the specified folder (`App.app/Resources/web-app/Public/`).