### PR TITLE
Add XCTHTTPClient

### DIFF
--- a/Sources/XCTVapor/XCTHTTPClient.swift
+++ b/Sources/XCTVapor/XCTHTTPClient.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Vapor
+import NIOCore
+
+extension ClientResponse: @unchecked Sendable  {
+}
+
+struct XCTHTTPClient: Client {
+    
+    let eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    let eventLoop: EventLoop
+    var mockData: [ClientRequest: ClientResponse]
+    
+    init(eventLoop: EventLoop?, mockData: [ClientRequest: ClientResponse] = [:]) {
+        self.eventLoop = eventLoop ?? eventLoopGroup.next()
+        self.mockData = mockData
+    }
+    
+    mutating func mock(request: ClientRequest, response: ClientResponse) {
+        self.mockData[request] = response
+    }
+    
+    func send(_ request: ClientRequest) -> EventLoopFuture<ClientResponse> {
+        
+        if let matched = self.mockData.first(where: { $0.key == request }) {
+            return self.eventLoop.future(matched.value)
+        }
+        
+        return self.eventLoop.makeFailedFuture(Abort(.notFound))
+    }
+    
+    internal func delegating(to eventLoop: EventLoop) -> Client {
+        return Self.init(eventLoop: eventLoop)
+    }
+    
+}
+
+extension ClientRequest: Hashable {
+    public static func == (lhs: ClientRequest, rhs: ClientRequest) -> Bool {
+        return lhs.method == rhs.method
+        && lhs.url.string == rhs.url.string
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.method.string)
+        hasher.combine(self.url.string)
+        hasher.combine(self.headers.description)
+    }
+}


### PR DESCRIPTION
This PR allow user to tests Services or Method without perform actual requests.

Here is an example.
```Swift
final class AppleTests: XCTestCase {
    
    var client = XCTHTTPClient(eventLoop: nil)
   
    func testSomething() async throws {
        
        var resp: ClientResponse = .init(status: .ok)
        try resp.content.encode(content, as: HTTPMediaType.json)
        
        client.mock(
            request: .init(method: .POST, url: .init(string: AppleApi.ValidationTokenRequest.method)),
            response: resp
        )
        
        let service = Service(signers: signers, client: client , properties: prop, log: log)
        
        let req = AppleApi.ValidationTokenRequest.init("...")
        let result = try await service.validateToken(request: req)
        
        guard case let .success(received) = result else {
            XCTFail()
            return
        }
        
        XCTAssertEqual(...)
    }
}
```