### PR TITLE
Fix URI handling with multiple slashes and variable components.

### DIFF
--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -103,10 +103,10 @@ public struct URI: CustomStringConvertible, ExpressibleByStringInterpolation, Ha
         if scheme.value == nil, userinfo == nil, host == nil, port == nil, query == nil, fragment == nil {
             // If only a path is given, treat it as a string to parse. (This behavior is awful, but must be kept for compatibility.)
             // In order to do this in a fully compatible way (where in this case "compatible" means "being stuck with
-            // systematic misuse of both the URI type and concept"), we must collapse any non-zero number of
-            // leading `/` characters into a single character (thus breaking the ability to parse what is otherwise a
-            // valid URI format according to spec) to avoid weird routing misbehaviors.
-            components = URL(string: "/\(path.drop(while: { $0 == "/" }))").flatMap { .init(url: $0, resolvingAgainstBaseURL: true) }
+            // systematic misuse of both the URI type and concept"), we must collapse any sequence of two or more `/`
+            // characters into a single character (thus breaking the ability to parse what is otherwise a valid URI
+            // format according to spec) to avoid weird routing misbehaviors.
+            components = URL(string: "/\(path.split(separator: "/").joined(separator: "/"))").flatMap { .init(url: $0, resolvingAgainstBaseURL: true) }
         } else {
             // N.B.: We perform percent encoding manually and unconditionally on each non-nil component because the
             // behavior of URLComponents is completely different on Linux than on macOS for inputs which are already

--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -106,7 +106,8 @@ public struct URI: CustomStringConvertible, ExpressibleByStringInterpolation, Ha
             // systematic misuse of both the URI type and concept"), we must collapse any sequence of two or more `/`
             // characters into a single character (thus breaking the ability to parse what is otherwise a valid URI
             // format according to spec) to avoid weird routing misbehaviors.
-            components = URL(string: "/\(path.split(separator: "/").joined(separator: "/"))").flatMap { .init(url: $0, resolvingAgainstBaseURL: true) }
+            components = URL(string: "/\(path.split(separator: "/").joined(separator: "/"))\(path.hasSuffix("/") ? "/" : "")")
+                .flatMap { .init(url: $0, resolvingAgainstBaseURL: true) }
         } else {
             // N.B.: We perform percent encoding manually and unconditionally on each non-nil component because the
             // behavior of URLComponents is completely different on Linux than on macOS for inputs which are already

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -128,7 +128,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         afterResponse: (XCTHTTPResponse) async throws -> ()
     ) async throws -> XCTApplicationTester {
@@ -150,7 +150,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         afterResponse: (XCTHTTPResponse) throws -> ()
     ) throws -> XCTApplicationTester {
@@ -172,7 +172,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) async throws -> () = { _ in },
         afterResponse: (XCTHTTPResponse) async throws -> () = { _ in }
@@ -188,7 +188,7 @@ extension XCTApplicationTester {
             let response = try self.performTest(request: request)
             try await afterResponse(response)
         } catch {
-            XCTFail("\(error)", file: (file), line: line)
+            XCTFail("\(error)", file: file, line: line)
             throw error
         }
         return self
@@ -200,7 +200,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) throws -> () = { _ in },
         afterResponse: (XCTHTTPResponse) throws -> () = { _ in }
@@ -216,7 +216,7 @@ extension XCTApplicationTester {
             let response = try self.performTest(request: request)
             try afterResponse(response)
         } catch {
-            XCTFail("\(error)", file: (file), line: line)
+            XCTFail("\(error)", file: file, line: line)
             throw error
         }
         return self
@@ -227,7 +227,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) async throws -> () = { _ in }
     ) async throws -> XCTHTTPResponse {
@@ -241,7 +241,7 @@ extension XCTApplicationTester {
         do {
             return try self.performTest(request: request)
         } catch {
-            XCTFail("\(error)", file: (file), line: line)
+            XCTFail("\(error)", file: file, line: line)
             throw error
         }
     }
@@ -251,7 +251,7 @@ extension XCTApplicationTester {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         beforeRequest: (inout XCTHTTPRequest) throws -> () = { _ in }
     ) throws -> XCTHTTPResponse {
@@ -265,7 +265,7 @@ extension XCTApplicationTester {
         do {
             return try self.performTest(request: request)
         } catch {
-            XCTFail("\(error)", file: (file), line: line)
+            XCTFail("\(error)", file: file, line: line)
             throw error
         }
     }

--- a/Sources/XCTVapor/XCTHTTPResponse.swift
+++ b/Sources/XCTVapor/XCTHTTPResponse.swift
@@ -47,15 +47,12 @@ extension Response.Body {
 public func XCTAssertContent<D>(
     _ type: D.Type,
     _ res: XCTHTTPResponse,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     _ closure: (D) throws -> ()
-)
-    rethrows
-    where D: Decodable
-{
+) rethrows where D: Decodable {
     guard let contentType = res.headers.contentType else {
-        XCTFail("response does not contain content type", file: (file), line: line)
+        XCTFail("response does not contain content type", file: file, line: line)
         return
     }
 
@@ -65,14 +62,14 @@ public func XCTAssertContent<D>(
         let decoder = try ContentConfiguration.global.requireDecoder(for: contentType)
         content = try decoder.decode(D.self, from: res.body, headers: res.headers)
     } catch {
-        XCTFail("could not decode body: \(error)", file: (file), line: line)
+        XCTFail("could not decode body: \(error)", file: file, line: line)
         return
     }
 
     try closure(content)
 }
 
-public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: StaticString = #file, line: UInt = #line) {
+public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: StaticString = #filePath, line: UInt = #line) {
     let file = (file)
     switch (haystack, needle) {
     case (.some(let haystack), .some(let needle)):
@@ -86,11 +83,11 @@ public func XCTAssertContains(_ haystack: String?, _ needle: String?, file: Stat
     }
 }
 
-public func XCTAssertEqualJSON<T>(_ data: String?, _ test: T, file: StaticString = #file, line: UInt = #line)
+public func XCTAssertEqualJSON<T>(_ data: String?, _ test: T, file: StaticString = #filePath, line: UInt = #line)
     where T: Codable & Equatable
 {
     guard let data = data else {
-        XCTFail("nil does not equal \(test)", file: (file), line: line)
+        XCTFail("nil does not equal \(test)", file: file, line: line)
         return
     }
     do {

--- a/Tests/AsyncTests/AsyncPasswordTests.swift
+++ b/Tests/AsyncTests/AsyncPasswordTests.swift
@@ -59,7 +59,7 @@ final class AsyncPasswordTests: XCTestCase {
     private func assertAsyncApplicationPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         app.passwords.use(provider)
@@ -72,13 +72,13 @@ final class AsyncPasswordTests: XCTestCase {
             .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
             .verify("vapor", created: asyncHash)
 
-        XCTAssertTrue(asyncVerifiy, file: (file), line: line)
+        XCTAssertTrue(asyncVerifiy, file: file, line: line)
     }
 
     private func assertAsyncRequestPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         app.passwords.use(provider)
@@ -90,7 +90,7 @@ final class AsyncPasswordTests: XCTestCase {
         }
 
         try app.test(.GET, "test", afterResponse: { res in
-            XCTAssertEqual(res.body.string, "true", file: (file), line: line)
+            XCTAssertEqual(res.body.string, "true", file: file, line: line)
         })
     }
 }

--- a/Tests/VaporTests/DotEnvTests.swift
+++ b/Tests/VaporTests/DotEnvTests.swift
@@ -10,7 +10,7 @@ final class DotEnvTests: XCTestCase {
         let pool = NIOThreadPool(numberOfThreads: 1)
         pool.start()
         let fileio = NonBlockingFileIO(threadPool: pool)
-        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/test.env"
         let file = try DotEnvFile.read(path: path, fileio: fileio, on: elg.next()).wait()
         let test = file.lines.map { $0.description }.joined(separator: "\n")

--- a/Tests/VaporTests/EnvironmentSecretTests.swift
+++ b/Tests/VaporTests/EnvironmentSecretTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class EnvironmentSecretTests: XCTestCase {
     func testNonExistingSecretFile() throws {
-        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/non-existing-secret"
 
         let app = Application(.testing)
@@ -16,7 +16,7 @@ final class EnvironmentSecretTests: XCTestCase {
     }
 
     func testExistingSecretFile() throws {
-        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/my-secret-env-content"
 
         let app = Application(.testing)
@@ -28,7 +28,7 @@ final class EnvironmentSecretTests: XCTestCase {
     }
 
     func testExistingSecretFileFromEnvironmentKey() throws {
-        let folder = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/my-secret-env-content"
 
         let key = "MY_ENVIRONMENT_SECRET"

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -99,7 +99,7 @@ final class ErrorTests: XCTestCase {
 func XCTAssertContains(
     _ haystack: String?,
     _ needle: String,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     let file = (file)

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -10,7 +10,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch { 
@@ -31,7 +31,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file)
+            return req.fileio.streamFile(at: #filePath)
         }
 
         var headers = HTTPHeaders()
@@ -72,7 +72,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -103,7 +103,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -134,7 +134,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -165,7 +165,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -192,7 +192,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -218,7 +218,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -244,7 +244,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file) { result in
+            return req.fileio.streamFile(at: #filePath) { result in
                 do {
                     try result.get()
                 } catch {
@@ -285,7 +285,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
         try app.test(.GET, "/Utilities/foo%20bar.html") { res in
@@ -298,7 +298,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
         try app.test(.GET, "%2e%2e/VaporTests/Utilities/foo.txt") { res in
@@ -313,7 +313,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "index.html"))
 
         try app.test(.GET, "Utilities/") { res in
@@ -329,7 +329,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "/Utilities/index.html"))
 
         try app.test(.GET, "Utilities/") { res in
@@ -345,7 +345,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
         try app.test(.GET, "Utilities/") { res in
@@ -357,7 +357,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(
             FileMiddleware(
                 publicDirectory: "/" + path,
@@ -377,7 +377,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(
             FileMiddleware(
                 publicDirectory: "/" + path,
@@ -402,7 +402,7 @@ final class FileTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        let path = #file.split(separator: "/").dropLast().joined(separator: "/")
+        let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         app.middleware.use(
             FileMiddleware(
                 publicDirectory: "/" + path,
@@ -424,7 +424,7 @@ final class FileTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("file-stream") { req in
-            return req.fileio.streamFile(at: #file)
+            return req.fileio.streamFile(at: #filePath)
         }
 
         var headers = HTTPHeaders()

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -85,7 +85,7 @@ final class PasswordTests: XCTestCase {
     private func assertAsyncApplicationPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         app.passwords.use(provider)
@@ -100,13 +100,13 @@ final class PasswordTests: XCTestCase {
             .verify("vapor", created: asyncHash)
             .wait()
         
-        XCTAssertTrue(asyncVerifiy, file: (file), line: line)
+        XCTAssertTrue(asyncVerifiy, file: file, line: line)
     }
     
     private func assertAsyncRequestPasswordVerifies(
         _ provider: Application.Passwords.Provider,
         on app: Application,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         app.passwords.use(provider)
@@ -125,7 +125,7 @@ final class PasswordTests: XCTestCase {
         }
         
         try app.test(.GET, "test", afterResponse: { res in
-            XCTAssertEqual(res.body.string, "true", file: (file), line: line)
+            XCTAssertEqual(res.body.string, "true", file: file, line: line)
         })
     }
 }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -431,20 +431,39 @@ final class RouteTests: XCTestCase {
     }
     
     // https://github.com/vapor/vapor/issues/3137
+    // https://github.com/vapor/vapor/issues/3142
     func testDoubleSlashRouteAccess() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
         
-        app.get("foo", "bar", "buz") { req -> String in
-            try req.query.get(at: "v")
+        app.get(":foo", ":bar", "buz") { req -> String in
+            "yes"
         }
         
-        try app.testable().test(.GET, "/foo/bar/buz?v=M%26M") { res in
+        try app.testable(method: .running(port: 0)).test(.GET, "/foop/barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, #"M&M"#)
-        }.test(.GET, "//foo/bar/buz?v=M%26M") { res in
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "//foop/barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, #"M&M"#)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "//foop//barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "//foop//barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "/foop//barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "/foop//barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "/foop/barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
+        }.test(.GET, "//foop/barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "yes")
         }
     }
 }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -437,33 +437,33 @@ final class RouteTests: XCTestCase {
         defer { app.shutdown() }
         
         app.get(":foo", ":bar", "buz") { req -> String in
-            "yes"
+            "\(try req.parameters.require("foo"))\(try req.parameters.require("bar"))"
         }
         
         try app.testable(method: .running(port: 0)).test(.GET, "/foop/barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "//foop/barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "//foop//barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "//foop//barp//buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "/foop//barp/buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "/foop//barp//buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "/foop/barp//buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }.test(.GET, "//foop/barp//buz") { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(res.body.string, "yes")
+            XCTAssertEqual(res.body.string, "foopbarp")
         }
     }
 }

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -846,10 +846,9 @@ private func assert<T>(
     _ data: T,
     fails validator: Validator<T>,
     _ description: String,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
-    let file = (file)
     let result = validator.validate(data)
     XCTAssert(result.isFailure, result.successDescription ?? "n/a", file: file, line: line)
     XCTAssertEqual(description, result.failureDescription ?? "n/a", file: file, line: line)
@@ -858,10 +857,9 @@ private func assert<T>(
 private func assert<T>(
     _ data: T,
     passes validator: Validator<T>,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
-    let file = (file)
     let result = validator.validate(data)
     XCTAssert(!result.isFailure, result.failureDescription ?? "n/a", file: file, line: line)
 }


### PR DESCRIPTION
Resolves some more subtle remaining issues in how `URI` is handled with respect to HTTP requests.

Fixes #3142.