### PR TITLE
Add fully async entrypoints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: all
     groups:
       dependencies:
         patterns:

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
 
         // 💻 APIs for creating interactive CLI tools.
-        .package(url: "https://github.com/vapor/console-kit.git", branch: "revise-async-commands"),
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.0"),
 
         // 🔑 Hashing (SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
 
         // 💻 APIs for creating interactive CLI tools.
-        .package(url: "https://github.com/vapor/console-kit.git", from: "4.13.0"),
+        .package(url: "https://github.com/vapor/console-kit.git", branch: "revise-async-commands"),
 
         // 🔑 Hashing (SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
 
         // 💻 APIs for creating interactive CLI tools.
-        .package(url: "https://github.com/vapor/console-kit.git", branch: "revise-async-commands"),
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.14.0"),
 
         // 🔑 Hashing (SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),
 
         // 💻 APIs for creating interactive CLI tools.
-        .package(url: "https://github.com/vapor/console-kit.git", from: "4.13.0"),
+        .package(url: "https://github.com/vapor/console-kit.git", branch: "revise-async-commands"),
 
         // 🔑 Hashing (SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),

--- a/Sources/Development/entrypoint.swift
+++ b/Sources/Development/entrypoint.swift
@@ -11,9 +11,7 @@ struct Entrypoint {
         defer { app.shutdown() }
 
         try configure(app)
-        // TODO: Replace with correctly async version of `app.run()`.
-        try app.start()
-        try await app.running?.onStop.get()
+        try await app.execute()
     }
 }
 

--- a/Tests/AsyncTests/AsyncClientTests.swift
+++ b/Tests/AsyncTests/AsyncClientTests.swift
@@ -42,7 +42,7 @@ final class AsyncClientTests: XCTestCase {
         
         remoteApp.environment.arguments = ["serve"]
         try remoteApp.boot()
-        try remoteApp.start()
+        try await remoteApp.startup()
         
         XCTAssertNotNil(remoteApp.http.server.shared.localAddress)
         guard let localAddress = remoteApp.http.server.shared.localAddress,
@@ -152,7 +152,7 @@ final class AsyncClientTests: XCTestCase {
 
         app.environment.arguments = ["serve"]
         try app.boot()
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,

--- a/Tests/AsyncTests/AsyncWebSocketTests.swift
+++ b/Tests/AsyncTests/AsyncWebSocketTests.swift
@@ -15,7 +15,7 @@ final class AsyncWebSocketTests: XCTestCase {
             ws.onText { ws.send($1) }
         }
         server.environment.arguments = ["serve"]
-        try server.start()
+        try await server.startup()
 
         defer {
             server.shutdown()
@@ -58,7 +58,7 @@ final class AsyncWebSocketTests: XCTestCase {
 
         app.environment.arguments = ["serve"]
 
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,
@@ -89,7 +89,7 @@ final class AsyncWebSocketTests: XCTestCase {
         app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
 
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,
@@ -128,7 +128,7 @@ final class AsyncWebSocketTests: XCTestCase {
 
         app.environment.arguments = ["serve"]
 
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -51,7 +51,7 @@ final class ClientTests: XCTestCase {
         
         remoteApp.environment.arguments = ["serve"]
         try remoteApp.boot()
-        try remoteApp.start()
+        try await remoteApp.startup()
         
         XCTAssertNotNil(remoteApp.http.server.shared.localAddress)
         guard let localAddress = remoteApp.http.server.shared.localAddress,

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -161,7 +161,7 @@ final class PipelineTests: XCTestCase {
 
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,
@@ -191,7 +191,7 @@ final class PipelineTests: XCTestCase {
 
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,
@@ -223,7 +223,7 @@ final class PipelineTests: XCTestCase {
         
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
-        try app.start()
+        try await app.startup()
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
         guard let localAddress = app.http.server.shared.localAddress,


### PR DESCRIPTION
Pretty much what it says on the tin. Use the new `execute()` API instead of `run()`, and/or `startup()` instead of `start()`.