### PR TITLE
Use `singleton` `EventLoopGroup`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.8.2"),
 
         // 💥 Backtraces for Swift on Linux
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.5.0"),
+        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.8.2"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -100,7 +100,7 @@ public final class Application: Sendable {
         case createNew
 
         public static var singleton: EventLoopGroupProvider {
-            .shared(NIOSingletons.posixEventLoopGroup)
+            .singleton
         }
     }
 
@@ -116,7 +116,7 @@ public final class Application: Sendable {
 
     public init(
         _ environment: Environment = .development,
-        _ eventLoopGroupProvider: EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup)
+        _ eventLoopGroupProvider: EventLoopGroupProvider = .singleton
     ) {
         #if swift(<5.9)
             Backtrace.install()

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -96,11 +96,11 @@ public final class Application: Sendable {
 
     public enum EventLoopGroupProvider: Sendable {
         case shared(EventLoopGroup)
-        @available(*, deprecated, renamed: "singleton", message: "Use '.singleton' to use a shared EventLoopGroup for better performance, or provide your own EventLoopGroup with '.shared()'")
+        @available(*, deprecated, renamed: "singleton", message: "Use '.singleton' for a shared 'EventLoopGroup', for better performance")
         case createNew
 
         public static var singleton: EventLoopGroupProvider {
-            .singleton
+            .shared(MultiThreadedEventLoopGroup.singleton)
         }
     }
 

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -96,7 +96,12 @@ public final class Application: Sendable {
 
     public enum EventLoopGroupProvider: Sendable {
         case shared(EventLoopGroup)
+        @available(*, deprecated, renamed: "singleton", message: "Use '.singleton' to use a shared EventLoopGroup for better performance, or provide your own EventLoopGroup with '.shared()'")
         case createNew
+
+        public static var singleton: EventLoopGroupProvider {
+            .shared(NIOSingletons.posixEventLoopGroup)
+        }
     }
 
     public let eventLoopGroupProvider: EventLoopGroupProvider
@@ -111,7 +116,7 @@ public final class Application: Sendable {
 
     public init(
         _ environment: Environment = .development,
-        _ eventLoopGroupProvider: EventLoopGroupProvider = .createNew
+        _ eventLoopGroupProvider: EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup)
     ) {
         #if swift(<5.9)
             Backtrace.install()

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -83,7 +83,7 @@ extension WebSocket {
         to url: String,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws {
         guard let url = URL(string: url) else {
@@ -103,7 +103,7 @@ extension WebSocket {
         to url: URL,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         let scheme = url.scheme ?? "ws"
@@ -127,7 +127,7 @@ extension WebSocket {
         path: String = "/",
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         return try await WebSocketClient(

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -83,7 +83,7 @@ extension WebSocket {
         to url: String,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws {
         guard let url = URL(string: url) else {
@@ -103,7 +103,7 @@ extension WebSocket {
         to url: URL,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         let scheme = url.scheme ?? "ws"
@@ -127,7 +127,7 @@ extension WebSocket {
         path: String = "/",
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup,
+        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         return try await WebSocketClient(

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -18,7 +18,7 @@ extension DotEnvFile {
     @available(*, deprecated, message: "use `load(for:on:fileio:logger)`")
     public static func load(
         for environment: Environment = .development,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)
@@ -50,7 +50,7 @@ extension DotEnvFile {
     @available(*, deprecated, message: "use `load(path:on:fileio:logger)`")
     public static func load(
         path: String,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -18,7 +18,7 @@ extension DotEnvFile {
     @available(*, deprecated, message: "use `load(for:on:fileio:logger)`")
     public static func load(
         for environment: Environment = .development,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)
@@ -50,7 +50,7 @@ extension DotEnvFile {
     @available(*, deprecated, message: "use `load(path:on:fileio:logger)`")
     public static func load(
         path: String,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -261,7 +261,7 @@ public final class HTTPServer: Server, Sendable {
         application: Application,
         responder: Responder,
         configuration: Configuration,
-        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup
+        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton
     ) {
         self.application = application
         self.responder = responder

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -261,7 +261,7 @@ public final class HTTPServer: Server, Sendable {
         application: Application,
         responder: Responder,
         configuration: Configuration,
-        on eventLoopGroup: EventLoopGroup
+        on eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup
     ) {
         self.application = application
         self.responder = responder

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -44,7 +44,7 @@ public struct DotEnvFile: Sendable {
     ///     - logger: Optionally provide an existing logger.
     public static func load(
         for environment: Environment = .development,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         fileio: NonBlockingFileIO,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
@@ -91,7 +91,7 @@ public struct DotEnvFile: Sendable {
     ///     - logger: Optionally provide an existing logger.
     public static func load(
         path: String,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         fileio: NonBlockingFileIO,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -44,7 +44,7 @@ public struct DotEnvFile: Sendable {
     ///     - logger: Optionally provide an existing logger.
     public static func load(
         for environment: Environment = .development,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
         fileio: NonBlockingFileIO,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {
@@ -91,7 +91,7 @@ public struct DotEnvFile: Sendable {
     ///     - logger: Optionally provide an existing logger.
     public static func load(
         path: String,
-        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .createNew,
+        on eventLoopGroupProvider: Application.EventLoopGroupProvider = .shared(NIOSingletons.posixEventLoopGroup),
         fileio: NonBlockingFileIO,
         logger: Logger = Logger(label: "dot-env-loggger")
     ) {

--- a/Sources/Vapor/View/PlaintextRenderer.swift
+++ b/Sources/Vapor/View/PlaintextRenderer.swift
@@ -12,7 +12,7 @@ public struct PlaintextRenderer: ViewRenderer, Sendable {
         fileio: NonBlockingFileIO,
         viewsDirectory: String,
         logger: Logger,
-        eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup
+        eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton
     ) {
         self.fileio = fileio
         self.viewsDirectory = viewsDirectory.finished(with: "/")

--- a/Sources/Vapor/View/PlaintextRenderer.swift
+++ b/Sources/Vapor/View/PlaintextRenderer.swift
@@ -12,7 +12,7 @@ public struct PlaintextRenderer: ViewRenderer, Sendable {
         fileio: NonBlockingFileIO,
         viewsDirectory: String,
         logger: Logger,
-        eventLoopGroup: EventLoopGroup
+        eventLoopGroup: EventLoopGroup = NIOSingletons.posixEventLoopGroup
     ) {
         self.fileio = fileio
         self.viewsDirectory = viewsDirectory.finished(with: "/")

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -48,7 +48,7 @@ extension Application {
             try app.server.start(address: .hostname(self.hostname, port: self.port))
             defer { app.server.shutdown() }
             
-            let client = HTTPClient(eventLoopGroup: NIOSingletons.posixEventLoopGroup)
+            let client = HTTPClient(eventLoopGroup: MultiThreadedEventLoopGroup.singleton)
             defer { try! client.syncShutdown() }
             var path = request.url.path
             path = path.hasPrefix("/") ? path : "/\(path)"

--- a/Tests/AsyncTests/AsyncRequestTests.swift
+++ b/Tests/AsyncTests/AsyncRequestTests.swift
@@ -174,7 +174,7 @@ final class AsyncRequestTests: XCTestCase {
                                               headers: [:],
                                               body: .byteBuffer(tenMB))
         let delegate = ResponseDelegate(bytesTheClientSent: bytesTheClientSent)
-        let httpClient = HTTPClient(eventLoopGroup: NIOSingletons.posixEventLoopGroup)
+        let httpClient = HTTPClient(eventLoopGroup: MultiThreadedEventLoopGroup.singleton)
         XCTAssertThrowsError(try httpClient.execute(request: request,
                                                                 delegate: delegate,
                                                                 deadline: .now() + .milliseconds(500)).wait()) { error in

--- a/Tests/AsyncTests/AsyncRequestTests.swift
+++ b/Tests/AsyncTests/AsyncRequestTests.swift
@@ -19,16 +19,13 @@ fileprivate extension String {
 final class AsyncRequestTests: XCTestCase {
     
     var app: Application!
-    var eventLoopGroup: EventLoopGroup!
     
     override func setUp() async throws {
-        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
-        app = Application(.testing, .shared(eventLoopGroup))
+        app = Application(.testing)
     }
     
     override func tearDown() async throws {
         app.shutdown()
-        try await eventLoopGroup.shutdownGracefully()
     }
     
     func testStreamingRequest() async throws {
@@ -177,7 +174,7 @@ final class AsyncRequestTests: XCTestCase {
                                               headers: [:],
                                               body: .byteBuffer(tenMB))
         let delegate = ResponseDelegate(bytesTheClientSent: bytesTheClientSent)
-        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+        let httpClient = HTTPClient(eventLoopGroup: NIOSingletons.posixEventLoopGroup)
         XCTAssertThrowsError(try httpClient.execute(request: request,
                                                                 delegate: delegate,
                                                                 deadline: .now() + .milliseconds(500)).wait()) { error in

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -507,9 +507,9 @@ final class ServerTests: XCTestCase {
         })
     }
     
+    @available(*, deprecated, message: "To avoid deprecation warnings")
     func testEchoServer() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let app = Application(.testing, .shared(eventLoopGroup))
+        let app = Application(.testing, .createNew)
         defer { app.shutdown() }
         
         final class Context: Sendable {
@@ -556,7 +556,7 @@ final class ServerTests: XCTestCase {
             body: .stream(length: nil, { stream in
                 // We set the application to have a single event loop so we can use the same
                 // event loop here
-                let streamBox = NIOLoopBound(stream, eventLoop: eventLoopGroup.any())
+                let streamBox = NIOLoopBound(stream, eventLoop: app.eventLoopGroup.any())
                 return stream.write(.byteBuffer(.init(string: "foo"))).flatMap {
                     streamBox.value.write(.byteBuffer(.init(string: "bar")))
                 }.flatMap {


### PR DESCRIPTION
Use the new `singleton` `EventLoopGroup` for more convenient and sometimes more performant APIs.