### PR TITLE
Add async alternative for Application.shutdown

### DIFF
--- a/Sources/Development/entrypoint.swift
+++ b/Sources/Development/entrypoint.swift
@@ -14,6 +14,7 @@ struct Entrypoint {
             try await app.asyncShutdown()
         } catch {
             try await app.asyncShutdown()
+            throw error
         }
     }
 }

--- a/Sources/Development/entrypoint.swift
+++ b/Sources/Development/entrypoint.swift
@@ -7,11 +7,14 @@ struct Entrypoint {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
 
-        let app = await Application(env)
-        defer { app.shutdown() }
-
-        try configure(app)
-        try await app.execute()
+        let app = try await Application.make(env)
+        do {
+            try configure(app)
+            try await app.execute()
+            try await app.asyncShutdown()
+        } catch {
+            try await app.asyncShutdown()
+        }
     }
 }
 

--- a/Sources/Development/entrypoint.swift
+++ b/Sources/Development/entrypoint.swift
@@ -13,7 +13,7 @@ struct Entrypoint {
             try await app.execute()
             try await app.asyncShutdown()
         } catch {
-            try await app.asyncShutdown()
+            try? await app.asyncShutdown()
             throw error
         }
     }

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -244,16 +244,7 @@ public final class Application: Sendable {
 
     @available(*, noasync, message: "This can block the thread and should not be called in an async context", renamed: "asyncShutdown()")
     public func shutdown() {
-        assert(!self.didShutdown, "Application has already shut down")
-        self.logger.debug("Application shutting down")
-
-        self.logger.trace("Shutting down providers")
-        self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
-        self.lifecycle.handlers = []
-
-        self.logger.trace("Clearing Application storage")
-        self.storage.shutdown()
-        self.storage.clear()
+        triggerShutdown()
 
         switch self.eventLoopGroupProvider {
         case .shared:
@@ -272,16 +263,7 @@ public final class Application: Sendable {
     }
     
     public func asyncShutdown() async throws {
-        assert(!self.didShutdown, "Application has already shut down")
-        self.logger.debug("Application shutting down")
-
-        self.logger.trace("Shutting down providers")
-        self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
-        self.lifecycle.handlers = []
-
-        self.logger.trace("Clearing Application storage")
-        self.storage.shutdown()
-        self.storage.clear()
+        triggerShutdown()
 
         switch self.eventLoopGroupProvider {
         case .shared:
@@ -297,6 +279,19 @@ public final class Application: Sendable {
 
         self._didShutdown.withLockedValue { $0 = true }
         self.logger.trace("Application shutdown complete")
+    }
+    
+    private func triggerShutdown() {
+        assert(!self.didShutdown, "Application has already shut down")
+        self.logger.debug("Application shutting down")
+
+        self.logger.trace("Shutting down providers")
+        self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
+        self.lifecycle.handlers = []
+
+        self.logger.trace("Clearing Application storage")
+        self.storage.shutdown()
+        self.storage.clear()
     }
 
     deinit {

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -242,6 +242,7 @@ public final class Application: Sendable {
         }
     }
 
+    @available(*, noasync, message: "This can block the thread and should not be called in an async context", renamed: "asyncShutdown()")
     public func shutdown() {
         assert(!self.didShutdown, "Application has already shut down")
         self.logger.debug("Application shutting down")
@@ -261,6 +262,34 @@ public final class Application: Sendable {
             self.logger.trace("Shutting down EventLoopGroup")
             do {
                 try self.eventLoopGroup.syncShutdownGracefully()
+            } catch {
+                self.logger.warning("Shutting down EventLoopGroup failed: \(error)")
+            }
+        }
+
+        self._didShutdown.withLockedValue { $0 = true }
+        self.logger.trace("Application shutdown complete")
+    }
+    
+    public func asyncShutdown() async throws {
+        assert(!self.didShutdown, "Application has already shut down")
+        self.logger.debug("Application shutting down")
+
+        self.logger.trace("Shutting down providers")
+        self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
+        self.lifecycle.handlers = []
+
+        self.logger.trace("Clearing Application storage")
+        self.storage.shutdown()
+        self.storage.clear()
+
+        switch self.eventLoopGroupProvider {
+        case .shared:
+            self.logger.trace("Running on shared EventLoopGroup. Not shutting down EventLoopGroup.")
+        case .createNew:
+            self.logger.trace("Shutting down EventLoopGroup")
+            do {
+                try await self.eventLoopGroup.shutdownGracefully()
             } catch {
                 self.logger.warning("Shutting down EventLoopGroup failed: \(error)")
             }

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -55,7 +55,7 @@ final class AsyncClientTests: XCTestCase {
     }
     
     override func tearDown() async throws {
-        remoteApp.shutdown()
+        try await remoteApp.asyncShutdown()
     }
     
     func testClientConfigurationChange() async throws {
@@ -119,7 +119,7 @@ final class AsyncClientTests: XCTestCase {
     }
 
     func testClientBeforeSend() async throws {
-        let app = await Application()
+        let app = try await Application.make()
         defer { app.shutdown() }
         try app.boot()
 

--- a/Tests/VaporTests/AsyncPasswordTests.swift
+++ b/Tests/VaporTests/AsyncPasswordTests.swift
@@ -5,7 +5,7 @@ import Vapor
 final class AsyncPasswordTests: XCTestCase {
     func testAsyncBCryptRequestPassword() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
 
         try await assertAsyncRequestPasswordVerifies(.bcrypt, on: app)
@@ -13,7 +13,7 @@ final class AsyncPasswordTests: XCTestCase {
 
     func testAsyncPlaintextRequestPassword() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
 
         try await assertAsyncRequestPasswordVerifies(.plaintext, on: app)
@@ -21,7 +21,7 @@ final class AsyncPasswordTests: XCTestCase {
 
     func testAsyncBCryptApplicationPassword() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
 
         try await assertAsyncApplicationPasswordVerifies(.bcrypt, on: app)
@@ -29,7 +29,7 @@ final class AsyncPasswordTests: XCTestCase {
 
     func testAsyncPlaintextApplicationPassword() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
 
         try await assertAsyncApplicationPasswordVerifies(.plaintext, on: app)
@@ -37,7 +37,7 @@ final class AsyncPasswordTests: XCTestCase {
 
     func testAsyncUsesProvider() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
         app.passwords.use(.plaintext)
         let hash = try await app.password.async(
@@ -49,7 +49,7 @@ final class AsyncPasswordTests: XCTestCase {
 
     func testAsyncApplicationDefault() async throws {
         let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = await Application(test)
+        let app = try await Application.make(test)
         defer { app.shutdown() }
         app.passwords.use(.plaintext)
         let hash = try await app.password.async.hash("vapor")

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -25,7 +25,7 @@ final class AsyncRequestTests: XCTestCase {
     }
     
     override func tearDown() async throws {
-        app.shutdown()
+        try await app.asyncShutdown()
     }
     
     func testStreamingRequest() async throws {

--- a/Tests/VaporTests/AsyncSessionTests.swift
+++ b/Tests/VaporTests/AsyncSessionTests.swift
@@ -40,7 +40,7 @@ final class AsyncSessionTests: XCTestCase {
 
         var cookie: HTTPCookies.Value?
 
-        let app = await Application()
+        let app = try await Application.make()
         defer { app.shutdown() }
 
         let cache = MockKeyedCache()

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -62,7 +62,7 @@ final class ClientTests: XCTestCase {
     }
     
     override func tearDown() async throws {
-        remoteApp.shutdown()
+        try await remoteApp.asyncShutdown()
     }
     
     func testClientConfigurationChange() throws {

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -14,7 +14,7 @@ final class PipelineTests: XCTestCase {
     }
     
     override func tearDown() async throws {
-        app.shutdown()
+        try await app.asyncShutdown()
     }
     
     

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -41,7 +41,7 @@ final class SessionTests: XCTestCase {
 
         var cookie: HTTPCookies.Value?
 
-        let app = await Application()
+        let app = try await Application.make()
         defer { app.shutdown() }
 
         let cache = MockKeyedCache()


### PR DESCRIPTION
Adds an async alternative for `Application.shutdown()` and annotates `shutdown()` with `noasync`