### PR TITLE
Throw an error if unkeyed container is at end

### DIFF
--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -367,6 +367,14 @@ private struct _Decoder: Decoder {
         mutating func decode<T: Decodable>(_: T.Type) throws -> T {
             defer { self.currentIndex += 1 }
             
+            guard !isAtEnd else {
+                let context = DecodingError.Context(
+                    codingPath: self.codingPath,
+                    debugDescription: "Unkeyed container is at end."
+                )
+                throw DecodingError.valueNotFound(T.self, context)
+            }
+            
             if self.allChildKeysAreNumbers {
                 // We can force-unwrap because we already checked data.allChildKeysAreNumbers in the initializer.
                 let childData = self.data.children[String(self.currentIndex)]!

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -338,4 +338,26 @@ final class QueryTests: XCTestCase {
         XCTAssertFalse(try req.query.decode(BarStruct.self).bar)
         XCTAssertNil(try req.query.decode(OptionalBarStruct.self).bar)
     }
+    
+    func testNotCrashingWhenUnkeyedContainerIsAtEnd() {
+        struct Query: Decodable {
+            let closedRange: ClosedRange<Double>
+        }
+        
+        let app = Application()
+        defer { app.shutdown() }
+        
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        request.headers.contentType = .json
+        request.url.path = "/"
+        request.url.query = "closedRange=1"
+        
+        XCTAssertThrowsError(try request.query.decode(Query.self)) { error in
+            if case .valueNotFound(_, let context) = error as? DecodingError {
+                XCTAssertEqual(context.debugDescription, "Unkeyed container is at end.")
+            } else {
+                XCTFail("Caught error \"\(error)\", but not the expected: \"DecodingError.valueNotFound\"")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Throwing an error if the unkeyed container is at end while decoding query params fixes the crash mentioned with this issue:
https://github.com/vapor/vapor/issues/3217

The error being thrown is `DecodingError.valueNotFound` and it's matching the error thrown by `JSONDecoder`.
