### PR TITLE
Use Configured JSONEncoder in ErrorMiddleware

### DIFF
--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -49,6 +49,7 @@ public final class ErrorMiddleware: Middleware {
                 let encoder = try ContentConfiguration.global.requireEncoder(for: .json)
                 var byteBuffer = req.byteBufferAllocator.buffer(capacity: 0)
                 try encoder.encode(ErrorResponse(error: true, reason: reason), to: &byteBuffer, headers: &headers)
+                
                 body = .init(
                     buffer: byteBuffer,
                     byteBufferAllocator: req.byteBufferAllocator

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -46,11 +46,13 @@ public final class ErrorMiddleware: Middleware {
             // attempt to serialize the error to json
             let body: Response.Body
             do {
+                let encoder = try ContentConfiguration.global.requireEncoder(for: .json)
+                var byteBuffer = req.byteBufferAllocator.buffer(capacity: 0)
+                try encoder.encode(ErrorResponse(error: true, reason: reason), to: &byteBuffer, headers: &headers)
                 body = .init(
-                    buffer: try JSONEncoder().encodeAsByteBuffer(ErrorResponse(error: true, reason: reason), allocator: req.byteBufferAllocator),
+                    buffer: byteBuffer,
                     byteBufferAllocator: req.byteBufferAllocator
                 )
-                headers.contentType = .json
             } catch {
                 body = .init(string: "Oops: \(String(describing: error))\nWhile encoding error: \(reason)", byteBufferAllocator: req.byteBufferAllocator)
                 headers.contentType = .plainText

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -107,7 +107,12 @@ final class ErrorTests: XCTestCase {
         
         try app.test(.GET, "foo") { res in
             XCTAssertEqual(res.status, HTTPStatus.internalServerError)
-            XCTAssertEqual(res.body.string, "error=true&reason=Foo")
+            let option1 = "error=true&reason=Foo"
+            let option2 = "reason=Foo&error=true"
+            guard res.body.string == option1 || res.body.string == option2 else {
+                XCTFail("Response does not match")
+                return
+            }
         }
     }
 }

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -94,6 +94,22 @@ final class ErrorTests: XCTestCase {
             XCTAssertEqual(abort.reason, "After decode")
         })
     }
+    
+    func testErrorMiddlewareUsesContentConfiguration() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        app.get("foo") { req -> String in
+            throw Abort(.internalServerError, reason: "Foo")
+        }
+        
+        ContentConfiguration.global.use(encoder: URLEncodedFormEncoder(), for: .json)
+        
+        try app.test(.GET, "foo") { res in
+            XCTAssertEqual(res.status, HTTPStatus.internalServerError)
+            XCTAssertEqual(res.body.string, "error=true&reason=Foo")
+        }
+    }
 }
 
 func XCTAssertContains(

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -114,6 +114,9 @@ final class ErrorTests: XCTestCase {
                 return
             }
         }
+        
+        // Clean up
+        ContentConfiguration.global.use(encoder: JSONEncoder(), for: .json)
     }
 }
 


### PR DESCRIPTION
Use the prescribed content encoder for the body of `ErrorMiddleware` instead of a contained `JSONEncoder` that can't be overridden.

You can set the encoder with

```swift
ContentConfiguration.global.use(encoder: myCustomEncoder, for: .json)
```

Resolves #3218 