### PR TITLE
Fixed static variables concurrency-safe warning

### DIFF
--- a/Sources/Vapor/Content/ContentConfiguration.swift
+++ b/Sources/Vapor/Content/ContentConfiguration.swift
@@ -16,7 +16,8 @@ import NIOConcurrencyHelpers
 ///
 /// Most often, these configured coders are used to encode and decode types conforming to ``Content``.
 /// See the ``Content`` protocol for more information.
-public struct ContentConfiguration {
+
+public struct ContentConfiguration: @unchecked Sendable {
     public static var global: ContentConfiguration {
         get {
             _global.withLockedValue { $0 }

--- a/Sources/Vapor/Utilities/LockedWritableKeyPath.swift
+++ b/Sources/Vapor/Utilities/LockedWritableKeyPath.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class LockedWritableKeyPath<Root, Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var path: WritableKeyPath<Root, Value>
+
+    init(path: WritableKeyPath<Root, Value>) {
+        self.path = path
+    }
+
+    var safeValue: WritableKeyPath<Root, Value>? {
+        get {
+            var lockedValue: WritableKeyPath<Root, Value>?
+            lock.lock()
+            lockedValue = path
+            lock.unlock()
+
+            return lockedValue
+        }
+    }
+}

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -14,8 +14,12 @@ import NIOPosix
 import NIOCore
 import NIOConcurrencyHelpers
 
+/// `ThreadSpecificVariable` is thread-safe so it can be used with multiple threads at the same time but the value
+/// returned by `currentValue` is defined per thread.
+extension ThreadSpecificVariable<RFC1123>: Sendable { }
+
 /// An internal helper that formats cookie dates as RFC1123
-private final class RFC1123 {
+private final class RFC1123: Sendable {
     /// Thread-specific RFC1123
     private static let thread: ThreadSpecificVariable<RFC1123> = .init()
     


### PR DESCRIPTION
Static fields with a compiler error about a potential concurrency-safe warning have been fixed