### PR TITLE
Support compiling against Musl

### DIFF
--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -1,5 +1,7 @@
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 import Darwin.C
 #endif

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -1,5 +1,7 @@
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 import Darwin
 #endif


### PR DESCRIPTION
Vapor already makes some provision for compiling against Musl in the RFC1123 implementation, where `Glibc` is not assumed and is imported conditionally alongside a conditional import of `Musl`. However, there are a couple of other places where `Glibc` is still assumed when compiling for Linux.

This patch replaces these imports with the same `#if canImport(...)` pattern.
