### PR TITLE
Incorrect HTTPMediaType/parameters Documentation Formatting.

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -71,27 +71,27 @@ public struct HTTPMediaType: Hashable, CustomStringConvertible, Equatable, Senda
     ///
     /// In the `MediaType` `"application/json; charset=utf8"`:
     ///
-    /// - type: `"application"`
-    /// - subtype: `"json"`
-    /// - parameters: ["charset": "utf8"]
+    /// - `type`: `"application"`
+    /// - `subtype`: `"json"`
+    /// - `parameters`: `["charset": "utf8"]` 
     public var type: String
     
     /// The `MediaType`'s specific type. Usually a unique string.
     ///
     /// In the `MediaType` `"application/json; charset=utf8"`:
     ///
-    /// - type: `"application"`
-    /// - subtype: `"json"`
-    /// - parameters: ["charset": "utf8"]
+    /// - `type`: `"application"`
+    /// - `subtype`: `"json"`
+    /// - `parameters`: `["charset": "utf8"]`
     public var subType: String
     
     /// The `MediaType`'s metadata. Zero or more key/value pairs.
     ///
     /// In the `MediaType` `"application/json; charset=utf8"`:
     ///
-    /// - type: `"application"`
-    /// - subtype: `"json"`
-    /// - parameters: ["charset": "utf8"]
+    /// - `type`: `"application"`
+    /// - `subtype`: `"json"`
+    /// - `parameters`: `["charset": "utf8"]`
     public var parameters: [String: String]
     
     /// Converts this `MediaType` into its string representation.


### PR DESCRIPTION
Fixed an issue where docs for HTTPMediaType/parameters were incorrectly formatted. This was because `parameters` was being interpreted as the argument list, and wouldn't render.

### Before

<img width="447" alt="image" src="https://github.com/vapor/vapor/assets/225505/c9f36d20-8a61-412c-a2ed-fcee29b8f9a3">

### After

<img width="479" alt="image" src="https://github.com/vapor/vapor/assets/225505/137189ae-67ad-4154-8537-7f45c8482c9a">

