### PR TITLE
Fix encoding and decoding of HTTPHeaders

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
@@ -49,7 +49,7 @@ extension HTTPHeaders: Codable {
                 
                 self.add(name: name, value: value)
             }
-        } catch DecodingError.typeMismatch(let type, _) where (type as? Array<Any>.Type) != nil {
+        } catch DecodingError.typeMismatch(let type, _) where "\(type)".starts(with: "Array<") {
             // Try the old format
             let container = try decoder.singleValueContainer()
             let dict = try container.decode([String: String].self)

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -465,4 +465,16 @@ final class HTTPHeaderTests: XCTestCase {
             XCTAssertEqual(v1, v2)
         }
     }
+    
+    /// Make sure the old HTTPHeaders encoding can still be decoded
+    func testOldHTTPHeadersEncoding() throws {
+        let decoder = JSONDecoder()
+        let json = #"{"connection":"fun","attention":"none"}"#
+        var headers = HTTPHeaders()
+        
+        XCTAssertNoThrow(headers = try decoder.decode(HTTPHeaders.self, from: Data(json.utf8)))
+        XCTAssertEqual(headers.count, 2)
+        XCTAssertEqual(headers.first(name: "connection"), "fun")
+        XCTAssertEqual(headers.first(name: "attention"), "none")
+    }
 }


### PR DESCRIPTION
The `Codable` conformance Vapor adds to the `HTTPHeaders` type now correctly handles cases where more than one header with the same name (such as `Set-Cookie`) is present, for both encoding and decoding.

The previous encoding format is still recognized for decoding, so that existing serialized data can be safely read.