### PR TITLE
asyncBoot will no longer try booting server again if it is already booted

### DIFF
--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -247,16 +247,14 @@ public final class Application: Sendable {
     
     /// Called when the applications starts up, will trigger the lifecycle handlers. The asynchronous version of ``boot()``
     public func asyncBoot() async throws {
-        let notBooted = self.isBooted.withLockedValue { booted in
-            guard booted else {
-                booted = true
-                return true
-            }
-
-            return false
+        /// Skip the boot process if already booted
+        guard !self.isBooted.withLockedValue({
+            var result = true
+            swap(&$0, &result)
+            return result
+        }) else {
+            return
         }
-
-        guard notBooted else { return }
 
         for handler in self.lifecycle.handlers {
             try await handler.willBootAsync(self)

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -247,12 +247,17 @@ public final class Application: Sendable {
     
     /// Called when the applications starts up, will trigger the lifecycle handlers. The asynchronous version of ``boot()``
     public func asyncBoot() async throws {
-        self.isBooted.withLockedValue { booted in
-            guard !booted else {
-                return
+        let notBooted = self.isBooted.withLockedValue { booted in
+            guard booted else {
+                booted = true
+                return true
             }
-            booted = true
+
+            return false
         }
+
+        guard notBooted else { return }
+
         for handler in self.lifecycle.handlers {
             try await handler.willBootAsync(self)
         }


### PR DESCRIPTION
The synchronous `boot` function skips running the lifecycle handlers if the server is already booted. However, the async version ignored this check. I have added a small fix to add this check again.