### PR TITLE
Conditional Content Response Compression

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
 
         // Useful code around SwiftNIO.
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.24.0"),
 
         // Swift logging API
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
 
         // Useful code around SwiftNIO.
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.24.0"),
 
         // Swift logging API
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -508,3 +508,7 @@ extension NIOHTTP1.HTTPHeaders: Swift.CustomDebugStringConvertible {
     }
 }
 
+// MARK: Internal Vapor Marker Headers
+extension HTTPHeaders.Name {
+    public static let xVaporResponseCompression = Self("X-Vapor-Response-Compression")
+}

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ResponseCompression.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ResponseCompression.swift
@@ -1,0 +1,54 @@
+import Foundation
+import NIOHTTP1
+
+extension HTTPHeaders {
+    /// A marker header internal to vapor that explicitely allows or disallows response compression.
+    public struct ResponseCompression: Sendable, Hashable {
+        enum Value: String {
+            case enable
+            case disable
+            case useDefault
+        }
+        
+        /// Explicitely use the server's default response compression determination.
+        public static let useDefault = ResponseCompression(value: .useDefault)
+        
+        /// Implicitely use the server's default response compression determination.
+        ///
+        /// This value has no effect when set as a route override
+        public static let unset = ResponseCompression(value: nil)
+        
+        /// Explicitely enable response compression.
+        public static let enable = ResponseCompression(value: .enable)
+        
+        /// Explicitely disable response compression.
+        public static let disable = ResponseCompression(value: .disable)
+        
+        let value: Value?
+        
+        init(value: Value?) {
+            self.value = value
+        }
+        
+        init(string: String?) {
+            self.init(value: string.flatMap { Value(rawValue: $0) })
+        }
+        
+        var rawValue: String? {
+            value?.rawValue
+        }
+    }
+
+    /// A marker header internal to vapor that explicitely allows or disallows response compression.
+    public var responseCompression: ResponseCompression {
+        get { ResponseCompression(string: self[canonicalForm: .xVaporResponseCompression].last.map { String ($0) }) }
+        set {
+            if let newValue = newValue.rawValue {
+                self.replaceOrAdd(name: .xVaporResponseCompression, value: newValue)
+            } else {
+                self.remove(name: .xVaporResponseCompression)
+            }
+        }
+    }
+}
+

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -89,33 +89,162 @@ public final class HTTPServer: Server, Sendable {
         /// Response compression configuration.
         public var responseCompression: CompressionConfiguration
 
-        /// Supported HTTP compression options.
+        /// Supported HTTP response compression options.
         public struct CompressionConfiguration: Sendable {
-            /// Disables compression. This is the default.
-            public static var disabled: Self {
-                .init(storage: .disabled)
+            /// The default initial byte buffer capacity to use for the compressor if none is specified.
+            public static let defaultInitialByteBufferCapacity = 1024
+
+            /// Disables compression unconditionally.
+            ///
+            /// This is useful when you never want any response to be compressed for debugging purposes.
+            public static var forceDisabled: Self {
+                .disabled(
+                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                    allowedTypes: .none,
+                    allowRequestOverrides: false
+                )
             }
 
-            /// Enables compression with default configuration.
+            /// Disables compression for all content types unless a route overrides the preference. This is the default.
+            ///
+            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
+            public static var disabled: Self {
+                .disabled(
+                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                    allowedTypes: .none,
+                    allowRequestOverrides: true
+                )
+            }
+
+            /// Disables compression by default, but allows easily compressible types such as text, unless a route overrides the preference.
+            ///
+            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
+            public static var enabledForCompressibleTypes: Self {
+                .disabled(
+                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                    allowedTypes: .compressible,
+                    allowRequestOverrides: true
+                )
+            }
+
+            /// Enables compression by default, dissallowing already compressed types such as images or video, unless a route overrides the preference.
+            ///
+            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
             public static var enabled: Self {
-                .enabled(initialByteBufferCapacity: 1024)
+                .enabled(
+                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                    disallowedTypes: .incompressible,
+                    allowRequestOverrides: true
+                )
             }
 
             /// Enables compression with custom configuration.
+            @available(*, deprecated, renamed: "enabled(initialByteBufferCapacity:disallowedTypes:allowRequestOverrides:)", message: "Renamed to allow for more parameters.")
+            @_disfavoredOverload // TODO: Remove this overload in Vapor 5
             public static func enabled(
                 initialByteBufferCapacity: Int
             ) -> Self {
+                .enabled(
+                    initialByteBufferCapacity: initialByteBufferCapacity,
+                    disallowedTypes: .incompressible,
+                    allowRequestOverrides: true
+                )
+            }
+
+            /// Disables compression by default, but offers options to allow it for the specified types.
+            ///
+            /// - Parameters:
+            ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
+            ///   - allowedTypes: The types to allow to be compressed. If unspecified, no types will match, thus disabling compression unless explicitly overriden. Specify ``HTTPMediaTypeSet/compressible`` to use a default set of types that compress well.
+            ///   - allowRequestOverrides: Allow routes and requests to explicitely enable compression. If unspecified, responses will not be compressed by default unless routes or responses explicitely enable it. See ``ResponseCompressionMiddleware`` for more information.
+            /// - Returns: A response compression configuration.
+            public static func disabled(
+                initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
+                allowedTypes: HTTPMediaTypeSet = .none,
+                allowRequestOverrides: Bool = true
+            ) -> Self {
+                .init(storage: .disabled(
+                    initialByteBufferCapacity: initialByteBufferCapacity,
+                    allowedTypes: allowedTypes,
+                    allowRequestOverrides: allowRequestOverrides
+                ))
+            }
+
+            /// Enables compression by default, but offers options to dissallow it for the specified types.
+            ///
+            /// - Parameters:
+            ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
+            ///   - disallowedTypes: The types to prevent from being compressed. If unspecified, incompressible types will match, thus disabling compression for media types unless explicitly overriden. Specify ``HTTPMediaTypeSet/none`` to enable compression for all types by default.
+            ///   - allowRequestOverrides: Allow routes and requests to explicitely disable compression. If unspecified, responses will be compressed by default unless routes or responses explicitely disable it. See ``ResponseCompressionMiddleware`` for more information.
+            /// - Returns: A response compression configuration.
+            public static func enabled(
+                initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
+                disallowedTypes: HTTPMediaTypeSet = .incompressible,
+                allowRequestOverrides: Bool = true
+            ) -> Self {
                 .init(storage: .enabled(
-                    initialByteBufferCapacity: initialByteBufferCapacity
+                    initialByteBufferCapacity: initialByteBufferCapacity,
+                    disallowedTypes: disallowedTypes,
+                    allowRequestOverrides: true
                 ))
             }
 
             enum Storage {
-                case disabled
-                case enabled(initialByteBufferCapacity: Int)
+                case disabled(initialByteBufferCapacity: Int, allowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
+                case enabled(initialByteBufferCapacity: Int, disallowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
+                
+                var initialByteBufferCapacity: Int {
+                    get {
+                        switch self {
+                        case .disabled(let initialByteBufferCapacity, _, _),
+                             .enabled(let initialByteBufferCapacity, _, _):
+                            return initialByteBufferCapacity
+                        }
+                    }
+                    set {
+                        switch self {
+                        case .disabled(_, let allowedTypes, let allowRequestOverrides):
+                            self = .disabled(initialByteBufferCapacity: newValue, allowedTypes: allowedTypes, allowRequestOverrides: allowRequestOverrides)
+                        case .enabled(_, let disallowedTypes, let allowRequestOverrides):
+                            self = .enabled(initialByteBufferCapacity: newValue, disallowedTypes: disallowedTypes, allowRequestOverrides: allowRequestOverrides)
+                        }
+                    }
+                }
+
+                var allowRequestOverrides: Bool {
+                    get {
+                        switch self {
+                        case .disabled(_, _, let allowRequestOverrides),
+                                .enabled(_, _, let allowRequestOverrides):
+                            return allowRequestOverrides
+                        }
+                    }
+                    set {
+                        switch self {
+                        case .disabled(let initialByteBufferCapacity, let allowedTypes, _):
+                            self = .disabled(initialByteBufferCapacity: initialByteBufferCapacity, allowedTypes: allowedTypes, allowRequestOverrides: newValue)
+                        case .enabled(let initialByteBufferCapacity, let disallowedTypes, _):
+                            self = .enabled(initialByteBufferCapacity: initialByteBufferCapacity, disallowedTypes: disallowedTypes, allowRequestOverrides: newValue)
+                        }
+                    }
+                }
             }
 
             var storage: Storage
+
+            /// The initial buffer capacity to use when instanciating the compressor.
+            public var initialByteBufferCapacity: Int {
+                get { storage.initialByteBufferCapacity }
+                set { storage.initialByteBufferCapacity = newValue }
+            }
+
+            /// Allow routes and requests to explicitely override compression.
+            ///
+            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information.
+            public var allowRequestOverrides: Bool {
+                get { storage.allowRequestOverrides }
+                set { storage.allowRequestOverrides = newValue }
+            }
         }
 
         /// Request decompression configuration.
@@ -604,16 +733,8 @@ extension ChannelPipeline {
         let http2 = HTTP2FramePayloadToHTTP1ServerCodec()
         handlers.append(http2)
         
-        /// Add response compressor if configured.
-        switch configuration.responseCompression.storage {
-        case .enabled(let initialByteBufferCapacity):
-            let responseCompressionHandler = HTTPResponseCompressor(
-                initialByteBufferCapacity: initialByteBufferCapacity
-            )
-            handlers.append(responseCompressionHandler)
-        case .disabled:
-            break
-        }
+        /// Add response compressor as configured.
+        handlers.append(configuration.responseCompression.makeCompressor())
         
         /// Add request decompressor if configured.
         switch configuration.requestDecompression.storage {
@@ -671,16 +792,8 @@ extension ChannelPipeline {
             handlers.append(pipelineHandler)
         }
         
-        /// Add response compressor if configured.
-        switch configuration.responseCompression.storage {
-        case .enabled(let initialByteBufferCapacity):
-            let responseCompressionHandler = HTTPResponseCompressor(
-                initialByteBufferCapacity: initialByteBufferCapacity
-            )
-            handlers.append(responseCompressionHandler)
-        case .disabled:
-            break
-        }
+        /// Add response compressor as configured.
+        handlers.append(configuration.responseCompression.makeCompressor())
 
         /// Add request decompressor if configured.
         switch configuration.requestDecompression.storage {
@@ -731,6 +844,55 @@ extension NIOSSLServerHandler {
             self.init(context: context, customVerificationCallback: callback)
         } else {
             self.init(context: context)
+        }
+    }
+}
+
+// MARK: Response Compression Helpers
+extension HTTPServer.Configuration.CompressionConfiguration {
+    func makeCompressor() -> HTTPResponseCompressor {
+        HTTPResponseCompressor(initialByteBufferCapacity: storage.initialByteBufferCapacity) { [storage] responseHeaders, isCompressionSupported in
+            defer {
+                /// Always remove this marker header.
+                responseHeaders.headers.remove(name: .xVaporResponseCompression)
+            }
+            
+            /// If compression isn't supported, skip any further processing.
+            guard isCompressionSupported else { return .doNotCompress }
+            
+            /// If we allow overrides, check for the response compression marker header value first before making any further checks:
+            if storage.allowRequestOverrides, let responseCompressionHeader = responseHeaders.headers.responseCompression.value {
+                switch responseCompressionHeader {
+                case .enable: return .compressIfPossible
+                case .disable: return .doNotCompress
+                case .useDefault: break
+                }
+            }
+            
+            switch storage {
+            case .enabled(_, let disallowedTypes, _):
+                /// If there were no explicit overrides, fallback to checking the content type against the disallowed set. If any type succeeds the check, disable compression:
+                let shouldDisable = responseHeaders.headers.parseDirectives(name: .contentType).contains { contentTypeDirectives in
+                    guard let mediaType = HTTPMediaType(directives: contentTypeDirectives)
+                    else { return false }
+                    
+                    return disallowedTypes.contains(mediaType)
+                }
+                
+                /// Return `.doNotCompress` if compression should be disabled, or `.compressIfPossible` to allow it.
+                return shouldDisable ? .doNotCompress : .compressIfPossible
+            case .disabled(_, let allowedTypes, _):
+                /// If there were no explicit overrides, fallback to checking the content type against the allowed set. If all types succeed the check, enable compression:
+                let shouldEnable = responseHeaders.headers.parseDirectives(name: .contentType).allSatisfy { contentTypeDirectives in
+                    guard let mediaType = HTTPMediaType(directives: contentTypeDirectives)
+                    else { return false }
+                    
+                    return allowedTypes.contains(mediaType)
+                }
+                
+                /// Return `.compressIfPossible` if compression should be enabled, or `.doNotCompress` to disallow it.
+                return shouldEnable ? .compressIfPossible : .doNotCompress
+            }
         }
     }
 }

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -23,7 +23,7 @@ public final class HTTPServer: Server, Sendable {
         public static let defaultHostname = "127.0.0.1"
         public static let defaultPort = 8080
         
-        /// Address the server will bind to. Configuring an address using a hostname with a nil host or port will use the default hostname or port respectively.
+        /// Address the server will bind to. Configuring an addrexss using a hostname with a nil host or port will use the default hostname or port respectively.
         public var address: BindAddress
         
         /// Host name the server will bind to.
@@ -87,195 +87,10 @@ public final class HTTPServer: Server, Sendable {
         public var tcpNoDelay: Bool
 
         /// Response compression configuration.
-        public var responseCompression: CompressionConfiguration
-
-        /// Supported HTTP response compression options.
-        public struct CompressionConfiguration: Sendable {
-            /// The default initial byte buffer capacity to use for the compressor if none is specified.
-            public static let defaultInitialByteBufferCapacity = 1024
-
-            /// Disables compression unconditionally.
-            ///
-            /// This is useful when you never want any response to be compressed for debugging purposes.
-            public static var forceDisabled: Self {
-                .disabled(
-                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
-                    allowedTypes: .none,
-                    allowRequestOverrides: false
-                )
-            }
-
-            /// Disables compression for all content types unless a route overrides the preference. This is the default.
-            ///
-            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
-            public static var disabled: Self {
-                .disabled(
-                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
-                    allowedTypes: .none,
-                    allowRequestOverrides: true
-                )
-            }
-
-            /// Disables compression by default, but allows easily compressible types such as text, unless a route overrides the preference.
-            ///
-            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
-            public static var enabledForCompressibleTypes: Self {
-                .disabled(
-                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
-                    allowedTypes: .compressible,
-                    allowRequestOverrides: true
-                )
-            }
-
-            /// Enables compression by default, dissallowing already compressed types such as images or video, unless a route overrides the preference.
-            ///
-            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
-            public static var enabled: Self {
-                .enabled(
-                    initialByteBufferCapacity: defaultInitialByteBufferCapacity,
-                    disallowedTypes: .incompressible,
-                    allowRequestOverrides: true
-                )
-            }
-
-            /// Enables compression with custom configuration.
-            @available(*, deprecated, renamed: "enabled(initialByteBufferCapacity:disallowedTypes:allowRequestOverrides:)", message: "Renamed to allow for more parameters.")
-            @_disfavoredOverload // TODO: Remove this overload in Vapor 5
-            public static func enabled(
-                initialByteBufferCapacity: Int
-            ) -> Self {
-                .enabled(
-                    initialByteBufferCapacity: initialByteBufferCapacity,
-                    disallowedTypes: .incompressible,
-                    allowRequestOverrides: true
-                )
-            }
-
-            /// Disables compression by default, but offers options to allow it for the specified types.
-            ///
-            /// - Parameters:
-            ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
-            ///   - allowedTypes: The types to allow to be compressed. If unspecified, no types will match, thus disabling compression unless explicitly overriden. Specify ``HTTPMediaTypeSet/compressible`` to use a default set of types that compress well.
-            ///   - allowRequestOverrides: Allow routes and requests to explicitely enable compression. If unspecified, responses will not be compressed by default unless routes or responses explicitely enable it. See ``ResponseCompressionMiddleware`` for more information.
-            /// - Returns: A response compression configuration.
-            public static func disabled(
-                initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
-                allowedTypes: HTTPMediaTypeSet = .none,
-                allowRequestOverrides: Bool = true
-            ) -> Self {
-                .init(storage: .disabled(
-                    initialByteBufferCapacity: initialByteBufferCapacity,
-                    allowedTypes: allowedTypes,
-                    allowRequestOverrides: allowRequestOverrides
-                ))
-            }
-
-            /// Enables compression by default, but offers options to dissallow it for the specified types.
-            ///
-            /// - Parameters:
-            ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
-            ///   - disallowedTypes: The types to prevent from being compressed. If unspecified, incompressible types will match, thus disabling compression for media types unless explicitly overriden. Specify ``HTTPMediaTypeSet/none`` to enable compression for all types by default.
-            ///   - allowRequestOverrides: Allow routes and requests to explicitely disable compression. If unspecified, responses will be compressed by default unless routes or responses explicitely disable it. See ``ResponseCompressionMiddleware`` for more information.
-            /// - Returns: A response compression configuration.
-            public static func enabled(
-                initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
-                disallowedTypes: HTTPMediaTypeSet = .incompressible,
-                allowRequestOverrides: Bool = true
-            ) -> Self {
-                .init(storage: .enabled(
-                    initialByteBufferCapacity: initialByteBufferCapacity,
-                    disallowedTypes: disallowedTypes,
-                    allowRequestOverrides: true
-                ))
-            }
-
-            enum Storage {
-                case disabled(initialByteBufferCapacity: Int, allowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
-                case enabled(initialByteBufferCapacity: Int, disallowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
-                
-                var initialByteBufferCapacity: Int {
-                    get {
-                        switch self {
-                        case .disabled(let initialByteBufferCapacity, _, _),
-                             .enabled(let initialByteBufferCapacity, _, _):
-                            return initialByteBufferCapacity
-                        }
-                    }
-                    set {
-                        switch self {
-                        case .disabled(_, let allowedTypes, let allowRequestOverrides):
-                            self = .disabled(initialByteBufferCapacity: newValue, allowedTypes: allowedTypes, allowRequestOverrides: allowRequestOverrides)
-                        case .enabled(_, let disallowedTypes, let allowRequestOverrides):
-                            self = .enabled(initialByteBufferCapacity: newValue, disallowedTypes: disallowedTypes, allowRequestOverrides: allowRequestOverrides)
-                        }
-                    }
-                }
-
-                var allowRequestOverrides: Bool {
-                    get {
-                        switch self {
-                        case .disabled(_, _, let allowRequestOverrides),
-                                .enabled(_, _, let allowRequestOverrides):
-                            return allowRequestOverrides
-                        }
-                    }
-                    set {
-                        switch self {
-                        case .disabled(let initialByteBufferCapacity, let allowedTypes, _):
-                            self = .disabled(initialByteBufferCapacity: initialByteBufferCapacity, allowedTypes: allowedTypes, allowRequestOverrides: newValue)
-                        case .enabled(let initialByteBufferCapacity, let disallowedTypes, _):
-                            self = .enabled(initialByteBufferCapacity: initialByteBufferCapacity, disallowedTypes: disallowedTypes, allowRequestOverrides: newValue)
-                        }
-                    }
-                }
-            }
-
-            var storage: Storage
-
-            /// The initial buffer capacity to use when instanciating the compressor.
-            public var initialByteBufferCapacity: Int {
-                get { storage.initialByteBufferCapacity }
-                set { storage.initialByteBufferCapacity = newValue }
-            }
-
-            /// Allow routes and requests to explicitely override compression.
-            ///
-            /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information.
-            public var allowRequestOverrides: Bool {
-                get { storage.allowRequestOverrides }
-                set { storage.allowRequestOverrides = newValue }
-            }
-        }
+        public var responseCompression: ResponseCompressionConfiguration
 
         /// Request decompression configuration.
-        public var requestDecompression: DecompressionConfiguration
-
-        /// Supported HTTP decompression options.
-        public struct DecompressionConfiguration: Sendable {
-            /// Disables decompression. This is the default option.
-            public static var disabled: Self {
-                .init(storage: .disabled)
-            }
-
-            /// Enables decompression with default configuration.
-            public static var enabled: Self {
-                .enabled(limit: .ratio(25))
-            }
-
-            /// Enables decompression with custom configuration.
-            public static func enabled(
-                limit: NIOHTTPDecompression.DecompressionLimit
-            ) -> Self {
-                .init(storage: .enabled(limit: limit))
-            }
-
-            enum Storage {
-                case disabled
-                case enabled(limit: NIOHTTPDecompression.DecompressionLimit)
-            }
-
-            var storage: Storage
-        }
+        public var requestDecompression: RequestDecompressionConfiguration
         
         /// When `true`, HTTP server will support pipelined requests.
         public var supportPipelining: Bool
@@ -315,8 +130,8 @@ public final class HTTPServer: Server, Sendable {
             backlog: Int = 256,
             reuseAddress: Bool = true,
             tcpNoDelay: Bool = true,
-            responseCompression: CompressionConfiguration = .disabled,
-            requestDecompression: DecompressionConfiguration = .enabled,
+            responseCompression: ResponseCompressionConfiguration = .disabled,
+            requestDecompression: RequestDecompressionConfiguration = .enabled,
             supportPipelining: Bool = true,
             supportVersions: Set<HTTPVersionMajor>? = nil,
             tlsConfiguration: TLSConfiguration? = nil,
@@ -351,8 +166,8 @@ public final class HTTPServer: Server, Sendable {
             backlog: Int = 256,
             reuseAddress: Bool = true,
             tcpNoDelay: Bool = true,
-            responseCompression: CompressionConfiguration = .disabled,
-            requestDecompression: DecompressionConfiguration = .enabled,
+            responseCompression: ResponseCompressionConfiguration = .disabled,
+            requestDecompression: RequestDecompressionConfiguration = .enabled,
             supportPipelining: Bool = true,
             supportVersions: Set<HTTPVersionMajor>? = nil,
             tlsConfiguration: TLSConfiguration? = nil,
@@ -849,7 +664,7 @@ extension NIOSSLServerHandler {
 }
 
 // MARK: Response Compression Helpers
-extension HTTPServer.Configuration.CompressionConfiguration {
+extension HTTPServer.Configuration.ResponseCompressionConfiguration {
     func makeCompressor() -> HTTPResponseCompressor {
         HTTPResponseCompressor(initialByteBufferCapacity: storage.initialByteBufferCapacity) { [storage] responseHeaders, isCompressionSupported in
             defer {

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -23,7 +23,7 @@ public final class HTTPServer: Server, Sendable {
         public static let defaultHostname = "127.0.0.1"
         public static let defaultPort = 8080
         
-        /// Address the server will bind to. Configuring an addrexss using a hostname with a nil host or port will use the default hostname or port respectively.
+        /// Address the server will bind to. Configuring an address using a hostname with a nil host or port will use the default hostname or port respectively.
         public var address: BindAddress
         
         /// Host name the server will bind to.

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+RequestDecompressionConfiguration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+RequestDecompressionConfiguration.swift
@@ -1,0 +1,31 @@
+extension HTTPServer.Configuration {
+    /// Supported HTTP decompression options.
+    public struct RequestDecompressionConfiguration: Sendable {
+        /// Disables decompression. This is the default option.
+        public static var disabled: Self {
+            .init(storage: .disabled)
+        }
+
+        /// Enables decompression with default configuration.
+        public static var enabled: Self {
+            .enabled(limit: .ratio(25))
+        }
+
+        /// Enables decompression with custom configuration.
+        public static func enabled(
+            limit: NIOHTTPDecompression.DecompressionLimit
+        ) -> Self {
+            .init(storage: .enabled(limit: limit))
+        }
+
+        enum Storage {
+            case disabled
+            case enabled(limit: NIOHTTPDecompression.DecompressionLimit)
+        }
+
+        var storage: Storage
+    }
+    
+    @available(*, deprecated, renamed: "RequestDecompressionConfiguration", message: "Renamed to RequestDecompressionConfiguration for clarity.")
+    public typealias DecompressionConfiguration = RequestDecompressionConfiguration
+}

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+ResponseCompressionConfiguration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+ResponseCompressionConfiguration.swift
@@ -1,0 +1,162 @@
+extension HTTPServer.Configuration {
+    /// Supported HTTP response compression options.
+    public struct ResponseCompressionConfiguration: Sendable {
+        /// The default initial byte buffer capacity to use for the compressor if none is specified.
+        public static let defaultInitialByteBufferCapacity = 1024
+        
+        /// Disables compression unconditionally.
+        ///
+        /// This is useful when you never want any response to be compressed for debugging purposes.
+        public static var forceDisabled: Self {
+            .disabled(
+                initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                allowedTypes: .none,
+                allowRequestOverrides: false
+            )
+        }
+        
+        /// Disables compression for all content types unless a route overrides the preference. This is the default.
+        ///
+        /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
+        public static var disabled: Self {
+            .disabled(
+                initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                allowedTypes: .none,
+                allowRequestOverrides: true
+            )
+        }
+        
+        /// Disables compression by default, but allows easily compressible types such as text, unless a route overrides the preference.
+        ///
+        /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
+        public static var enabledForCompressibleTypes: Self {
+            .disabled(
+                initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                allowedTypes: .compressible,
+                allowRequestOverrides: true
+            )
+        }
+        
+        /// Enables compression by default, dissallowing already compressed types such as images or video, unless a route overrides the preference.
+        ///
+        /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
+        public static var enabled: Self {
+            .enabled(
+                initialByteBufferCapacity: defaultInitialByteBufferCapacity,
+                disallowedTypes: .incompressible,
+                allowRequestOverrides: true
+            )
+        }
+        
+        /// Enables compression with custom configuration.
+        @available(*, deprecated, renamed: "enabled(initialByteBufferCapacity:disallowedTypes:allowRequestOverrides:)", message: "Renamed to allow for more parameters.")
+        @_disfavoredOverload // TODO: Remove this overload in Vapor 5
+        public static func enabled(
+            initialByteBufferCapacity: Int
+        ) -> Self {
+            .enabled(
+                initialByteBufferCapacity: initialByteBufferCapacity,
+                disallowedTypes: .incompressible,
+                allowRequestOverrides: true
+            )
+        }
+        
+        /// Disables compression by default, but offers options to allow it for the specified types.
+        ///
+        /// - Parameters:
+        ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
+        ///   - allowedTypes: The types to allow to be compressed. If unspecified, no types will match, thus disabling compression unless explicitly overriden. Specify ``HTTPMediaTypeSet/compressible`` to use a default set of types that compress well.
+        ///   - allowRequestOverrides: Allow routes and requests to explicitely enable compression. If unspecified, responses will not be compressed by default unless routes or responses explicitely enable it. See ``ResponseCompressionMiddleware`` for more information.
+        /// - Returns: A response compression configuration.
+        public static func disabled(
+            initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
+            allowedTypes: HTTPMediaTypeSet = .none,
+            allowRequestOverrides: Bool = true
+        ) -> Self {
+            .init(storage: .disabled(
+                initialByteBufferCapacity: initialByteBufferCapacity,
+                allowedTypes: allowedTypes,
+                allowRequestOverrides: allowRequestOverrides
+            ))
+        }
+        
+        /// Enables compression by default, but offers options to dissallow it for the specified types.
+        ///
+        /// - Parameters:
+        ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.
+        ///   - disallowedTypes: The types to prevent from being compressed. If unspecified, incompressible types will match, thus disabling compression for media types unless explicitly overriden. Specify ``HTTPMediaTypeSet/none`` to enable compression for all types by default.
+        ///   - allowRequestOverrides: Allow routes and requests to explicitely disable compression. If unspecified, responses will be compressed by default unless routes or responses explicitely disable it. See ``ResponseCompressionMiddleware`` for more information.
+        /// - Returns: A response compression configuration.
+        public static func enabled(
+            initialByteBufferCapacity: Int = defaultInitialByteBufferCapacity,
+            disallowedTypes: HTTPMediaTypeSet = .incompressible,
+            allowRequestOverrides: Bool = true
+        ) -> Self {
+            .init(storage: .enabled(
+                initialByteBufferCapacity: initialByteBufferCapacity,
+                disallowedTypes: disallowedTypes,
+                allowRequestOverrides: true
+            ))
+        }
+        
+        enum Storage {
+            case disabled(initialByteBufferCapacity: Int, allowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
+            case enabled(initialByteBufferCapacity: Int, disallowedTypes: HTTPMediaTypeSet, allowRequestOverrides: Bool)
+            
+            var initialByteBufferCapacity: Int {
+                get {
+                    switch self {
+                    case .disabled(let initialByteBufferCapacity, _, _),
+                            .enabled(let initialByteBufferCapacity, _, _):
+                        return initialByteBufferCapacity
+                    }
+                }
+                set {
+                    switch self {
+                    case .disabled(_, let allowedTypes, let allowRequestOverrides):
+                        self = .disabled(initialByteBufferCapacity: newValue, allowedTypes: allowedTypes, allowRequestOverrides: allowRequestOverrides)
+                    case .enabled(_, let disallowedTypes, let allowRequestOverrides):
+                        self = .enabled(initialByteBufferCapacity: newValue, disallowedTypes: disallowedTypes, allowRequestOverrides: allowRequestOverrides)
+                    }
+                }
+            }
+            
+            var allowRequestOverrides: Bool {
+                get {
+                    switch self {
+                    case .disabled(_, _, let allowRequestOverrides),
+                            .enabled(_, _, let allowRequestOverrides):
+                        return allowRequestOverrides
+                    }
+                }
+                set {
+                    switch self {
+                    case .disabled(let initialByteBufferCapacity, let allowedTypes, _):
+                        self = .disabled(initialByteBufferCapacity: initialByteBufferCapacity, allowedTypes: allowedTypes, allowRequestOverrides: newValue)
+                    case .enabled(let initialByteBufferCapacity, let disallowedTypes, _):
+                        self = .enabled(initialByteBufferCapacity: initialByteBufferCapacity, disallowedTypes: disallowedTypes, allowRequestOverrides: newValue)
+                    }
+                }
+            }
+        }
+        
+        var storage: Storage
+        
+        /// The initial buffer capacity to use when instanciating the compressor.
+        public var initialByteBufferCapacity: Int {
+            get { storage.initialByteBufferCapacity }
+            set { storage.initialByteBufferCapacity = newValue }
+        }
+        
+        /// Allow routes and requests to explicitely override compression.
+        ///
+        /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information.
+        public var allowRequestOverrides: Bool {
+            get { storage.allowRequestOverrides }
+            set { storage.allowRequestOverrides = newValue }
+        }
+    }
+    
+    @available(*, deprecated, renamed: "ResponseCompressionConfiguration", message: "Renamed to ResponseCompressionConfiguration for clarity.")
+    public typealias CompressionConfiguration = ResponseCompressionConfiguration
+}

--- a/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
+++ b/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
@@ -2,7 +2,7 @@
 ///
 /// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
 ///
-/// When the ``HTTPServer/Configuration-swift.struct/CompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
+/// When the ``HTTPServer/Configuration-swift.struct/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
 ///
 /// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPHeaders/ResponseCompression/useDefault``.
 ///
@@ -10,7 +10,7 @@
 public struct ResponseCompressionMiddleware: AsyncMiddleware {
     /// The response compression override to use over the base configuration.
     ///
-    /// Overrides are only used when the server's ``HTTPServer/Configuration-swift.struct/CompressionConfiguration/allowRequestOverrides`` property is enabled, otherwise they are ignored.
+    /// Overrides are only used when the server's ``HTTPServer/Configuration-swift.struct/ResponseCompressionConfiguration/allowRequestOverrides`` property is enabled, otherwise they are ignored.
     ///
     /// To clear an override set previously in the chain (ie. closer to the root route than to the original response), set ``HTTPHeaders/ResponseCompression/useDefault``.
     ///
@@ -47,7 +47,7 @@ extension RoutesBuilder {
     /// 
     /// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
     /// 
-    /// When the ``HTTPServer/Configuration-swift.struct/CompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
+    /// When the ``HTTPServer/Configuration-swift.struct/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
     ///
     /// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPHeaders/ResponseCompression/useDefault``.
     ///

--- a/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
+++ b/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
@@ -1,0 +1,64 @@
+/// Overrides the response compression settings for a route.
+///
+/// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
+///
+/// When the ``HTTPServer/Configuration-swift.struct/CompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
+///
+/// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPHeaders/ResponseCompression/useDefault``.
+///
+/// - Note: Response compression is only actually used if the client indicates it supports it via an `Accept` header.
+public struct ResponseCompressionMiddleware: AsyncMiddleware {
+    /// The response compression override to use over the base configuration.
+    ///
+    /// Overrides are only used when the server's ``HTTPServer/Configuration-swift.struct/CompressionConfiguration/allowRequestOverrides`` property is enabled, otherwise they are ignored.
+    ///
+    /// To clear an override set previously in the chain (ie. closer to the root route than to the original response), set ``HTTPHeaders/ResponseCompression/useDefault``.
+    ///
+    /// - Note: Middleware that come after this one, or responses with a ``HTTPHeaders/ResponseCompression`` header, will take priority over the override set here, unless ``shouldForce`` is set to true.
+    public var responseCompressionOverride: HTTPHeaders.ResponseCompression
+    
+    /// A flag to force the override atop whatever the response or output of middleware that process the response before this one.
+    public var shouldForce: Bool
+    
+    /// Initialize a response compression middleware with an override.
+    /// 
+    /// - Parameters:
+    ///   - override: The compression preference to apply if none is already set.
+    ///   - shouldForce: Wether to force the compression preference over what the response prefers.
+    ///
+    /// - SeeAlso: Please see ``responseCompressionOverride`` for more details.
+    public init(override: HTTPHeaders.ResponseCompression, force shouldForce: Bool = false) {
+        self.responseCompressionOverride = override
+        self.shouldForce = shouldForce
+    }
+    
+    public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let response = try await next.respond(to: request)
+        /// Only set the header if it is unset, and prefer the next responder's header over our own override, as _it_ is overriding ours.
+        if response.headers.responseCompression == .unset || shouldForce {
+            response.headers.responseCompression = responseCompressionOverride
+        }
+        return response
+    }
+}
+
+extension RoutesBuilder {
+    /// Override the response compression settings for a route.
+    /// 
+    /// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
+    /// 
+    /// When the ``HTTPServer/Configuration-swift.struct/CompressionConfiguration`` is set to be disabled by default, ``HTTPHeaders/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPHeaders/ResponseCompression/disable`` can be set to explicitly disable compression.
+    ///
+    /// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPHeaders/ResponseCompression/useDefault``.
+    ///
+    /// - Note: Response compression is only actually used if the client indicates it supports it via an `Accept` header.
+    /// - Note: Setting the override to ``HTTPHeaders/ResponseCompression/unset`` has no effect here unless `force` is set to true.
+    ///
+    /// - Parameters:
+    ///   - override: The compression preference to apply if none is already set.
+    ///   - shouldForce: Wether to force the compression preference over what the response prefers.
+    /// - Returns: A route with the specified response compression preferences.
+    public func responseCompression(_ override: HTTPHeaders.ResponseCompression, force shouldForce: Bool = false) -> RoutesBuilder {
+        self.grouped(ResponseCompressionMiddleware(override: override, force: shouldForce))
+    }
+}

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -111,7 +111,7 @@ final class ConditionalResponseCompressionServerTests: XCTestCase, @unchecked Se
     var app: Application!
     
     func assertCompressed(
-        _ configuration: HTTPServer.Configuration.CompressionConfiguration,
+        _ configuration: HTTPServer.Configuration.ResponseCompressionConfiguration,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
@@ -133,7 +133,7 @@ final class ConditionalResponseCompressionServerTests: XCTestCase, @unchecked Se
     }
     
     func assertUncompressed(
-        _ configuration: HTTPServer.Configuration.CompressionConfiguration,
+        _ configuration: HTTPServer.Configuration.ResponseCompressionConfiguration,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -100,3 +100,289 @@ final class ConditionalResponseCompressionParsingTests: XCTestCase, @unchecked S
         XCTAssertEqual(headers.responseCompression, .unset)
     }
 }
+
+
+private let compressiblePayload = #"{"compressed": ["key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value", "key": "value"]}"#
+
+private let unknownType = HTTPMediaType(type: "vapor-test", subType: "unknown")
+
+
+final class ConditionalResponseCompressionServerTests: XCTestCase, @unchecked Sendable {
+    var app: Application!
+    
+    func assertCompressed(
+        _ configuration: HTTPServer.Configuration.CompressionConfiguration,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+        
+        app.http.server.configuration.responseCompression = configuration
+        
+        let response = try await app.client.get("http://localhost:\(port)/resource") { request in
+            request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip")
+        }
+        XCTAssertEqual(response.headers.first(name: .contentEncoding), "gzip", file: file, line: line)
+        XCTAssertNotEqual(response.headers.first(name: .contentLength), "\(compressiblePayload.count)", file: file, line: line)
+        XCTAssertEqual(response.body?.string, compressiblePayload, file: file, line: line)
+    }
+    
+    func assertUncompressed(
+        _ configuration: HTTPServer.Configuration.CompressionConfiguration,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+        
+        app.http.server.configuration.responseCompression = configuration
+        
+        let response = try await app.client.get("http://localhost:\(port)/resource") { request in
+            request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip")
+        }
+        XCTAssertNotEqual(response.headers.first(name: .contentEncoding), "gzip", file: file, line: line)
+        XCTAssertEqual(response.headers.first(name: .contentLength), "\(compressiblePayload.count)", file: file, line: line)
+        XCTAssertEqual(response.body?.string, compressiblePayload, file: file, line: line)
+    }
+    
+    override func setUp() async throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        app = try await Application.make(test)
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+        
+        app.http.server.configuration.supportVersions = [.one]
+        
+        /// Make sure the client doesn't keep the server open by re-using the connection.
+        app.http.client.configuration.maximumUsesPerConnection = 1
+        app.http.client.configuration.decompression = .enabled(limit: .none)
+    }
+    
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+    
+    func testAutoDetectedType() async throws {
+        app.get("resource") { _ in compressiblePayload }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertCompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testUnknownType() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType /// Not explicitely marked as compressible or not.
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testImage() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = .png /// PNGs are explicitely called out as incompressible.
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertUncompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testVideo() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = .mpeg /// Videos are explicitely called out as incompressible, but as a class.
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertUncompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testText() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = .plainText /// Text types are explicitely called out as compressible, but as a class.
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertCompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testEnabledByResponse() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            headers.responseCompression = .enable
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertCompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertCompressed(.disabled)
+        try await assertCompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testDisabledByResponse() async throws {
+        app.get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            headers.responseCompression = .disable
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertUncompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+}

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -1,0 +1,102 @@
+#if !canImport(Darwin)
+@preconcurrency import Dispatch
+#endif
+import Foundation
+import Vapor
+import XCTest
+import AsyncHTTPClient
+import NIOCore
+import NIOPosix
+import NIOConcurrencyHelpers
+import NIOHTTP1
+import NIOSSL
+import Atomics
+
+
+let markerHeader = HTTPHeaders.Name.xVaporResponseCompression.description
+
+final class ConditionalResponseCompressionParsingTests: XCTestCase, @unchecked Sendable {
+    func testEncodingEnable() {
+        var headers = HTTPHeaders()
+        headers.responseCompression = .enable
+        XCTAssertEqual(headers, [markerHeader : "enable"])
+    }
+    
+    func testEncodingDisable() {
+        var headers = HTTPHeaders()
+        headers.responseCompression = .disable
+        XCTAssertEqual(headers, [markerHeader : "disable"])
+    }
+    
+    func testEncodingUseDefault() {
+        var headers = HTTPHeaders()
+        headers.responseCompression = .useDefault
+        XCTAssertEqual(headers, [markerHeader : "useDefault"])
+    }
+    
+    func testEncodingUnset() {
+        var headers = HTTPHeaders()
+        headers.responseCompression = .unset
+        XCTAssertEqual(headers, [:])
+    }
+    
+    func testUpdating() {
+        var headers = HTTPHeaders()
+        headers.responseCompression = .enable
+        XCTAssertEqual(headers, [markerHeader : "enable"])
+        headers.responseCompression = .disable
+        XCTAssertEqual(headers, [markerHeader : "disable"])
+        headers.responseCompression = .unset
+        XCTAssertEqual(headers, [:])
+        headers.add(name: markerHeader, value: "enable")
+        headers.add(name: markerHeader, value: "disable")
+        XCTAssertEqual(headers, [markerHeader : "enable", markerHeader : "disable"])
+        headers.responseCompression = .disable
+        XCTAssertEqual(headers, [markerHeader : "disable"])
+    }
+    
+    func testDecodingUnset() {
+        let headers: HTTPHeaders = [:]
+        XCTAssertEqual(headers.responseCompression, .unset)
+    }
+    
+    func testDecodingEnabled() {
+        let headers: HTTPHeaders = [markerHeader : "enable"]
+        XCTAssertEqual(headers.responseCompression, .enable)
+    }
+    
+    func testDecodingDisabled() {
+        let headers: HTTPHeaders = [markerHeader : "disable"]
+        XCTAssertEqual(headers.responseCompression, .disable)
+    }
+    
+    func testDecodingUseDefault() {
+        let headers: HTTPHeaders = [markerHeader : "useDefault"]
+        XCTAssertEqual(headers.responseCompression, .useDefault)
+    }
+    
+    func testDecodingLiteralUnset() {
+        let headers: HTTPHeaders = [markerHeader : "unset"]
+        XCTAssertEqual(headers.responseCompression, .unset)
+    }
+    
+    func testDecodingOther() {
+        let headers: HTTPHeaders = [markerHeader : "other"]
+        XCTAssertEqual(headers.responseCompression, .unset)
+    }
+    
+    func testDecodingMultipleValid() {
+        let headers: HTTPHeaders = [markerHeader : "enable", markerHeader : "disable"]
+        XCTAssertEqual(headers.responseCompression, .disable)
+    }
+    
+    func testDecodingMultipleFirstInvalid() {
+        let headers: HTTPHeaders = [markerHeader : "other", markerHeader : "enable"]
+        XCTAssertEqual(headers.responseCompression, .enable)
+    }
+    
+    func testDecodingMultipleLastInvalid() {
+        let headers: HTTPHeaders = [markerHeader : "enable", markerHeader : "other"]
+        XCTAssertEqual(headers.responseCompression, .unset)
+    }
+}

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -385,4 +385,447 @@ final class ConditionalResponseCompressionServerTests: XCTestCase, @unchecked Se
         try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
         try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
     }
+    
+    func testForceEnabledByResponse() async throws {
+        app.responseCompression(.disable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            headers.responseCompression = .enable
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertCompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertCompressed(.disabled)
+        try await assertCompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testForceDisabledByResponse() async throws {
+        app.responseCompression(.enable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            headers.responseCompression = .disable
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertUncompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testEnabledByRoute() async throws {
+        app.responseCompression(.enable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertCompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertCompressed(.disabled)
+        try await assertCompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testDisabledByRoute() async throws {
+        app.responseCompression(.disable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertUncompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testDisabledByRouteButReset() async throws {
+        app.responseCompression(.disable).responseCompression(.useDefault).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testEnabledByRouteButReset() async throws {
+        app.responseCompression(.enable).responseCompression(.useDefault).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testDisabledByRouteResetByResponse() async throws {
+        app.responseCompression(.disable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.responseCompression = .useDefault
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testEnabledByRouteResetByResponse() async throws {
+        app.responseCompression(.enable).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.responseCompression = .useDefault
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testNoopsDisabledByRouteButReset() async throws {
+        app.responseCompression(.unset).responseCompression(.disable).responseCompression(.unset).responseCompression(.useDefault).responseCompression(.unset).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+    
+    func testNoopsEnabledByRouteButReset() async throws {
+        app.responseCompression(.unset).responseCompression(.enable).responseCompression(.unset).responseCompression(.useDefault).responseCompression(.unset).get("resource") { request in
+            var headers = HTTPHeaders()
+            headers.contentType = unknownType
+            return compressiblePayload.encodeResponse(status: .ok, headers: headers, for: request)
+        }
+        
+        try app.server.start()
+        defer { app.server.shutdown() }
+        
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+        
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertCompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+        
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+}
+
+
+final class ConditionalResponseCompressionRouteTests: XCTestCase, @unchecked Sendable {
+    var app: Application!
+    
+    override func setUp() async throws {
+        let test = Environment(name: "testing", arguments: ["vapor"])
+        app = try await Application.make(test)
+    }
+    
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+    
+    func assertResponseCompression(
+        middleware: any AsyncMiddleware,
+        responder: any AsyncResponder,
+        compressionValue: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let response = try await middleware.respond(to: Request(application: app, on: app.eventLoopGroup.next()), chainingTo: responder)
+        let header = response.headers[canonicalForm: .xVaporResponseCompression]
+        
+        XCTAssertEqual(header, compressionValue.map { $0.components(separatedBy: ", ") }?.map { $0[...] } ?? [], file: file, line: line)
+    }
+    
+    let enabledMiddleware = ResponseCompressionMiddleware(override: .enable)
+    let disabledMiddleware = ResponseCompressionMiddleware(override: .disable)
+    let defaultMiddleware = ResponseCompressionMiddleware(override: .useDefault)
+    let unsetMiddleware = ResponseCompressionMiddleware(override: .unset)
+    
+    let forceEnabledMiddleware = ResponseCompressionMiddleware(override: .enable, force: true)
+    let forceDisabledMiddleware = ResponseCompressionMiddleware(override: .disable, force: true)
+    let forceDefaultMiddleware = ResponseCompressionMiddleware(override: .useDefault, force: true)
+    let forceUnsetMiddleware = ResponseCompressionMiddleware(override: .unset, force: true)
+    
+    func testRoutingDoesNotPrioritizeUnsetResponse() async throws {
+        let unsetResponse = TestResponder { _ in Response() }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: unsetResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: unsetResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: unsetResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: unsetResponse, compressionValue: nil)
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: unsetResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: unsetResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: unsetResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: unsetResponse, compressionValue: nil)
+    }
+    
+    func testRoutingDoesNotPrioritizeEmptyResponse() async throws {
+        let emptyResponse = TestResponder { _ in Response(headers: [markerHeader : ""]) }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: emptyResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: emptyResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: emptyResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: emptyResponse, compressionValue: nil)
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: emptyResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: emptyResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: emptyResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: emptyResponse, compressionValue: nil)
+    }
+    
+    func testRoutingPrioritizesEnabledResponse() async throws {
+        let enabledResponse = TestResponder { _ in Response(headers: [markerHeader : "enable"]) }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: enabledResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: enabledResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: enabledResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: enabledResponse, compressionValue: "enable")
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: enabledResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: enabledResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: enabledResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: enabledResponse, compressionValue: nil)
+    }
+    
+    func testRoutingPrioritizesDisabledResponse() async throws {
+        let disabledResponse = TestResponder { _ in Response(headers: [markerHeader : "disable"]) }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: disabledResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: disabledResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: disabledResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: disabledResponse, compressionValue: "disable")
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: disabledResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: disabledResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: disabledResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: disabledResponse, compressionValue: nil)
+    }
+    
+    func testRoutingDoesNotPrioritizeOtherResponse() async throws {
+        let otherResponse = TestResponder { _ in Response(headers: [markerHeader : "other"]) }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: otherResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: otherResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: otherResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: otherResponse, compressionValue: nil)
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: otherResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: otherResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: otherResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: otherResponse, compressionValue: nil)
+    }
+    
+    func testRoutingPrioritizesMultipleResponse() async throws {
+        let multipleResponse = TestResponder { _ in Response(headers: [markerHeader : "enable", markerHeader : "disable"]) }
+        
+        try await assertResponseCompression(middleware: enabledMiddleware, responder: multipleResponse, compressionValue: "enable, disable")
+        try await assertResponseCompression(middleware: disabledMiddleware, responder: multipleResponse, compressionValue: "enable, disable")
+        try await assertResponseCompression(middleware: defaultMiddleware, responder: multipleResponse, compressionValue: "enable, disable")
+        try await assertResponseCompression(middleware: unsetMiddleware, responder: multipleResponse, compressionValue: "enable, disable")
+        
+        try await assertResponseCompression(middleware: forceEnabledMiddleware, responder: multipleResponse, compressionValue: "enable")
+        try await assertResponseCompression(middleware: forceDisabledMiddleware, responder: multipleResponse, compressionValue: "disable")
+        try await assertResponseCompression(middleware: forceDefaultMiddleware, responder: multipleResponse, compressionValue: "useDefault")
+        try await assertResponseCompression(middleware: forceUnsetMiddleware, responder: multipleResponse, compressionValue: nil)
+    }
+}
+
+private struct TestResponder: AsyncResponder {
+    let transform: @Sendable (_ request: Request) -> Response
+    
+    func respond(to request: Request) async throws -> Response {
+        transform(request)
+    }
 }

--- a/Tests/VaporTests/HTTPMediaTypeSetTests.swift
+++ b/Tests/VaporTests/HTTPMediaTypeSetTests.swift
@@ -1,0 +1,112 @@
+@testable import Vapor
+import XCTest
+import NIOHTTP1
+
+final class HTTPMediaTypeSetTests: XCTestCase {
+    func testEmptySet() {
+        let mediaSet = HTTPMediaTypeSet.none
+        
+        XCTAssertFalse(mediaSet.contains(.any))
+        XCTAssertFalse(mediaSet.contains(.html))
+        XCTAssertFalse(mediaSet.contains(.multipart))
+        
+        XCTAssertEqual(mediaSet.mediaTypeLookup, [:])
+        XCTAssertTrue(mediaSet.allowsNone)
+        XCTAssertFalse(mediaSet.allowsAny)
+    }
+    
+    func testAllSet() {
+        let mediaSet = HTTPMediaTypeSet.all
+        
+        XCTAssertTrue(mediaSet.contains(.any))
+        XCTAssertTrue(mediaSet.contains(.html))
+        XCTAssertTrue(mediaSet.contains(.multipart))
+        
+        XCTAssertEqual(mediaSet.mediaTypeLookup, ["*": ["*" : [.any]]])
+        XCTAssertFalse(mediaSet.allowsNone)
+        XCTAssertTrue(mediaSet.allowsAny)
+    }
+    
+    func testInitialization() {
+        var mediaSet: HTTPMediaTypeSet
+        
+        mediaSet = []
+        XCTAssertEqual(mediaSet.mediaTypeLookup, [:])
+        
+        mediaSet = [.any]
+        XCTAssertEqual(mediaSet.mediaTypeLookup, ["*" : ["*" : [.any]]])
+        
+        mediaSet = [.html]
+        XCTAssertEqual(mediaSet.mediaTypeLookup, ["text" : ["html" : [.html]]])
+        
+        mediaSet = [.html, .css]
+        XCTAssertEqual(mediaSet.mediaTypeLookup, ["text" : ["css" : [.css], "html": [.html]]])
+        
+        mediaSet = [.html, .png]
+        XCTAssertEqual(mediaSet.mediaTypeLookup, ["text" : ["html": [.html]], "image" : ["png" : [.png]]])
+    }
+    
+    func testContains() {
+        let mediaSet: HTTPMediaTypeSet = [
+            HTTPMediaType(type: "a", subType: "1"),
+            HTTPMediaType(type: "a", subType: "2"),
+            HTTPMediaType(type: "a", subType: "-", parameters: ["A": "a"]),
+            HTTPMediaType(type: "b", subType: "3"),
+            HTTPMediaType(type: "b", subType: "4"),
+            HTTPMediaType(type: "b", subType: "-", parameters: ["A": "a"]),
+            HTTPMediaType(type: "b", subType: "-", parameters: ["B": "b"]),
+        ]
+        
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "1")))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "2")))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "-", parameters: ["A": "a"])))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "b", subType: "3")))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "b", subType: "4")))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "b", subType: "-", parameters: ["A": "a"])))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "b", subType: "-", parameters: ["B": "b"])))
+        
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "2", parameters: ["A": "a"])))
+        
+        XCTAssertFalse(mediaSet.contains(HTTPMediaType(type: "a", subType: "3")))
+        XCTAssertFalse(mediaSet.contains(HTTPMediaType(type: "b", subType: "1")))
+        XCTAssertFalse(mediaSet.contains(HTTPMediaType(type: "c", subType: "1")))
+        XCTAssertFalse(mediaSet.contains(HTTPMediaType(type: "c", subType: "5")))
+        
+        /// These are currently allowed because `HTTPMediaType` current performs equality by ignoring the parameters, which we may not want in a set like this in the future. This does not currently impact anything, but leaving this note here in case a future version of Vapor would like to change the behavior to meet these expectations.
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "-")))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "-", parameters: ["A": "b"])))
+        XCTAssertTrue(mediaSet.contains(HTTPMediaType(type: "a", subType: "-", parameters: ["B": "b"])))
+    }
+    
+    func testCompressibleSample() {
+        let compressible = HTTPMediaTypeSet.compressible
+        XCTAssertTrue(compressible.contains(.html))
+        XCTAssertTrue(compressible.contains(.jsonAPI))
+        XCTAssertTrue(compressible.contains(.json))
+        XCTAssertTrue(compressible.contains(.svg))
+        XCTAssertTrue(compressible.contains(.formData))
+        
+        XCTAssertFalse(compressible.contains(.png))
+        XCTAssertFalse(compressible.contains(.mp3))
+        XCTAssertFalse(compressible.contains(.mpeg))
+        XCTAssertFalse(compressible.contains(.tar))
+        
+        XCTAssertFalse(compressible.contains(.any))
+    }
+    
+    func testIncompressibleSample() {
+        let incompressible = HTTPMediaTypeSet.incompressible
+        XCTAssertFalse(incompressible.contains(.html))
+        XCTAssertFalse(incompressible.contains(.jsonAPI))
+        XCTAssertFalse(incompressible.contains(.json))
+        XCTAssertFalse(incompressible.contains(.svg))
+        XCTAssertFalse(incompressible.contains(.formData))
+        
+        XCTAssertTrue(incompressible.contains(.png))
+        XCTAssertTrue(incompressible.contains(.mp3))
+        XCTAssertTrue(incompressible.contains(.mpeg))
+        XCTAssertTrue(incompressible.contains(.tar))
+        
+        XCTAssertFalse(incompressible.contains(.any))
+    }
+}


### PR DESCRIPTION
Added support for conditionally compressing responses based on content type or marker headers. This is necessary because some resource types, such as images, don't compress much, and end up maxing out CPU time on the thread and sometimes block the entire channel while they compress. This results in pipelined resources taking a long time to load even on fast connections.

This change comes with three knobs to control this:
- A global disabled/enabled by default state for the entire server.
- Allow and disallow lists of content types for automatic configurations.
- A marker header for explicitly configuring certain requests or routes to compress or not.

Notably, since the response compression handler now takes a predicate, it is always installed, and the predicate statelessly determines if a response should be compressed based on the server configuration:
- If a response compression configuration was never set, this continues to be a no-op and no compression will occur, though routes can now explicitly enable it as needed.
- If response compression is enabled, compression will be supported for all types except those that are known to be incompressible, fixing poor performance when there is no gain to be had by compressing resources.
- If any of the new permutations are used, the user gains more control over the process as needed.

This change relies on a feature recently added to [NIOExtras](https://github.com/apple/swift-nio-extras): https://github.com/apple/swift-nio-extras/pull/225