### PR TITLE
Easy way to customize `Error` rendering

### DIFF
--- a/Sources/Vapor/Error/RenderableError.swift
+++ b/Sources/Vapor/Error/RenderableError.swift
@@ -1,3 +1,3 @@
 protocol RenderableError: Error {
-    func render(_ req: Request) async -> Response
+    func render(_ req: Request) -> Response
 }

--- a/Sources/Vapor/Error/RenderableError.swift
+++ b/Sources/Vapor/Error/RenderableError.swift
@@ -1,0 +1,3 @@
+protocol RenderableError: Error {
+    func render(_ req: Request) async -> Response
+}

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -42,6 +42,10 @@ public final class ErrorMiddleware: Middleware {
             
             // Report the error
             req.logger.report(error: error, file: source.file, function: source.function, line: source.line)
+
+            if let error = error as? RenderableError {
+                return error.render(req)
+            }
             
             // attempt to serialize the error to json
             let body: Response.Body


### PR DESCRIPTION
Customizing the response an exception returns is currently pretty involved (you need to nuke all middleware, then re-implement `ErrorMiddleware` from scratch.

This PR adds a `RenderableError` protocol, allowing developers to easily customize the response their errors produce.