### PR TITLE
Fixed an issue where response compression would fail when returning 304 Not Modified

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.67.0"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.67.0"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),


### PR DESCRIPTION
I recently discovered that when response compression was enabled, browsers would fail to load resources they had cached when the server responded with `304 Not Modified`, indicating the browser should use the resource they have, but failed to do so leading to images or stylesheets not loading. This applied to both HTTP 1.1 and 2 servers, using the FileMiddleware to provide the caching logic. This was [fixed](https://github.com/apple/swift-nio/pull/2737) in `SwiftNIO`, and has new [tests](https://github.com/apple/swift-nio-extras/pull/224) in `NIOHTTPCompression`, so this PR just bumps the minimum version to ensure folks don't run into the bug if response compression is enabled and caching is actually used.

### Learn More:
- [Discussion on Discord](https://discord.com/channels/431917998102675485/1249304655863877637/1249304655863877637)
- https://github.com/apple/swift-nio/pull/2737
- https://github.com/apple/swift-nio-extras/pull/224