### PR TITLE
Allow `HTTPServer`'s configuration to be dynamically updatable

### DIFF
--- a/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
+++ b/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
@@ -33,6 +33,18 @@ extension Application.HTTP {
             typealias Value = HTTPServer
         }
 
+        /// The configuration for the HTTP server.
+        ///
+        /// Although the configuration can be changed after the server has started, a warning will be logged
+        /// and the configuration will be discarded if an option will no longer be considered.
+        /// 
+        /// These include the following properties, which are only read once when the server starts:
+        /// - ``HTTPServer/Configuration-swift.struct/address``
+        /// - ``HTTPServer/Configuration-swift.struct/hostname``
+        /// - ``HTTPServer/Configuration-swift.struct/port``
+        /// - ``HTTPServer/Configuration-swift.struct/backlog``
+        /// - ``HTTPServer/Configuration-swift.struct/reuseAddress``
+        /// - ``HTTPServer/Configuration-swift.struct/tcpNoDelay``
         public var configuration: HTTPServer.Configuration {
             get {
                 self.application.storage[ConfigurationKey.self] ?? .init(
@@ -40,8 +52,10 @@ extension Application.HTTP {
                 )
             }
             nonmutating set {
-                if self.application.storage.contains(Key.self) {
-                    self.application.logger.warning("Cannot modify server configuration after server has been used.")
+                /// If a server is available, configure it directly, otherwise cache a configuration instance
+                /// here to be used until the server is instantiated.
+                if let server = self.application.storage[Key.self] {
+                    server.configuration = newValue
                 } else {
                     self.application.storage[ConfigurationKey.self] = newValue
                 }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -931,7 +931,6 @@ final class ServerTests: XCTestCase {
             // This lies and accepts the above cert, which has actually expired.
             XCTAssertEqual(peerCerts, [cert])
             successPromise.succeed(.certificateVerified)
-            
         }
         
         // We need to disable verification on the client, because the cert we're using has expired, and we want to
@@ -965,6 +964,90 @@ final class ServerTests: XCTestCase {
         )
         let a = try app.http.client.shared.execute(request: request).wait()
         XCTAssertEqual(a.body, ByteBuffer(string: "world"))
+    }
+    
+    func testCanChangeConfigurationDynamically() throws {
+        guard let clientCertPath = Bundle.module.url(forResource: "expired", withExtension: "crt"),
+              let clientKeyPath = Bundle.module.url(forResource: "expired", withExtension: "key") else {
+            XCTFail("Cannot load expired cert and associated key")
+            return
+        }
+        
+        let cert = try NIOSSLCertificate(file: clientCertPath.path, format: .pem)
+        let key = try NIOSSLPrivateKey(file: clientKeyPath.path, format: .pem)
+        
+        let app = Application(.testing)
+        
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+        app.http.server.configuration.serverName = "Old"
+        
+        /// We need to disable verification on the client, because the cert we're using has expired
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .none
+        clientConfig.certificateChain = [.certificate(cert)]
+        clientConfig.privateKey = .privateKey(key)
+        app.http.client.configuration.tlsConfiguration = clientConfig
+        app.http.client.configuration.maximumUsesPerConnection = 1
+        
+        app.environment.arguments = ["serve"]
+        
+        app.get("hello") { req in
+            "world"
+        }
+        
+        defer { app.shutdown() }
+        try app.start()
+        
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let ip = localAddress.ipAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+        
+        /// Make a regular request
+        let a = try app.http.client.shared.execute(
+            request: try HTTPClient.Request(
+                url: "http://\(ip):\(port)/hello",
+                method: .GET
+            )
+        ).wait()
+        XCTAssertEqual(a.headers[.server], ["Old"])
+        XCTAssertEqual(a.body, ByteBuffer(string: "world"))
+        
+        /// Configure server name without stopping the server
+        app.http.server.configuration.serverName = "New"
+        /// Configure TLS without stopping the server
+        var serverConfig = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(cert)], privateKey: .privateKey(key))
+        serverConfig.certificateVerification = .noHostnameVerification
+        
+        app.http.server.configuration.tlsConfiguration = serverConfig
+        app.http.server.configuration.customCertificateVerifyCallback = { peerCerts, successPromise in
+            /// This lies and accepts the above cert, which has actually expired.
+            XCTAssertEqual(peerCerts, [cert])
+            successPromise.succeed(.certificateVerified)
+        }
+        
+        /// Make a TLS request this time around
+        let b = try app.http.client.shared.execute(
+            request: try HTTPClient.Request(
+                url: "https://\(ip):\(port)/hello",
+                method: .GET
+            )
+        ).wait()
+        XCTAssertEqual(b.headers[.server], ["New"])
+        XCTAssertEqual(b.body, ByteBuffer(string: "world"))
+        
+        /// Non-TLS request should now fail
+        let c = try? app.http.client.shared.execute(
+            request: try HTTPClient.Request(
+                url: "http://\(ip):\(port)/hello",
+                method: .GET
+            )
+        ).wait()
+        XCTAssertNil(c)
     }
     
     override class func setUp() {

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1041,13 +1041,14 @@ final class ServerTests: XCTestCase {
         XCTAssertEqual(b.body, ByteBuffer(string: "world"))
         
         /// Non-TLS request should now fail
-        let c = try? app.http.client.shared.execute(
+        XCTAssertThrowsError(try app.http.client.shared.execute(
             request: try HTTPClient.Request(
                 url: "http://\(ip):\(port)/hello",
                 method: .GET
             )
-        ).wait()
-        XCTAssertNil(c)
+        ).wait()) { error in
+            XCTAssertEqual(error as? HTTPClientError, HTTPClientError.remoteConnectionClosed)
+        }
     }
     
     override class func setUp() {


### PR DESCRIPTION
This allows many aspects of the HTTP server configuration to be changed after the server starts without needing to stop and restart it, or drop existing connections in the process.

Some things that can now be re-configured include request/response configuration options, HTTP version support, HTTP pipelining, TLS configuration (ie. enabling/disabling, rotating certificates, etc…), server name, metrics reporting, the logger, and the shutdown timer.

Fixes #3130.