### PR TITLE
Fix handling of "flag" URL query params

### DIFF
--- a/Sources/Vapor/Content/ContainerGetPathExecutor.swift
+++ b/Sources/Vapor/Content/ContainerGetPathExecutor.swift
@@ -11,13 +11,21 @@ internal struct ContainerGetPathExecutor<D: Decodable>: Decodable {
             throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "Container getter couldn't find keypath to fetch (broken Decoder?)"))
         }
         
-        self.result = try keypath.reduce(decoder) {
+        let lastDecoder = try keypath.dropLast().reduce(decoder) {
             if let index = $1.intValue {
                 return try $0.unkeyedContainer(startingAt: index)._unsafe_inplace_superDecoder()
             } else {
                 return try $0.container(keyedBy: BasicCodingKey.self).superDecoder(forKey: .key($1.stringValue))
             }
-        }.singleValueContainer().decode(D.self)
+        }
+        if let index = keypath.last?.intValue {
+            var container = try lastDecoder.unkeyedContainer(startingAt: index)
+            self.result = try container.decode(D.self)
+        } else if let key = keypath.last?.stringValue {
+            self.result = try lastDecoder.container(keyedBy: BasicCodingKey.self).decode(D.self, forKey: .key(key))
+        } else {
+            self.result = try lastDecoder.singleValueContainer().decode(D.self)
+        }
     }
 }
 

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -1,5 +1,13 @@
-#if canImport(Glibc) && swift(>=5.10)
+#if swift(>=5.10)
+#if canImport(Darwin)
+@preconcurrency import Darwin
+#elseif canImport(Glibc)
 @preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(WinSDK)
+@preconcurrency import WinSDK
+#endif
 #endif
 import Foundation
 import NIOPosix

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -300,4 +300,27 @@ final class QueryTests: XCTestCase {
             XCTAssertThrowsError(try req.query.get(Int?.self, at: "page"))
         }
     }
+
+    func testValuelessParamGet() throws {
+        let app = Application()
+        defer { app.shutdown() }
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/"),
+            on: app.eventLoopGroup.next()
+        )
+
+        req.url = .init(path: "/foo?bar")
+        XCTAssertTrue(try req.query.get(Bool.self, at: "bar"))
+
+        req.url = .init(path: "/foo?bar&baz=bop")
+        XCTAssertTrue(try req.query.get(Bool.self, at: "bar"))
+
+        req.url = .init(path: "/foo")
+        XCTAssertFalse(try req.query.get(Bool.self, at: "bar"))
+
+        req.url = .init(path: "/foo?baz=bop")
+        XCTAssertFalse(try req.query.get(Bool.self, at: "bar"))
+    }
 }


### PR DESCRIPTION
Flag query parameters (e.g. `/foo?bar&baz`) were broken by [4.75.0](https://github.com/vapor/vapor/releases/tag/4.75.0), and apparently no one noticed for quite awhile. They now work again. Many thanks to @daveanderson for reporting this!

Fixes #3150.