### PR TITLE
Use "best for platform" `EventLoopGroup` instead of always using `MultiThreadedEventLoopGroup`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // HTTP client library built on SwiftNIO
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
 
         // Sugary extensions for the SwiftNIO library
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.15.0"),

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,5 +1,6 @@
 import ConsoleKit
 import Logging
+import AsyncHTTPClient
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOPosix
@@ -100,7 +101,7 @@ public final class Application: Sendable {
         case createNew
 
         public static var singleton: EventLoopGroupProvider {
-            .shared(MultiThreadedEventLoopGroup.singleton)
+            .shared(Application.defaultEventLoopGroup)
         }
     }
 
@@ -113,6 +114,13 @@ public final class Application: Sendable {
     private let _logger: NIOLockedValueBox<Logger>
     private let _lifecycle: NIOLockedValueBox<Lifecycle>
     private let _locks: NIOLockedValueBox<Locks>
+
+    /// Returns the default `EventLoopGroup` singleton, automatically selecting the best for the platform.
+    ///
+    /// This will select the concrete `EventLoopGroup` depending which platform this is running on.
+    public static var defaultEventLoopGroup: any EventLoopGroup {
+        HTTPClient.defaultEventLoopGroup
+    }
 
     public init(
         _ environment: Environment = .development,

--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -83,7 +83,7 @@ extension WebSocket {
         to url: String,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
+        on eventLoopGroup: EventLoopGroup = Application.defaultEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws {
         guard let url = URL(string: url) else {
@@ -103,7 +103,7 @@ extension WebSocket {
         to url: URL,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
+        on eventLoopGroup: EventLoopGroup = Application.defaultEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         let scheme = url.scheme ?? "ws"
@@ -127,7 +127,7 @@ extension WebSocket {
         path: String = "/",
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
-        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
+        on eventLoopGroup: EventLoopGroup = Application.defaultEventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) async throws  {
         return try await WebSocketClient(

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -282,7 +282,7 @@ public final class HTTPServer: Server, Sendable {
         application: Application,
         responder: Responder,
         configuration: Configuration,
-        on eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        on eventLoopGroup: EventLoopGroup = Application.defaultEventLoopGroup
     ) {
         self.application = application
         self.responder = responder

--- a/Sources/Vapor/View/PlaintextRenderer.swift
+++ b/Sources/Vapor/View/PlaintextRenderer.swift
@@ -12,7 +12,7 @@ public struct PlaintextRenderer: ViewRenderer, Sendable {
         fileio: NonBlockingFileIO,
         viewsDirectory: String,
         logger: Logger,
-        eventLoopGroup: EventLoopGroup = MultiThreadedEventLoopGroup.singleton
+        eventLoopGroup: EventLoopGroup = Application.defaultEventLoopGroup
     ) {
         self.fileio = fileio
         self.viewsDirectory = viewsDirectory.finished(with: "/")

--- a/Sources/XCTVapor/XCTApplication.swift
+++ b/Sources/XCTVapor/XCTApplication.swift
@@ -48,7 +48,7 @@ extension Application {
             try app.server.start(address: .hostname(self.hostname, port: self.port))
             defer { app.server.shutdown() }
             
-            let client = HTTPClient(eventLoopGroup: MultiThreadedEventLoopGroup.singleton)
+            let client = HTTPClient(eventLoopGroup: Application.defaultEventLoopGroup)
             defer { try! client.syncShutdown() }
             var path = request.url.path
             path = path.hasPrefix("/") ? path : "/\(path)"

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -174,7 +174,7 @@ final class AsyncRequestTests: XCTestCase {
                                               headers: [:],
                                               body: .byteBuffer(tenMB))
         let delegate = ResponseDelegate(bytesTheClientSent: bytesTheClientSent)
-        let httpClient = HTTPClient(eventLoopGroup: MultiThreadedEventLoopGroup.singleton)
+        let httpClient = HTTPClient(eventLoopGroup: Application.defaultEventLoopGroup)
         XCTAssertThrowsError(try httpClient.execute(request: request,
                                                                 delegate: delegate,
                                                                 deadline: .now() + .milliseconds(500)).wait()) { error in


### PR DESCRIPTION


<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
