### PR TITLE
Fix typos across the codebase

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -84,7 +84,7 @@ The release title should be concise description. For example:
 - ✅ Add case-insensitive routing
 - ✅ Fix `routes` command symbol usage
 
-The release titles should use sentence capitialization and not be too verbose. They should also use present tense.
+The release titles should use sentence capitalization and not be too verbose. They should also use present tense.
 
 - ❌ Fix `routes` Command Symbol Usage
 - ❌ Add new method on RouteBuilder called `caseInsensitive` which can be used to enable case-insensitive routing 

--- a/.github/maintainers.md
+++ b/.github/maintainers.md
@@ -6,7 +6,7 @@ maintainers will determine if you are a good fit and either accept and merge the
 to be taken in order to be accepted.
 
 ## Perks
-- Special "Maintainer" role in Discord with purple highlght.
+- Special "Maintainer" role in Discord with purple highlight.
 - Write access to maintained repo (including approve and merge permissions). 
 - Invite to "Maintainers" team on GitHub.
 - Opportunity to actively participate in deciding on new features in package. 

--- a/Sources/Vapor/Authentication/AuthenticationCache.swift
+++ b/Sources/Vapor/Authentication/AuthenticationCache.swift
@@ -104,7 +104,7 @@ extension Request.Authentication {
 // multiple places. But given how Vapor and its users use Authentication this should almost never
 // occur and it was decided the trade-off was acceptable
 // As the name implies, the usage of this is unsafe because it disables the sendable checking of the
-// compiler and does not add any synchronisation.
+// compiler and does not add any synchronization.
 @usableFromInline
 internal struct UnsafeAuthenticationBox<A>: @unchecked Sendable {
     @usableFromInline

--- a/Sources/Vapor/Concurrency/RequestBody+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RequestBody+Concurrency.swift
@@ -120,7 +120,7 @@ extension Request.Body: AsyncSequence {
     /// Generates an `AsyncIterator` to stream the body’s content as
     /// `ByteBuffer` sequences. This implementation supports backpressure using
     /// `NIOAsyncSequenceProducerBackPressureStrategies`
-    /// - Returns: `AsyncIterator` containing the `Requeset.Body` as a
+    /// - Returns: `AsyncIterator` containing the `Request.Body` as a
     /// `ByteBuffer` sequence
     public func makeAsyncIterator() -> AsyncIterator {
         let delegate = AsyncSequenceDelegate(eventLoop: request.eventLoop)
@@ -159,7 +159,7 @@ extension Request.Body: AsyncSequence {
                     // return the future that we will fulfill eventually.
                     return promise.futureResult
                 case .produceMore:
-                    // We can produce more immidately. Return a succeeded future.
+                    // We can produce more immediately. Return a succeeded future.
                     return request.eventLoop.makeSucceededVoidFuture()
                 }
             case .error(let error):

--- a/Sources/Vapor/Content/ContentCoders.swift
+++ b/Sources/Vapor/Content/ContentCoders.swift
@@ -27,7 +27,7 @@ public protocol ContentEncoder {
 
 /// Conform a type to this protocol to make it usable for decoding data via Vapor's ``ContentConfiguration`` system.
 public protocol ContentDecoder {
-    /// Legacy "decode object" method. The provided ``NIOCore/ByteBuffer`` should be decoded as a vaule of the given
+    /// Legacy "decode object" method. The provided ``NIOCore/ByteBuffer`` should be decoded as a value of the given
     /// type, optionally guided by the provided ``NIOHTTP1/HTTPHeaders``.
     ///
     /// Most decoders should implement this method by simply forwarding it to the decoder userInfo-aware version below,
@@ -36,7 +36,7 @@ public protocol ContentDecoder {
     func decode<D>(_ decodable: D.Type, from body: ByteBuffer, headers: HTTPHeaders) throws -> D
         where D: Decodable
 
-    /// "Decode object" method. The provided ``NIOCore/ByteBuffer`` should be decoded as a vaule of the given type,
+    /// "Decode object" method. The provided ``NIOCore/ByteBuffer`` should be decoded as a value of the given type,
     /// optionally guided by the provided ``NIOHTTP1/HTTPHeaders``. The provided ``userInfo`` dictionary must be
     /// forwarded to the underlying ``Swift/Decoder`` used to perform the decoding operation.
     ///

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -98,7 +98,7 @@ private final class _PlaintextEncoder: Encoder, SingleValueEncodingContainer {
         }
     }
 
-    /// This ridiculosity is a workaround for the inability of encoders to throw errors in various places. It's still better than fatalError()ing.
+    /// This ridiculously is a workaround for the inability of encoders to throw errors in various places. It's still better than fatalError()ing.
     struct FailureEncoder<K: CodingKey>: Encoder, KeyedEncodingContainerProtocol, UnkeyedEncodingContainer, SingleValueEncodingContainer {
         let codingPath = [CodingKey](), userInfo = [CodingUserInfoKey: Any](), count = 0
         var error: EncodingError { .invalidValue((), .init(codingPath: [], debugDescription: "Plaintext encoding does not support nesting.")) }

--- a/Sources/Vapor/Deprecations/DotEnvFile+load.swift
+++ b/Sources/Vapor/Deprecations/DotEnvFile+load.swift
@@ -19,7 +19,7 @@ extension DotEnvFile {
     public static func load(
         for environment: Environment = .development,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
-        logger: Logger = Logger(label: "dot-env-loggger")
+        logger: Logger = Logger(label: "dot-env-logger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)
         threadPool.start()
@@ -51,7 +51,7 @@ extension DotEnvFile {
     public static func load(
         path: String,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
-        logger: Logger = Logger(label: "dot-env-loggger")
+        logger: Logger = Logger(label: "dot-env-logger")
     ) {
         let threadPool = NIOThreadPool(numberOfThreads: 1)
         threadPool.start()

--- a/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
+++ b/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
@@ -1,6 +1,6 @@
 extension Routes {
     @available(*, deprecated, renamed: "caseInsensitive")
-    public var caseInsenstive: Bool {
+    public var caseInsensitive: Bool {
         get {
             caseInsensitive
         }

--- a/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
+++ b/Sources/Vapor/Deprecations/Routes+caseInsenstive.swift
@@ -1,6 +1,6 @@
 extension Routes {
     @available(*, deprecated, renamed: "caseInsensitive")
-    public var caseInsensitive: Bool {
+    public var caseInsenstive: Bool {
         get {
             caseInsensitive
         }

--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -193,7 +193,7 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
         
         // MARK: Methods
         
-        /// Seriaizes an `HTTPCookie` to a `String`.
+        /// Serializes an `HTTPCookie` to a `String`.
         public func serialize(name: String) -> String {
             var serialized = "\(name)=\(self.string)"
             
@@ -264,7 +264,7 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
     
     // MARK: Serialize
     
-    /// Seriaizes the `Cookies` for a `Request`
+    /// Serializes the `Cookies` for a `Request`
     var cookieHeader: String? {
         guard !self.cookies.isEmpty else {
             return nil

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -57,7 +57,7 @@ public final class Request: CustomStringConvertible, Sendable {
     /// A unique ID for the request.
     ///
     /// The request identifier is set to value of the `X-Request-Id` header when present, or to a
-    /// uniquelly generated value otherwise.
+    /// uniquely generated value otherwise.
     public let id: String
     
     // MARK: Metadata

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
@@ -53,7 +53,7 @@ extension Array where Element == CodingKey {
     }
 }
 
-// MARK: Utilties
+// MARK: Utilities
 
 extension String {
     /// Prepares a `String` for inclusion in form-urlencoded data.

--- a/Sources/Vapor/Utilities/BaseN.swift
+++ b/Sources/Vapor/Utilities/BaseN.swift
@@ -12,7 +12,7 @@ public struct BaseNEncoding: Sendable {
     @inlinable
     internal static func sizeEnc(for bits: Int, count: Int) -> Int {
         let outputs = 8 >> bits.trailingZeroBitCount, inputs = bits >> bits.trailingZeroBitCount // number of output values per input bytes
-        return ((count * outputs - 1) / inputs) + 1 // Integer divsion rounding away from zero
+        return ((count * outputs - 1) / inputs) + 1 // Integer division rounding away from zero
     }
     
     /// For a given base and count, calculate the number of bytes encoded by a given count of values. Does not
@@ -101,7 +101,7 @@ public struct BaseNEncoding: Sendable {
     internal struct BreakLoopError: Error { @inlinable internal init() {} }
     
     // N.B.: The values used for the invalid and padding byte representations are not arbitrarily chosen; they are
-    // intended to be used in optimized versions of the algorithm to quickly distinguish the vairous cases.
+    // intended to be used in optimized versions of the algorithm to quickly distinguish the various cases.
     
     @usableFromInline
     internal static var invalidByte: UInt8 { 0b1111_1111 } // All bits set

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -46,7 +46,7 @@ public struct DotEnvFile: Sendable {
         for environment: Environment = .development,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         fileio: NonBlockingFileIO,
-        logger: Logger = Logger(label: "dot-env-loggger")
+        logger: Logger = Logger(label: "dot-env-logger")
     ) {
         let eventLoopGroup: EventLoopGroup
 
@@ -93,7 +93,7 @@ public struct DotEnvFile: Sendable {
         path: String,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
         fileio: NonBlockingFileIO,
-        logger: Logger = Logger(label: "dot-env-loggger")
+        logger: Logger = Logger(label: "dot-env-logger")
     ) {
         let eventLoopGroup: EventLoopGroup
 

--- a/Sources/Vapor/Validation/RangeResult.swift
+++ b/Sources/Vapor/Validation/RangeResult.swift
@@ -57,7 +57,7 @@ public enum RangeResult<T>: Equatable where T: Comparable {
             // any other case is either not comparable (e.g. comparing Float.nan with anything is always false)
             // or it should never happen because all static methods on `Validator` that can make
             // the count and range validators all result in at least a minimum or a maximum or both.
-            // The thrown error needs to be handlded at a higher level then.
+            // The thrown error needs to be handled at a higher level then.
             throw RangeResultError.notComparable
         }
     }

--- a/Sources/Vapor/Validation/Validators/Range.swift
+++ b/Sources/Vapor/Validation/Validators/Range.swift
@@ -59,7 +59,7 @@ extension Validator {
 // TODO: Remove when keypaths are `Sendable`
 /// ``UnsafeMutableTransferBox`` can be used to make non-`Sendable` values `Sendable` and mutable.
 /// It can be used to capture local mutable values in a `@Sendable` closure and mutate them from within the closure.
-/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronisation.
+/// As the name implies, the usage of this is unsafe because it disables the sendable checking of the compiler and does not add any synchronization.
 @usableFromInline
 final class UnsafeMutableTransferBox<Wrapped> {
     @usableFromInline

--- a/Tests/VaporTests/AsyncMiddlewareTests.swift
+++ b/Tests/VaporTests/AsyncMiddlewareTests.swift
@@ -88,7 +88,7 @@ final class AsyncMiddlewareTests: XCTestCase {
         }
     }
 
-    func testCORSMiddlewareNoVariationByRequstOriginAllowed() throws {
+    func testCORSMiddlewareNoVariationByRequestOriginAllowed() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 

--- a/Tests/VaporTests/AsyncPasswordTests.swift
+++ b/Tests/VaporTests/AsyncPasswordTests.swift
@@ -68,11 +68,11 @@ final class AsyncPasswordTests: XCTestCase {
             .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
             .hash("vapor")
 
-        let asyncVerifiy = try await app.password
+        let asyncVerify = try await app.password
             .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
             .verify("vapor", created: asyncHash)
 
-        XCTAssertTrue(asyncVerifiy, file: file, line: line)
+        XCTAssertTrue(asyncVerify, file: file, line: line)
     }
 
     private func assertAsyncRequestPasswordVerifies(

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -35,13 +35,13 @@ final class AsyncRequestTests: XCTestCase {
         let testValue = String.randomDigits()
 
         app.on(.POST, "stream", body: .stream) { req in
-            var recievedBuffer = ByteBuffer()
+            var receivedBuffer = ByteBuffer()
             for try await part in req.body {
                 XCTAssertNotNil(part)
                 var part = part
-                recievedBuffer.writeBuffer(&part)
+                receivedBuffer.writeBuffer(&part)
             }
-            let string = String(buffer: recievedBuffer)
+            let string = String(buffer: receivedBuffer)
             return string
         }
 

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -92,7 +92,7 @@ final class MiddlewareTests: XCTestCase {
         }
     }
 
-    func testCORSMiddlewareNoVariationByRequstOriginAllowed() throws {
+    func testCORSMiddlewareNoVariationByRequestOriginAllowed() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -95,12 +95,12 @@ final class PasswordTests: XCTestCase {
             .hash("vapor")
             .wait()
         
-        let asyncVerifiy = try app.password
+        let asyncVerify = try app.password
             .async(on: app.threadPool, hopTo: app.eventLoopGroup.next())
             .verify("vapor", created: asyncHash)
             .wait()
         
-        XCTAssertTrue(asyncVerifiy, file: file, line: line)
+        XCTAssertTrue(asyncVerify, file: file, line: line)
     }
     
     private func assertAsyncRequestPasswordVerifies(

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -75,7 +75,7 @@ final class RequestTests: XCTestCase {
         }
     }
 
-    func testRequestPeerAddressRemoteAddres() throws {
+    func testRequestPeerAddressRemoteAddress() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
 

--- a/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
+++ b/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
@@ -156,7 +156,7 @@ internal final class TestTimer: TimerHandler, Equatable, @unchecked Sendable {
         }
     }
 
-    func retriveValueInPreferredUnit(atIndex i: Int) -> Double {
+    func retrieveValueInPreferredUnit(atIndex i: Int) -> Double {
         return self.lock.withLock {
             let value = values[i].1
             guard let displayUnit = self.displayUnit else {


### PR DESCRIPTION
Fixes a number of typos in the codebase.

⚠️ the logger for loading environment files now has the correctly spelt label - `dot-env-logger` if you need to search for that