### PR TITLE
Exclude Query and Fragment from URI semicolon fix on Linux

### DIFF
--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -197,9 +197,12 @@ public struct URI: CustomStringConvertible, ExpressibleByStringInterpolation, Ha
     public var string: String {
         if urlPathAllowedIsBroken {
             // On Linux and in older Xcode versions, URLComponents incorrectly treats `;` as *not* allowed in the path component.
-            let modify = self.components?.string ?? ""
-            let replaceUntil = modify.firstIndex(where: { $0 == "?" || $0 == "#" }) ?? modify.endIndex
-            return modify[modify.startIndex..<replaceUntil].replacingOccurrences(of: "%3B", with: ";") + modify[replaceUntil..<modify.endIndex]
+            let string = self.components?.string ?? ""
+            return string.replacingOccurrences(
+                of: "%3B", with: ";",
+                options: .literal, // N.B.: `rangeOfPath` never actually returns `nil`
+                range: self.components?.rangeOfPath ?? (string.startIndex..<string.startIndex)
+            )
         } else {
             return self.components?.string ?? ""
         }
@@ -335,6 +338,6 @@ extension CharacterSet {
 }
 
 /// On Linux and in older Xcode versions, URLComponents incorrectly treats `;` as *not* allowed in the path component.
-fileprivate let urlPathAllowedIsBroken: Bool = {
-    return CharacterSet.urlPathAllowed != CharacterSet.urlCorrectPathAllowed
+private let urlPathAllowedIsBroken: Bool = {
+    CharacterSet.urlPathAllowed != CharacterSet.urlCorrectPathAllowed
 }()

--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -199,7 +199,9 @@ public struct URI: CustomStringConvertible, ExpressibleByStringInterpolation, Ha
         self.components?.string ?? ""
         #else
         // On Linux, URLComponents incorrectly treats `;` as *not* allowed in the path component.
-        self.components?.string?.replacingOccurrences(of: "%3B", with: ";") ?? ""
+        let modify = self.components?.string ?? ""
+        let replaceUntil = modify.firstIndex(where: { $0 == "?" || $0 == "#" }) ?? modify.endIndex
+        return modify[modify.startIndex..<replaceUntil].replacingOccurrences(of: "%3B", with: ";") + modify[replaceUntil..<modify.endIndex]
         #endif
     }
     

--- a/Tests/VaporTests/URITests.swift
+++ b/Tests/VaporTests/URITests.swift
@@ -132,16 +132,16 @@ final class URITests: XCTestCase {
         XCTAssertURIComponents(scheme: "wss", host: "echo.websocket.org", path: "/", generate: "wss://echo.websocket.org/")
     }
     
-    func testSpecialCharacters() {
+    func testSemicolonIsNotEncodedInPathComponent() {
         XCTAssertURIString(
-            "https://user:pass@vapor.codes:1234/foo;?bar=abcd%C3%A4%2B#qux",
+            "https://user:pass@vapor.codes:1234/foo;?bar=abcd%3B%C3%A4%2B;efg#qux%3B",
             hasScheme: "https",
             hasUserinfo: "user:pass",
             hasHost: "vapor.codes",
             hasPort: 1234,
             hasPath: "/foo;",
-            hasQuery: "bar=abcd%C3%A4%2B",
-            hasFragment: "qux"
+            hasQuery: "bar=abcd%3B%C3%A4%2B;efg",
+            hasFragment: "qux%3B"
         )
     }
     

--- a/Tests/VaporTests/URITests.swift
+++ b/Tests/VaporTests/URITests.swift
@@ -132,6 +132,19 @@ final class URITests: XCTestCase {
         XCTAssertURIComponents(scheme: "wss", host: "echo.websocket.org", path: "/", generate: "wss://echo.websocket.org/")
     }
     
+    func testSpecialCharacters() {
+        XCTAssertURIString(
+            "https://user:pass@vapor.codes:1234/foo;?bar=abcd%C3%A4%2B#qux",
+            hasScheme: "https",
+            hasUserinfo: "user:pass",
+            hasHost: "vapor.codes",
+            hasPort: 1234,
+            hasPath: "/foo;",
+            hasQuery: "bar=abcd%C3%A4%2B",
+            hasFragment: "qux"
+        )
+    }
+    
     func testMutation() {
         var uri = URI(string: "https://user:pass@vapor.codes:1234/foo?bar=baz#qux")
     


### PR DESCRIPTION
<!-- Describe your changes clearly and use examples if possible. -->

On Linux, `URLComponents` does not have 100% the same behavior like on macOS. Vapor accounts for [this unfixed bug](https://github.com/apple/swift-corelibs-foundation/issues/3352) by replacing percent-encoded semicolon `%3B` with `;` in `URI`s.

This is however not fully correct, because if a URI contains a percent encoded semicolon, this might have a different meaning, than when it is not percent encoded, compare the following sentence from RFC 3986:
```
A percent-encoding mechanism is used to represent a data octet in a
component when that octet's corresponding character is outside the
allowed set or is being used as a delimiter of, or within, the component.
```

This PR aims to limit the impact of the required semicolon fix by ensuring that query and fragments are not unnecessarily and incorrectly modified. 

Hopefully, in a future with the new swift-foundation this fix will not be needed anymore. But for now it would solve an issue on our side which is related to the concept of a signed request.