### PR TITLE
Raise error when the data expected an array but not parsed as array

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -357,6 +357,14 @@ private struct _Decoder: Decoder {
                         .split(omittingEmptySubsequences: false, whereSeparator: configuration.arraySeparators.contains)
                         .map { .urlEncoded(.init($0)) }
                 }
+
+                if self.values.isEmpty && !data.children.isEmpty {
+                    let context = DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Expected an array but could not parse the data as an array"
+                    )
+                    throw DecodingError.dataCorrupted(context)
+                }
             }
         }
         

--- a/Tests/VaporTests/URLEncodedFormTests.swift
+++ b/Tests/VaporTests/URLEncodedFormTests.swift
@@ -480,6 +480,13 @@ final class URLEncodedFormTests: XCTestCase {
         XCTAssertEqual(content["array"], [1, 2, 3])
     }
 
+    func testSparseArray() throws {
+        let data = """
+        array[0]=0&array[1]=1&array[3]=3
+        """
+        XCTAssertThrowsError(try URLEncodedFormDecoder().decode([String: [Int]].self, from: data))
+    }
+
     func testRawEnum() throws {
         enum PetType: String, Codable {
             case cat, dog


### PR DESCRIPTION
`URLEncodedFormDecoder` fails silently without throwing an error when attempting to decode data in the following pattern: `array[0]=0&array[1]=1&array[3]=3`. Now it is decoded as an empty array.
Typically, a decoder throws an error when data cannot be parsed as the expected structure, so I propose modifying the decoder to throw an error in this case as well.