### PR TITLE
Session cookie creation flag

### DIFF
--- a/Sources/Vapor/Sessions/Session.swift
+++ b/Sources/Vapor/Sessions/Session.swift
@@ -27,12 +27,23 @@ public final class Session: Sendable {
         }
     }
 
+    /// whether created by SessionsMiddleware
+    internal var isCreated: Bool {
+        get {
+            self._isCreated.withLockedValue { $0 }
+        }
+        set {
+            self._isCreated.withLockedValue { $0 = newValue }
+        }
+    }
+
     /// `true` if this session is still valid.
     let isValid: NIOLockedValueBox<Bool>
     
     private let _id: NIOLockedValueBox<SessionID?>
     private let _data: NIOLockedValueBox<SessionData>
-
+    private let _isCreated: NIOLockedValueBox<Bool>
+    
     /// Create a new `Session`.
     ///
     /// Normally you will use `Request.session()` to do this.
@@ -40,6 +51,7 @@ public final class Session: Sendable {
         self._id = .init(id)
         self._data = .init(data)
         self.isValid = .init(true)
+        self._isCreated = .init(false)
     }
 
     /// Invalidates the current session, removing persisted data from the session driver

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -66,12 +66,13 @@ public final class SessionsMiddleware: Middleware {
             // A session exists or has been created. we must
             // set a cookie value on the response
             let createOrUpdate: EventLoopFuture<SessionID>
-            if let id = session.id {
+            if let id = session.id, session.isCreated {
                 // A cookie exists, just update this session.
                 createOrUpdate = self.session.updateSession(id, to: session.data, for: request)
             } else {
                 // No cookie, this is a new session.
                 createOrUpdate = self.session.createSession(session.data, for: request)
+                session.isCreated = true
             }
 
             // After create or update, set cookie on the response.


### PR DESCRIPTION
I ran into a problem where setting the session id prevented it from being saved by SessionsMiddleware.

In line 69 of SessionsMiddleware.swift...
[https://github.com/bgisme/vapor/blob/11cdb29614a5c7f8c5289f3c97b3398c3d89b395/Sources/Vapor/Sessions/SessionsMiddleware.swift#L69](url)
...the session is created depending on whether or not it has an id.

So if you set the session id for the first time it will not be saved.

This pull request is just a simple attempt at addressing the issue with an internal boolean flag for whether the session was created or not. I'll be the first to admit it may not be the best way. Just a suggestion. In case anyone thinks it's a problem.