### PR TITLE
Update routing-kit version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.8.2"),
+        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // 💥 Backtraces for Swift on Linux
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
 
         // 🚍 High-performance trie-node router.
-        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.8.2"),
+        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),


### PR DESCRIPTION
Update routing-kit version to get `Equatable` conformance for `PathComponent`s

Related to https://github.com/vapor/routing-kit/pull/129
and https://github.com/swift-server/swift-openapi-vapor/pull/13#issuecomment-1879752829