### PR TITLE
Fix some Sendable warnings on 5.10

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -268,7 +268,7 @@ public func routes(_ app: Application) throws {
         return [cred1]
     }
     
-    func opaqueRouteTester(_ req: Request) async throws -> some AsyncResponseEncodable {
+    @Sendable func opaqueRouteTester(_ req: Request) async throws -> some AsyncResponseEncodable {
         "Hello World"
     }
     asyncRoutes.get("opaque", use: opaqueRouteTester)

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -268,7 +268,7 @@ public func routes(_ app: Application) throws {
         return [cred1]
     }
     
-    @Sendable func opaqueRouteTester(_ req: Request) async throws -> some AsyncResponseEncodable {
+    func opaqueRouteTester(_ req: Request) async throws -> some AsyncResponseEncodable {
         "Hello World"
     }
     asyncRoutes.get("opaque", use: opaqueRouteTester)

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Connection.swift
@@ -1,7 +1,7 @@
 import NIOHTTP1
 
 extension HTTPHeaders {
-    public struct Connection: ExpressibleByStringLiteral, Equatable {
+    public struct Connection: ExpressibleByStringLiteral, Equatable, Sendable {
         public static let close: Self = "close"
         public static let keepAlive: Self = "keep-alive"
 

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentDisposition.swift
@@ -20,7 +20,7 @@ extension HTTPHeaders {
     }
 
     public struct ContentDisposition {
-        public struct Value: Equatable {
+        public struct Value: Equatable, Sendable {
             public static let inline = Value(string: "inline")
             public static let attachment = Value(string: "attachment")
             public static let formData = Value(string: "form-data")

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Link.swift
@@ -21,7 +21,7 @@ extension HTTPHeaders {
     // TODO: Support multiple relations in a single `rel` attribute, as permitted by spec.
     public struct Link {
         /// See https://www.iana.org/assignments/link-relations/link-relations.xhtml
-        public struct Relation: RawRepresentable, Hashable {
+        public struct Relation: RawRepresentable, Hashable, Sendable {
             public static let about = Relation("about")
             public static let alternate = Relation("alternate")
             public static let appendix = Relation("appendix")

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -2,7 +2,7 @@ import NIOHTTP1
 
 extension HTTPHeaders {
     /// Type used for the name of a HTTP header in the `HTTPHeaders` storage.
-    public struct Name: Codable, Hashable, Equatable, CustomStringConvertible, ExpressibleByStringLiteral {
+    public struct Name: Codable, Hashable, Equatable, CustomStringConvertible, ExpressibleByStringLiteral, Sendable {
         /// See `Hashable`
         public func hash(into hasher: inout Hasher) {
             self.lowercased.hash(into: &hasher)

--- a/Sources/Vapor/Utilities/BaseN.swift
+++ b/Sources/Vapor/Utilities/BaseN.swift
@@ -7,7 +7,7 @@ import Algorithms
 
 import struct Foundation.Data
 
-public struct BaseNEncoding {
+public struct BaseNEncoding: Sendable {
     /// For a given base and count, calculate the number of values needed to encode the given count of bytes.
     @inlinable
     internal static func sizeEnc(for bits: Int, count: Int) -> Int {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Fix a number of warnings in Swift 5.10 like below.

![](https://github.com/vapor/vapor/assets/19257572/1e3daa24-8e01-4307-8b7b-8307adf2704d)

Fix simple issues that can be addressed by simply adding `Sendable`.

<!-- When this PR is merged, the title and body will be -->

<!-- used to generate a release automatically. -->
