### PR TITLE
Add Async Storage shutdown

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -268,6 +268,7 @@ public func routes(_ app: Application) throws {
         return [cred1]
     }
     
+    @Sendable
     func opaqueRouteTester(_ req: Request) async throws -> some AsyncResponseEncodable {
         "Hello World"
     }

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -120,6 +120,7 @@ public final class Application: Sendable {
         _ eventLoopGroupProvider: EventLoopGroupProvider = .singleton
     ) {
         self.init(environment, eventLoopGroupProvider, async: false)
+        self.asyncCommands.use(self.servers.command, as: "serve", isDefault: true)
         DotEnvFile.load(for: environment, on: .shared(self.eventLoopGroup), fileio: self.fileio, logger: self.logger)
     }
     
@@ -155,12 +156,12 @@ public final class Application: Sendable {
         self.servers.use(.http)
         self.clients.initialize()
         self.clients.use(.http)
-        self.asyncCommands.use(self.servers.command, as: "serve", isDefault: true)
         self.asyncCommands.use(RoutesCommand(), as: "routes")
     }
     
     public static func make(_ environment: Environment = .development, _ eventLoopGroupProvider: EventLoopGroupProvider = .singleton) async throws -> Application {
         let app = Application(environment, eventLoopGroupProvider, async: true)
+        await app.asyncCommands.use(app.servers.asyncCommand, as: "serve", isDefault: true)
         await DotEnvFile.load(for: app.environment, fileio: app.fileio, logger: app.logger)
         return app
     }
@@ -268,8 +269,11 @@ public final class Application: Sendable {
 
         self.logger.trace("Shutting down providers")
         self.lifecycle.handlers.reversed().forEach { $0.shutdown(self) }
-        
-        triggerShutdown()
+        self.lifecycle.handlers = []
+
+        self.logger.trace("Clearing Application storage")
+        self.storage.shutdown()
+        self.storage.clear()
 
         switch self.eventLoopGroupProvider {
         case .shared:
@@ -295,8 +299,11 @@ public final class Application: Sendable {
         for handler in self.lifecycle.handlers.reversed()  {
             await handler.shutdownAsync(self)
         }
-        
-        triggerShutdown()
+        self.lifecycle.handlers = []
+
+        self.logger.trace("Clearing Application storage")
+        await self.storage.asyncShutdown()
+        self.storage.clear()
 
         switch self.eventLoopGroupProvider {
         case .shared:
@@ -312,14 +319,6 @@ public final class Application: Sendable {
 
         self._didShutdown.withLockedValue { $0 = true }
         self.logger.trace("Application shutdown complete")
-    }
-    
-    private func triggerShutdown() {
-        self.lifecycle.handlers = []
-
-        self.logger.trace("Clearing Application storage")
-        self.storage.shutdown()
-        self.storage.clear()
     }
 
     deinit {

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -2,7 +2,7 @@ import NIOCore
 import NIOHTTP1
 import Foundation
 
-public struct ClientResponse {
+public struct ClientResponse: Sendable {
     public var status: HTTPStatus
     public var headers: HTTPHeaders
     public var body: ByteBuffer?

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -103,12 +103,25 @@ public final class ServeCommand: AsyncCommand, Sendable {
         self.box.withLockedValue { $0 = box }
     }
 
+    @available(*, noasync, message: "Use the async asyncShutdown() method instead.")
     func shutdown() {
         var box = self.box.withLockedValue { $0 }
         box.didShutdown = true
         box.running?.stop()
         if let server = box.server {
             server.shutdown()
+        }
+        box.signalSources.forEach { $0.cancel() } // clear refs
+        box.signalSources = []
+        self.box.withLockedValue { $0 = box }
+    }
+    
+    func asyncShutdown() async {
+        var box = self.box.withLockedValue { $0 }
+        box.didShutdown = true
+        box.running?.stop()
+        if let server = box.server {
+            await server.shutdown()
         }
         box.signalSources.forEach { $0.cancel() } // clear refs
         box.signalSources = []

--- a/Sources/Vapor/Commands/ServeCommand.swift
+++ b/Sources/Vapor/Commands/ServeCommand.swift
@@ -120,9 +120,7 @@ public final class ServeCommand: AsyncCommand, Sendable {
         var box = self.box.withLockedValue { $0 }
         box.didShutdown = true
         box.running?.stop()
-        if let server = box.server {
-            await server.shutdown()
-        }
+        await box.server?.shutdown()
         box.signalSources.forEach { $0.cancel() } // clear refs
         box.signalSources = []
         self.box.withLockedValue { $0 = box }

--- a/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
+++ b/Sources/Vapor/HTTP/Client/Application+HTTP+Client.swift
@@ -1,6 +1,7 @@
 import AsyncHTTPClient
 
 extension Application.Clients.Provider {
+    @available(*, noasync, message: "Don't use from an async context")
     public static var http: Self {
         .init {
             $0.clients.use {

--- a/Sources/Vapor/Server/Application+Servers.swift
+++ b/Sources/Vapor/Server/Application+Servers.swift
@@ -51,7 +51,7 @@ extension Application {
             self.storage.makeServer.withLockedValue { $0 = .init(factory: makeServer) }
         }
 
-        @available(*, deprecated, renamed: "asyncCommand", message: "Use asyncCommand instead")
+        @available(*, noasync, renamed: "asyncCommand", message: "Use the async property instead.")
         public var command: ServeCommand {
             if let existing = self.application.storage.get(CommandKey.self) {
                 return existing

--- a/Sources/Vapor/Server/Application+Servers.swift
+++ b/Sources/Vapor/Server/Application+Servers.swift
@@ -51,6 +51,7 @@ extension Application {
             self.storage.makeServer.withLockedValue { $0 = .init(factory: makeServer) }
         }
 
+        @available(*, deprecated, renamed: "asyncCommand", message: "Use asyncCommand instead")
         public var command: ServeCommand {
             if let existing = self.application.storage.get(CommandKey.self) {
                 return existing
@@ -60,6 +61,20 @@ extension Application {
                     $0.shutdown()
                 }
                 return new
+            }
+        }
+        
+        public var asyncCommand: ServeCommand {
+            get async {
+                if let existing = self.application.storage.get(CommandKey.self) {
+                    return existing
+                } else {
+                    let new = ServeCommand()
+                    await self.application.storage.setWithAsyncShutdown(CommandKey.self, to: new) {
+                        await $0.asyncShutdown()
+                    }
+                    return new
+                }
             }
         }
 

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -21,8 +21,8 @@ public struct Storage: Sendable {
         }
         func asyncShutdown(logger: Logger) async {
             do {
-                try self.onShutdown?(self.value)
                 try await self.onAsyncShutdown?(self.value)
+                try self.onShutdown?(self.value)
             } catch {
                 logger.warning("Could not shutdown \(T.self): \(error)")
             }

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -21,6 +21,7 @@ public struct Storage: Sendable {
         }
         func asyncShutdown(logger: Logger) async {
             do {
+                try self.onShutdown?(self.value)
                 try await self.onAsyncShutdown?(self.value)
             } catch {
                 logger.warning("Could not shutdown \(T.self): \(error)")
@@ -87,6 +88,7 @@ public struct Storage: Sendable {
     /// Set or remove a value for a given key, optionally providing a shutdown closure for the value.
     ///
     /// If a key that has a shutdown closure is removed by this method, the closure **is** invoked.
+    @available(*, noasync, message: "Use the async setWithAsyncShutdown() method instead.", renamed: "setWithAsyncShutdown")
     public mutating func set<Key>(
         _ key: Key.Type,
         to value: Key.Value?,

--- a/Sources/Vapor/Utilities/Storage.swift
+++ b/Sources/Vapor/Utilities/Storage.swift
@@ -21,8 +21,11 @@ public struct Storage: Sendable {
         }
         func asyncShutdown(logger: Logger) async {
             do {
-                try await self.onAsyncShutdown?(self.value)
-                try self.onShutdown?(self.value)
+                if let onAsyncShutdown {
+                    try await onAsyncShutdown(self.value)
+                } else {
+                    try self.onShutdown?(self.value)
+                }
             } catch {
                 logger.warning("Could not shutdown \(T.self): \(error)")
             }

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -59,7 +59,7 @@ final class AsyncRequestTests: XCTestCase {
         request.method = .POST
         request.body = .stream(testValue.utf8.async, length: .unknown)
         
-        let response: HTTPClientResponse = try await app.http.client.asyncShared.execute(request, timeout: .seconds(5))
+        let response: HTTPClientResponse = try await app.http.client.shared.execute(request, timeout: .seconds(5))
         XCTAssertEqual(response.status, .ok)
         let body = try await response.body.collect(upTo: 1024 * 1024)
         XCTAssertEqual(body.string, testValue)
@@ -94,7 +94,7 @@ final class AsyncRequestTests: XCTestCase {
         var request = HTTPClientRequest(url: "http://\(ip):\(port)/hello")
         request.method = .POST
         request.body = .stream(oneMB.async, length: .known(oneMB.count))
-        if let response = try? await app.http.client.asyncShared.execute(request, timeout: .seconds(5)) {
+        if let response = try? await app.http.client.shared.execute(request, timeout: .seconds(5)) {
             XCTAssertGreaterThan(bytesTheServerRead.load(ordering: .relaxed), 0)
             XCTAssertEqual(response.status, .internalServerError)
         }

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -59,7 +59,7 @@ final class AsyncRequestTests: XCTestCase {
         request.method = .POST
         request.body = .stream(testValue.utf8.async, length: .unknown)
         
-        let response: HTTPClientResponse = try await app.http.client.shared.execute(request, timeout: .seconds(5))
+        let response: HTTPClientResponse = try await app.http.client.asyncShared.execute(request, timeout: .seconds(5))
         XCTAssertEqual(response.status, .ok)
         let body = try await response.body.collect(upTo: 1024 * 1024)
         XCTAssertEqual(body.string, testValue)
@@ -94,7 +94,7 @@ final class AsyncRequestTests: XCTestCase {
         var request = HTTPClientRequest(url: "http://\(ip):\(port)/hello")
         request.method = .POST
         request.body = .stream(oneMB.async, length: .known(oneMB.count))
-        if let response = try? await app.http.client.shared.execute(request, timeout: .seconds(5)) {
+        if let response = try? await app.http.client.asyncShared.execute(request, timeout: .seconds(5)) {
             XCTAssertGreaterThan(bytesTheServerRead.load(ordering: .relaxed), 0)
             XCTAssertEqual(response.status, .internalServerError)
         }


### PR DESCRIPTION
Currently running

```swift
Task {
    try? await Task.sleep(for: .seconds(5))
    app.running?.stop()
}
```

When you try and install NIO as the global executor will crash because the storage API didn't have any async entry points so stopping would trigger a synchronous shutdown, with a `wait()`. This fixes that