### PR TITLE
Fix test when run in parallel

### DIFF
--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1411,6 +1411,7 @@ final class ServerTests: XCTestCase {
     
     func testConfigurationHasActualPortAfterStart() throws {
         let app = Application(.testing)
+        app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
         defer { app.shutdown() }
         try app.start()


### PR DESCRIPTION
`testConfigurationHasActualPortAfterStart` fails when tests are run in parallel with "Unknown command `VaporTests.ServerTests/testConfigurationHasActualPortAfterStart`".