### PR TITLE
Update URLEncodedFormEncoder encoding rules

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
@@ -72,10 +72,10 @@ extension String {
 
 /// Characters allowed in form-urlencoded data.
 private enum Characters {
+    // https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set
     static let allowedCharacters: CharacterSet = {
-        var allowed = CharacterSet.urlQueryAllowed
-        // these symbols are reserved for url-encoded form
-        allowed.remove(charactersIn: "?&=[];+$")
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "*-._")
         return allowed
     }()
 }

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormSerializer.swift
@@ -3,13 +3,13 @@ import struct Foundation.CharacterSet
 struct URLEncodedFormSerializer: Sendable {
     let splitVariablesOn: Character
     let splitKeyValueOn: Character
-    
+
     /// Create a new form-urlencoded data parser.
     init(splitVariablesOn: Character = "&", splitKeyValueOn: Character = "=") {
         self.splitVariablesOn = splitVariablesOn
         self.splitKeyValueOn = splitKeyValueOn
     }
-    
+
     func serialize(_ data: URLEncodedFormData, codingPath: [CodingKey] = []) throws -> String {
         var entries: [String] = []
         let key = try codingPath.toURLEncodedKey()
@@ -21,20 +21,20 @@ struct URLEncodedFormSerializer: Sendable {
             }
         }
         for (key, child) in data.children {
-            entries.append(try serialize(child, codingPath: codingPath + [_CodingKey(stringValue: key) as CodingKey]))
+            try entries.append(serialize(child, codingPath: codingPath + [_CodingKey(stringValue: key) as CodingKey]))
         }
         return entries.joined(separator: String(splitVariablesOn))
     }
-    
+
     struct _CodingKey: CodingKey {
         var stringValue: String
-        
+
         init(stringValue: String) {
             self.stringValue = stringValue
         }
-        
+
         var intValue: Int?
-        
+
         init?(intValue: Int) {
             self.intValue = intValue
             self.stringValue = intValue.description
@@ -47,9 +47,9 @@ extension Array where Element == CodingKey {
         if count < 1 {
             return ""
         }
-        return try self[0].stringValue.urlEncoded(codingPath: self) + self[1...].map({ (key: CodingKey) -> String in
-            return try "[" + key.stringValue.urlEncoded(codingPath: self) + "]"
-        }).joined()
+        return try self[0].stringValue.urlEncoded(codingPath: self) + self[1...].map { (key: CodingKey) -> String in
+            try "[" + key.stringValue.urlEncoded(codingPath: self) + "]"
+        }.joined()
     }
 }
 
@@ -75,7 +75,7 @@ private enum Characters {
     static let allowedCharacters: CharacterSet = {
         var allowed = CharacterSet.urlQueryAllowed
         // these symbols are reserved for url-encoded form
-        allowed.remove(charactersIn: "?&=[];+")
+        allowed.remove(charactersIn: "?&=[];+$")
         return allowed
     }()
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -1,9 +1,9 @@
-import XCTVapor
-import XCTest
-import Vapor
 import NIOCore
-import NIOHTTP1
 import NIOEmbedded
+import NIOHTTP1
+import Vapor
+import XCTest
+import XCTVapor
 
 final class ContentTests: XCTestCase {
     func testContent() throws {
@@ -69,7 +69,7 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.routes.get("decode_error") { req -> String in
+        app.routes.get("decode_error") { _ -> String in
             struct Foo: Decodable {
                 var name: String
                 var bar: Int
@@ -95,7 +95,7 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.routes.get("encode") { req -> Response in
+        app.routes.get("encode") { _ -> Response in
             let res = Response()
             try res.content.encode(FooContent())
             try res.content.encode(FooContent(), as: .json)
@@ -153,7 +153,7 @@ final class ContentTests: XCTestCase {
             XCTAssertContains(res.body.string, "decoded!")
         }
     }
-    
+
     func testMultipartDecode() throws {
         let data = """
         --123\r
@@ -199,7 +199,7 @@ final class ContentTests: XCTestCase {
             XCTAssertEqualJSON(res.body.string, expected)
         }
     }
-  
+
     func testMultipartDecodedEmptyMultipartForm() throws {
         let data = """
         --123\r
@@ -254,7 +254,7 @@ final class ContentTests: XCTestCase {
             XCTAssertEqual(res.status, .unprocessableEntity)
         }
     }
-    
+
     func testMultipartDecodeUnicode() throws {
         let data = """
         --123\r
@@ -312,8 +312,8 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.get("multipart") { req -> User in
-            return User(
+        app.get("multipart") { _ -> User in
+            User(
                 name: "Vapor",
                 age: 4,
                 image: File(data: "<contents of image>", filename: "droplet.png")
@@ -328,7 +328,7 @@ final class ContentTests: XCTestCase {
             XCTAssertContains(res.body.string, "name=\"image\"")
         }
     }
-    
+
     func testMultiPartEncodeUnicode() throws {
         struct User: Content {
             static let defaultContentType: HTTPMediaType = .formData
@@ -340,8 +340,8 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.get("multipart") { req -> User in
-            return User(
+        app.get("multipart") { _ -> User in
+            User(
                 name: "Vapor",
                 age: 4,
                 image: File(data: "<contents of image>", filename: "UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png")
@@ -396,8 +396,8 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.get("urlencodedform") { req -> User in
-            return User(name: "Vapor", age: 3, luckyNumbers: [5, 7])
+        app.get("urlencodedform") { _ -> User in
+            User(name: "Vapor", age: 3, luckyNumbers: [5, 7])
         }
         try app.testable().test(.GET, "/urlencodedform") { res in
             XCTAssertEqual(res.status.code, 200)
@@ -414,7 +414,7 @@ final class ContentTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("check") { (req: Request) -> String in
-            return "\(req.headers.first(name: .init("X-Test-Value")) ?? "MISSING").\(req.headers.first(name: .contentType) ?? "?")"
+            "\(req.headers.first(name: .init("X-Test-Value")) ?? "MISSING").\(req.headers.first(name: .contentType) ?? "?")"
         }
 
         try app.test(.GET, "/check", headers: ["X-Test-Value": "PRESENT"], beforeRequest: { req in
@@ -429,16 +429,16 @@ final class ContentTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("check") { (req: Request) -> String in
-            return "\(req.headers.first(name: .init("X-Test-Value")) ?? "MISSING").\(req.headers.first(name: .contentType) ?? "?")"
+            "\(req.headers.first(name: .init("X-Test-Value")) ?? "MISSING").\(req.headers.first(name: .contentType) ?? "?")"
         }
         // Me and my sadistic sense of humor.
         ContentConfiguration.global.use(decoder: try! ContentConfiguration.global.requireDecoder(for: .json), for: .xml)
 
         try app.testable().test(.GET, "/check", headers: [
             "X-Test-Value": "PRESENT"
-            ], beforeRequest: { req in
-                try req.content.encode(["foo": "bar"], as: .json)
-                req.headers.contentType = .xml
+        ], beforeRequest: { req in
+            try req.content.encode(["foo": "bar"], as: .json)
+            req.headers.contentType = .xml
         }) { res in
             XCTAssertEqual(res.body.string, "PRESENT.application/xml; charset=utf-8")
         }
@@ -473,7 +473,7 @@ final class ContentTests: XCTestCase {
         let content = try request.content.decode(SampleContent.self)
         XCTAssertEqual(content.name, "new name after decode")
     }
-    
+
     func testSupportsJsonApi() throws {
         let app = Application()
         defer { app.shutdown() }
@@ -499,7 +499,7 @@ final class ContentTests: XCTestCase {
 
         let request = Request(
             application: app,
-            collectedBody: .init(string:""),
+            collectedBody: .init(string: ""),
             on: app.eventLoopGroup.any()
         )
         request.url.query = "name=before+decode"
@@ -531,17 +531,17 @@ final class ContentTests: XCTestCase {
     func testEncodePercentEncodedQuery() throws {
         let app = Application()
         defer { app.shutdown() }
-        
+
         struct Foo: Content {
             var status: String
         }
-        
+
         var request = ClientRequest(url: .init(scheme: "https", host: "example.com", path: "/api"))
         try request.query.encode(Foo(status:
             "⬆️ taylorswift just released swift-mongodb v0.10.1 – use BSON and MongoDB in pure Swift\n\nhttps://swiftpackageindex.com/tayloraswift/swift-mongodb#releases"
         ))
 
-        XCTAssertEqual(request.url.string, "https://example.com/api?status=%E2%AC%86%EF%B8%8F%20taylorswift%20just%20released%20swift-mongodb%20v0.10.1%20%E2%80%93%20use%20BSON%20and%20MongoDB%20in%20pure%20Swift%0A%0Ahttps://swiftpackageindex.com/tayloraswift/swift-mongodb%23releases")
+        XCTAssertEqual(request.url.string, "https://example.com/api?status=%E2%AC%86%EF%B8%8F%20taylorswift%20just%20released%20swift-mongodb%20v0.10.1%20%E2%80%93%20use%20BSON%20and%20MongoDB%20in%20pure%20Swift%0A%0Ahttps%3A%2F%2Fswiftpackageindex.com%2Ftayloraswift%2Fswift-mongodb%23releases")
     }
 
     func testSnakeCaseCodingKeyError() throws {
@@ -557,6 +557,7 @@ final class ContentTests: XCTestCase {
             enum CodingKeys: String, CodingKey {
                 case id, title, isFree = "is_free"
             }
+
             let id: UUID?
             let title: String
             let isFree: Bool
@@ -572,7 +573,7 @@ final class ContentTests: XCTestCase {
     func testDataCorruptionError() throws {
         let app = Application()
         defer { app.shutdown() }
-        
+
         let req = Request(
             application: app,
             method: .GET,
@@ -581,7 +582,7 @@ final class ContentTests: XCTestCase {
             collectedBody: ByteBuffer(string: #"{"badJson: "Key doesn't have a trailing quote"}"#),
             on: app.eventLoopGroup.any()
         )
-        
+
         struct DecodeModel: Content {
             let badJson: String
         }
@@ -596,12 +597,12 @@ final class ContentTests: XCTestCase {
     func testValueNotFoundError() throws {
         let app = Application()
         defer { app.shutdown() }
-        
+
         let req = Request(application: app, on: app.eventLoopGroup.any())
         try req.content.encode([
             "items": ["1"]
         ], as: .json)
-        
+
         struct DecodeModel: Content {
             struct Item: Content {
                 init(from decoder: Decoder) throws {
@@ -611,7 +612,7 @@ final class ContentTests: XCTestCase {
                     fatalError()
                 }
             }
-            
+
             let items: Item
         }
         XCTAssertThrowsError(try req.content.decode(DecodeModel.self)) { error in
@@ -625,18 +626,19 @@ final class ContentTests: XCTestCase {
     func testTypeMismatchError() throws {
         let app = Application()
         defer { app.shutdown() }
-        
+
         let req = Request(application: app, on: app.eventLoopGroup.any())
         try req.content.encode([
             "item": [
                 "title": "The title"
             ]
         ], as: .json)
-        
+
         struct DecodeModel: Content {
             struct Item: Content {
                 let title: Int
             }
+
             let item: Item
         }
         XCTAssertThrowsError(try req.content.decode(DecodeModel.self)) { error in
@@ -652,13 +654,13 @@ final class ContentTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
 
-        app.routes.get("plaintext") { (req) -> Response in
+        app.routes.get("plaintext") { _ -> Response in
             let res = Response()
             try res.content.encode(data, as: .plainText)
             return res
         }
 
-        app.routes.get("empty-plaintext") { (req) -> Response in
+        app.routes.get("empty-plaintext") { _ -> Response in
             let res = Response()
             try res.content.encode("", as: .plainText)
             return res
@@ -704,15 +706,15 @@ final class ContentTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         }
     }
-    
+
     func testContentIsBool() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
-        
-        app.routes.get("success") { req in
-            return true
+
+        app.routes.get("success") { _ in
+            true
         }
-        
+
         try app.testable().test(.GET, "/success") { res in
             XCTAssertEqual(try res.content.decode(Bool.self), true)
         }
@@ -733,7 +735,7 @@ private struct SampleContent: Content {
 
 private struct JsonApiContent: Content {
     struct Meta: Codable {}
-    
+
     var data: [String]
     var meta = Meta()
 }

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -193,7 +193,7 @@ final class URLEncodedFormTests: XCTestCase {
         let resultForInternetDateTime = try URLEncodedFormEncoder(
             configuration: .init(dateEncodingStrategy: .iso8601)
         ).encode(toEncode)
-        XCTAssertEqual("dates[]=1970-01-01T00:00:00Z&dates[]=1970-01-01T02:46:40Z&dates[]=1970-01-01T05:33:20Z&dates[]=1970-01-01T08:20:00Z&dates[]=1970-01-01T11:06:40Z&dates[]=1970-01-01T13:53:20Z", resultForInternetDateTime)
+        XCTAssertEqual("dates[]=1970-01-01T00%3A00%3A00Z&dates[]=1970-01-01T02%3A46%3A40Z&dates[]=1970-01-01T05%3A33%3A20Z&dates[]=1970-01-01T08%3A20%3A00Z&dates[]=1970-01-01T11%3A06%3A40Z&dates[]=1970-01-01T13%3A53%3A20Z", resultForInternetDateTime)
 
         let decodedInternetDateTime = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
@@ -230,7 +230,7 @@ final class URLEncodedFormTests: XCTestCase {
                 try container.encode(factory.currentValue.string(from: date))
             })
         ).encode(toEncode)
-        XCTAssertEqual("dates[]=Date:%201970-01-01%20Time:%2000:00:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2002:46:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2005:33:20%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2008:20:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2011:06:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2013:53:20%20Timezone:%20Z", resultCustom)
+        XCTAssertEqual("dates[]=Date%3A%201970-01-01%20Time%3A%2000%3A00%3A00%20Timezone%3A%20Z&dates[]=Date%3A%201970-01-01%20Time%3A%2002%3A46%3A40%20Timezone%3A%20Z&dates[]=Date%3A%201970-01-01%20Time%3A%2005%3A33%3A20%20Timezone%3A%20Z&dates[]=Date%3A%201970-01-01%20Time%3A%2008%3A20%3A00%20Timezone%3A%20Z&dates[]=Date%3A%201970-01-01%20Time%3A%2011%3A06%3A40%20Timezone%3A%20Z&dates[]=Date%3A%201970-01-01%20Time%3A%2013%3A53%3A20%20Timezone%3A%20Z", resultCustom)
 
         let decodedCustom = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .custom { decoder -> Date in
@@ -270,7 +270,7 @@ final class URLEncodedFormTests: XCTestCase {
         let resultForInternetDateTime = try URLEncodedFormEncoder(
             configuration: .init(dateEncodingStrategy: .iso8601)
         ).encode(toEncode)
-        XCTAssertEqual("date=1970-01-01T00:00:00Z", resultForInternetDateTime)
+        XCTAssertEqual("date=1970-01-01T00%3A00%3A00Z", resultForInternetDateTime)
 
         let decodedInternetDateTime = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
@@ -307,7 +307,7 @@ final class URLEncodedFormTests: XCTestCase {
                 try container.encode(factory.currentValue.string(from: date))
             })
         ).encode(toEncode)
-        XCTAssertEqual("date=Date:%201970-01-01%20Time:%2000:00:00%20Timezone:%20Z", resultCustom)
+        XCTAssertEqual("date=Date%3A%201970-01-01%20Time%3A%2000%3A00%3A00%20Timezone%3A%20Z", resultCustom)
 
         let decodedCustom = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .custom { decoder -> Date in
@@ -324,7 +324,7 @@ final class URLEncodedFormTests: XCTestCase {
 
     func testOptionalDateEncodingAndDecoding_GH2518() throws {
         let optionalDate: Date? = Date(timeIntervalSince1970: 0)
-        let dateString = "1970-01-01T00:00:00Z"
+        let dateString = "1970-01-01T00%3A00%3A00Z"
 
         let resultForDecodedOptionalDate = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
@@ -664,7 +664,7 @@ final class URLEncodedFormTests: XCTestCase {
         let data = try URLEncodedFormSerializer().serialize([
             "test": "&;!$'(),/:=?@~",
         ])
-        XCTAssertEqual(data, "test=%26%3B!%24'(),/:%3D%3F@~")
+        XCTAssertEqual(data, "test=%26%3B%21%24%27%28%29%2C%2F%3A%3D%3F%40%7E")
     }
 
     func testHeavilyNestedArray() throws {

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -1,4 +1,3 @@
-import NIOCore
 import NIOPosix
 @testable import Vapor
 import XCTest

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -1,15 +1,16 @@
+import NIOCore
+import NIOPosix
 @testable import Vapor
 import XCTest
-import NIOPosix
 
 final class URLEncodedFormTests: XCTestCase {
     // MARK: Codable
-    
+
     func testDecode() throws {
         let data = """
         name=Tanner&age=23&pets[]=Zizek&pets[]=Foo&dict[a]=1&dict[b]=2&foos[]=baz&nums[]=3.14
         """
-        
+
         let user = try URLEncodedFormDecoder().decode(User.self, from: data)
         XCTAssertEqual(user.name, "Tanner")
         XCTAssertEqual(user.age, 23)
@@ -21,7 +22,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(user.foos[0], .baz)
         XCTAssertEqual(user.nums[0], 3.14)
     }
-    
+
     func testDecodeCommaSeparatedArray() throws {
         let data = """
         name=Tanner&age=23&pets=Zizek,Foo%2C&dict[a]=1&dict[b]=2&foos=baz&nums=3.14
@@ -37,12 +38,12 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(user.foos[0], .baz)
         XCTAssertEqual(user.nums[0], 3.14)
     }
-    
+
     func testDecodeWithoutArrayBrackets() throws {
         let data = """
         name=Tanner&age=23&pets=Zizek&pets=Foo&dict[a]=1&dict[b]=2&foos=baz&nums=3.14
         """
-        
+
         let user = try URLEncodedFormDecoder().decode(User.self, from: data)
         XCTAssertEqual(user.name, "Tanner")
         XCTAssertEqual(user.age, 23)
@@ -61,7 +62,7 @@ final class URLEncodedFormTests: XCTestCase {
         """
         XCTAssertThrowsError(try URLEncodedFormDecoder().decode(User.self, from: data))
     }
-    
+
     func testDecodeStringWithCommas() throws {
         let data = """
         name=Vapor, Tanner&age=23&pets[]=Zizek&pets[]=Foo&dict[a]=1&dict[b]=2&foos[]=baz&nums[]=3.14
@@ -115,7 +116,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(test.array[2], "b")
         XCTAssertEqual(test.array[3], "")
     }
-    
+
     func testDecodeUnindexedArray() throws {
         struct Test: Decodable {
             let array: [String]
@@ -157,65 +158,63 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("nums[]=3.14"))
         XCTAssert(result.contains("isCool=true"))
     }
-    
+
     func testDateArrayCoding() throws {
         let toEncode = DateArrayCoding(
             dates: [
                 Date(timeIntervalSince1970: 0),
-                Date(timeIntervalSince1970: 10_000),
-                Date(timeIntervalSince1970: 20_000),
-                Date(timeIntervalSince1970: 30_000),
-                Date(timeIntervalSince1970: 40_000),
-                Date(timeIntervalSince1970: 50_000),
+                Date(timeIntervalSince1970: 10000),
+                Date(timeIntervalSince1970: 20000),
+                Date(timeIntervalSince1970: 30000),
+                Date(timeIntervalSince1970: 40000),
+                Date(timeIntervalSince1970: 50000),
             ]
         )
-        
+
         let decodedDefaultFromUnixTimestamp = try URLEncodedFormDecoder().decode(DateArrayCoding.self, from: "dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0")
         XCTAssertEqual(decodedDefaultFromUnixTimestamp, toEncode)
-        
+
         let resultForDefault = try URLEncodedFormEncoder().encode(toEncode)
         XCTAssertEqual("dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0", resultForDefault)
-        
+
         let decodedDefault = try URLEncodedFormDecoder().decode(DateArrayCoding.self, from: resultForDefault)
         XCTAssertEqual(decodedDefault, toEncode)
-        
+
         let resultForTimeIntervalSince1970 = try URLEncodedFormEncoder(
             configuration: .init(dateEncodingStrategy: .secondsSince1970)
         ).encode(toEncode)
         XCTAssertEqual("dates[]=0.0&dates[]=10000.0&dates[]=20000.0&dates[]=30000.0&dates[]=40000.0&dates[]=50000.0", resultForDefault)
-        
+
         let decodedTimeIntervalSince1970 = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .secondsSince1970)
         ).decode(DateArrayCoding.self, from: resultForTimeIntervalSince1970)
         XCTAssertEqual(decodedTimeIntervalSince1970, toEncode)
-        
+
         let resultForInternetDateTime = try URLEncodedFormEncoder(
             configuration: .init(dateEncodingStrategy: .iso8601)
         ).encode(toEncode)
         XCTAssertEqual("dates[]=1970-01-01T00:00:00Z&dates[]=1970-01-01T02:46:40Z&dates[]=1970-01-01T05:33:20Z&dates[]=1970-01-01T08:20:00Z&dates[]=1970-01-01T11:06:40Z&dates[]=1970-01-01T13:53:20Z", resultForInternetDateTime)
-        
+
         let decodedInternetDateTime = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
         ).decode(DateArrayCoding.self, from: resultForInternetDateTime)
         XCTAssertEqual(decodedInternetDateTime, toEncode)
-        
+
         XCTAssertThrowsError(try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
         ).decode(DateArrayCoding.self, from: "dates=bad-date"))
-        
+
         class DateFormatterFactory {
             private var threadSpecificValue = ThreadSpecificVariable<DateFormatter>()
             var currentValue: DateFormatter {
-                get {
-                    guard let dateFormatter = threadSpecificValue.currentValue else {
-                        let threadSpecificDateFormatter = self.newDateFormatter
-                        threadSpecificValue.currentValue = threadSpecificDateFormatter
-                        return threadSpecificDateFormatter
-                    }
-                    return dateFormatter
+                guard let dateFormatter = threadSpecificValue.currentValue else {
+                    let threadSpecificDateFormatter = self.newDateFormatter
+                    threadSpecificValue.currentValue = threadSpecificDateFormatter
+                    return threadSpecificDateFormatter
                 }
+                return dateFormatter
             }
-            
+
             private var newDateFormatter: DateFormatter {
                 let dateFormatter = DateFormatter()
                 dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -226,22 +225,22 @@ final class URLEncodedFormTests: XCTestCase {
         }
         let factory = DateFormatterFactory()
         let resultCustom = try URLEncodedFormEncoder(
-            configuration: .init(dateEncodingStrategy: .custom({ (date, encoder) in
+            configuration: .init(dateEncodingStrategy: .custom { date, encoder in
                 var container = encoder.singleValueContainer()
                 try container.encode(factory.currentValue.string(from: date))
-            }))
+            })
         ).encode(toEncode)
         XCTAssertEqual("dates[]=Date:%201970-01-01%20Time:%2000:00:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2002:46:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2005:33:20%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2008:20:00%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2011:06:40%20Timezone:%20Z&dates[]=Date:%201970-01-01%20Time:%2013:53:20%20Timezone:%20Z", resultCustom)
-        
+
         let decodedCustom = try URLEncodedFormDecoder(
-            configuration: .init(dateDecodingStrategy: .custom({ (decoder) -> Date in
+            configuration: .init(dateDecodingStrategy: .custom { decoder -> Date in
                 let container = try decoder.singleValueContainer()
                 let string = try container.decode(String.self)
                 guard let date = factory.currentValue.date(from: string) else {
                     throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode date from string '\(string)'")
                 }
                 return date
-            }))
+            })
         ).decode(DateArrayCoding.self, from: resultCustom)
         XCTAssertEqual(decodedCustom, toEncode)
     }
@@ -254,7 +253,7 @@ final class URLEncodedFormTests: XCTestCase {
 
         let resultForDefault = try URLEncodedFormEncoder().encode(toEncode)
         XCTAssertEqual("date=0.0", resultForDefault)
-        
+
         let decodedDefault = try URLEncodedFormDecoder().decode(DateCoding.self, from: resultForDefault)
         XCTAssertEqual(decodedDefault, toEncode)
 
@@ -262,12 +261,12 @@ final class URLEncodedFormTests: XCTestCase {
             configuration: .init(dateEncodingStrategy: .secondsSince1970)
         ).encode(toEncode)
         XCTAssertEqual("date=0.0", resultForTimeIntervalSince1970)
-        
+
         let decodedTimeIntervalSince1970 = try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .secondsSince1970)
         ).decode(DateCoding.self, from: resultForTimeIntervalSince1970)
         XCTAssertEqual(decodedTimeIntervalSince1970, toEncode)
-        
+
         let resultForInternetDateTime = try URLEncodedFormEncoder(
             configuration: .init(dateEncodingStrategy: .iso8601)
         ).encode(toEncode)
@@ -281,20 +280,18 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertThrowsError(try URLEncodedFormDecoder(
             configuration: .init(dateDecodingStrategy: .iso8601)
         ).decode(DateCoding.self, from: "date=bad-date"))
-                
+
         class DateFormatterFactory {
             private var threadSpecificValue = ThreadSpecificVariable<DateFormatter>()
             var currentValue: DateFormatter {
-                get {
-                    guard let dateFormatter = threadSpecificValue.currentValue else {
-                        let threadSpecificDateFormatter = self.newDateFormatter
-                        threadSpecificValue.currentValue = threadSpecificDateFormatter
-                        return threadSpecificDateFormatter
-                    }
-                    return dateFormatter
+                guard let dateFormatter = threadSpecificValue.currentValue else {
+                    let threadSpecificDateFormatter = self.newDateFormatter
+                    threadSpecificValue.currentValue = threadSpecificDateFormatter
+                    return threadSpecificDateFormatter
                 }
+                return dateFormatter
             }
-            
+
             private var newDateFormatter: DateFormatter {
                 let dateFormatter = DateFormatter()
                 dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -305,22 +302,22 @@ final class URLEncodedFormTests: XCTestCase {
         }
         let factory = DateFormatterFactory()
         let resultCustom = try URLEncodedFormEncoder(
-            configuration: .init(dateEncodingStrategy: .custom({ (date, encoder) in
+            configuration: .init(dateEncodingStrategy: .custom { date, encoder in
                 var container = encoder.singleValueContainer()
                 try container.encode(factory.currentValue.string(from: date))
-            }))
+            })
         ).encode(toEncode)
         XCTAssertEqual("date=Date:%201970-01-01%20Time:%2000:00:00%20Timezone:%20Z", resultCustom)
-        
+
         let decodedCustom = try URLEncodedFormDecoder(
-            configuration: .init(dateDecodingStrategy: .custom({ (decoder) -> Date in
+            configuration: .init(dateDecodingStrategy: .custom { decoder -> Date in
                 let container = try decoder.singleValueContainer()
                 let string = try container.decode(String.self)
                 guard let date = factory.currentValue.date(from: string) else {
                     throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode date from string '\(string)'")
                 }
                 return date
-            }))
+            })
         ).decode(DateCoding.self, from: resultCustom)
         XCTAssertEqual(decodedCustom, toEncode)
     }
@@ -370,7 +367,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("nums=3.14"))
         XCTAssert(result.contains("isCool=true"))
     }
-    
+
     func testMultiObjectArrayEncode() throws {
         let tanner = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [.baz], nums: [3.14], isCool: true)
         let ravneet = User(name: "Ravneet", age: 33, pets: ["Piku"], dict: ["a": -3, "b": 99], foos: [.baz, .bar], nums: [3.14, 144], isCool: true)
@@ -385,7 +382,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[0][foos][]=baz"))
         XCTAssert(result.contains("users[0][nums][]=3.14"))
         XCTAssert(result.contains("users[0][isCool]=true"))
-        
+
         XCTAssert(result.contains("users[1][pets][]=Piku"))
         XCTAssert(result.contains("users[1][age]=33"))
         XCTAssert(result.contains("users[1][name]=Ravneet"))
@@ -396,7 +393,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[1][nums][]=3.14"))
         XCTAssert(result.contains("users[1][nums][]=144"))
         XCTAssert(result.contains("users[1][isCool]=true"))
-        
+
         let decodedUsers = try URLEncodedFormDecoder().decode(Users.self, from: result)
         XCTAssertEqual(decodedUsers, usersToEncode)
     }
@@ -417,7 +414,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[0][foos]=baz"))
         XCTAssert(result.contains("users[0][nums]=3.14"))
         XCTAssert(result.contains("users[0][isCool]=true"))
-        
+
         XCTAssert(result.contains("users[1][pets]=Piku"))
         XCTAssert(result.contains("users[1][age]=33"))
         XCTAssert(result.contains("users[1][name]=Ravneet"))
@@ -428,11 +425,11 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[1][nums]=3.14"))
         XCTAssert(result.contains("users[1][nums]=144"))
         XCTAssert(result.contains("users[1][isCool]=true"))
-        
+
         let decodedUsers = try URLEncodedFormDecoder().decode(Users.self, from: result)
         XCTAssertEqual(decodedUsers, usersToEncode)
     }
-    
+
     func testInheritanceCoding() throws {
         let toEncode = ChildClass()
         toEncode.baseField = "Base Value"
@@ -450,7 +447,7 @@ final class URLEncodedFormTests: XCTestCase {
         let decoded = try URLEncodedFormDecoder().decode([[User]].self, from: result)
         XCTAssertEqual(decoded, toEncode)
     }
-    
+
     func testMultiObjectArrayEncodeWithArraySeparator() throws {
         let tanner = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2], foos: [.baz], nums: [3.14], isCool: true)
         let ravneet = User(name: "Ravneet", age: 33, pets: ["Piku"], dict: ["a": -3, "b": 99], foos: [.baz, .bar], nums: [3.14, 144], isCool: true)
@@ -466,7 +463,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[0][foos]=baz"))
         XCTAssert(result.contains("users[0][nums]=3.14"))
         XCTAssert(result.contains("users[0][isCool]=true"))
-        
+
         XCTAssert(result.contains("users[1][pets]=Piku"))
         XCTAssert(result.contains("users[1][age]=33"))
         XCTAssert(result.contains("users[1][name]=Ravneet"))
@@ -475,7 +472,7 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssert(result.contains("users[1][foos]=baz,bar"))
         XCTAssert(result.contains("users[1][nums]=3.14,144"))
         XCTAssert(result.contains("users[1][isCool]=true"))
-        
+
         let decodedUsers = try URLEncodedFormDecoder().decode(Users.self, from: result)
         XCTAssertEqual(decodedUsers, usersToEncode)
     }
@@ -486,16 +483,16 @@ final class URLEncodedFormTests: XCTestCase {
         let b = try! URLEncodedFormDecoder().decode(User.self, from: body)
         XCTAssertEqual(a, b)
     }
-    
+
     func testDecodeIntArray() throws {
         let data = """
         array[]=1&array[]=2&array[]=3
         """
-        
+
         let content = try URLEncodedFormDecoder().decode([String: [Int]].self, from: data)
         XCTAssertEqual(content["array"], [1, 2, 3])
     }
-    
+
     func testRawEnum() throws {
         enum PetType: String, Codable {
             case cat, dog
@@ -519,7 +516,7 @@ final class URLEncodedFormTests: XCTestCase {
         let foo = try URLEncodedFormDecoder().decode(Foo.self, from: "flag")
         XCTAssertEqual(foo.flag, true)
     }
-    
+
     func testFlagIsOnDecodingAsBool() throws {
         struct Foo: Codable {
             var flag: Bool
@@ -536,63 +533,63 @@ final class URLEncodedFormTests: XCTestCase {
         let foo = try URLEncodedFormDecoder().decode(Foo.self, from: "flag=1")
         XCTAssertEqual(foo.flag, true)
     }
-    
+
     // MARK: Parser
-    
+
     func testBasic() throws {
         let data = "hello=world&foo=bar"
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["hello": "world", "foo": "bar"])
     }
-    
+
     func testBasicWithAmpersand() throws {
         let data = "hello=world&foo=bar%26bar"
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["hello": "world", "foo": "bar&bar"])
     }
-    
+
     func testDictionary() throws {
         let data = "greeting[en]=hello&greeting[es]=hola"
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["greeting": ["es": "hola", "en": "hello"]])
     }
-    
+
     func testArray() throws {
         let data = "greetings[]=hello&greetings[]=hola"
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["greetings": ["": ["hello", "hola"]]])
     }
-  
+
     func testArrayWithoutBrackets() throws {
         let data = "greetings=hello&greetings=hola"
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["greetings": ["hello", "hola"]])
     }
-  
+
     func testSubArray() throws {
         let data = "greetings[sub][]=hello&greetings[sub][]=hola"
         let form = try URLEncodedFormParser().parse(data)
-        XCTAssertEqual(form, ["greetings":["sub":["":["hello", "hola"]]]])
+        XCTAssertEqual(form, ["greetings": ["sub": ["": ["hello", "hola"]]]])
     }
 
     func testSubArray2() throws {
         let data = "greetings[sub]=hello&greetings[sub][]=hola"
         let form = try URLEncodedFormParser().parse(data)
         let expected: URLEncodedFormData = ["greetings": ["sub":
-            URLEncodedFormData(values: ["hello"], children: [
-                "": "hola"
-            ])
+                URLEncodedFormData(values: ["hello"], children: [
+                    "": "hola",
+                ]),
         ]]
         XCTAssertEqual(form, expected)
     }
-    
+
     func testSubArray3() throws {
         let data = "greetings[sub][]=hello&greetings[sub]=hola"
         let form = try URLEncodedFormParser().parse(data)
         let expected: URLEncodedFormData = ["greetings": ["sub":
-            URLEncodedFormData(values: ["hola"], children: [
-                "": "hello"
-            ])
+                URLEncodedFormData(values: ["hola"], children: [
+                    "": "hello",
+                ]),
         ]]
         XCTAssertEqual(form, expected)
     }
@@ -601,9 +598,9 @@ final class URLEncodedFormTests: XCTestCase {
         let data = "greetings[sub][]=hello&greetings[sub]=hola&greetings[sub]=bonjour"
         let form = try URLEncodedFormParser().parse(data)
         let expected: URLEncodedFormData = ["greetings": ["sub":
-            URLEncodedFormData(values: ["hola", "bonjour"], children: [
-            "": "hello"
-            ])
+                URLEncodedFormData(values: ["hola", "bonjour"], children: [
+                    "": "hello",
+                ]),
         ]]
         XCTAssertEqual(form, expected)
     }
@@ -617,24 +614,24 @@ final class URLEncodedFormTests: XCTestCase {
     func testSubArrayWithoutBrackets() throws {
         let data = "greetings[sub]=hello&greetings[sub]=hola"
         let form = try URLEncodedFormParser().parse(data)
-        XCTAssertEqual(form, ["greetings":["sub":["hello", "hola"]]])
+        XCTAssertEqual(form, ["greetings": ["sub": ["hello", "hola"]]])
     }
 
     func testFlags() throws {
         let data = "hello=&foo"
         let form = try URLEncodedFormParser().parse(data)
-        let expected = URLEncodedFormData(values: ["foo"], children:[
-            "hello": URLEncodedFormData("")
+        let expected = URLEncodedFormData(values: ["foo"], children: [
+            "hello": URLEncodedFormData(""),
         ])
         XCTAssertEqual(form, expected)
     }
-    
+
     func testPercentDecoding() throws {
         let data = "aaa%5B%5D=%2Bbbb%20+ccc&d[]=1&d[]=2"
         let form = try URLEncodedFormParser().parse(data)
-        XCTAssertEqual(form, ["aaa": ["": "+bbb  ccc"], "d": ["": ["1","2"]]])
+        XCTAssertEqual(form, ["aaa": ["": "+bbb  ccc"], "d": ["": ["1", "2"]]])
     }
-    
+
     func testNestedParsing() throws {
         // a[][b]=c&a[][b]=c
         // [a:[[b:c],[b:c]]
@@ -642,9 +639,9 @@ final class URLEncodedFormTests: XCTestCase {
         let form = try URLEncodedFormParser().parse(data)
         XCTAssertEqual(form, ["a": ["b": ["c": ["d": ["hello": "world"]]]]])
     }
-    
+
     // MARK: Serializer
-    
+
     func testPercentEncoding() throws {
         let form: URLEncodedFormData = ["aaa]": "+bbb  ccc"]
         let data = try URLEncodedFormSerializer().serialize(form)
@@ -662,14 +659,14 @@ final class URLEncodedFormTests: XCTestCase {
         let data = try URLEncodedFormSerializer().serialize(form)
         XCTAssertEqual(data, "a[b][c][d][hello]=world")
     }
-    
+
     func testPercentEncodingSpecial() throws {
         let data = try URLEncodedFormSerializer().serialize([
-            "test": "&;!$'(),/:=?@~"
+            "test": "&;!$'(),/:=?@~",
         ])
-        XCTAssertEqual(data, "test=%26%3B!$'(),/:%3D%3F@~")
+        XCTAssertEqual(data, "test=%26%3B!%24'(),/:%3D%3F@~")
     }
-    
+
     func testHeavilyNestedArray() throws {
         var body = "x"
         body += String(repeating: "[]", count: 80000)


### PR DESCRIPTION
Solves #3173 
References https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set to set the encoding rules 
> The [application/x-www-form-urlencoded percent-encode set](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set) contains all code points, except the [ASCII alphanumeric](https://infra.spec.whatwg.org/#ascii-alphanumeric), U+002A (*), U+002D (-), U+002E (.), and U+005F (_).