### PR TITLE
Add response order pipelining test

### DIFF
--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -331,7 +331,7 @@ final class PipelineTests: XCTestCase {
 
         try await channel.writeInbound(ByteBuffer(string: "GET /sleep/100 HTTP/1.1\r\n\r\nGET /sleep/0 HTTP/1.1\r\n\r\n"))
 
-        // We expect 6 responses to be there, however if there are less
+        // We expect 6 writes to be there - three parts (the head, body and separator for each request). However, if there are less
         // we need to have a timeout to avoid hanging the test
         let deadline = NIODeadline.now() + .milliseconds(200)
         var responses: [String] = []

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -382,7 +382,8 @@ final class PipelineTests: XCTestCase {
             var sleeps = 0
             for try await chunk in inbound {
                 data.writeImmutableBuffer(chunk)
-                data.writeImmutableBuffer(ByteBuffer(string: "\r\n"))
+                data.writeString("\r\n")
+                
                 if String(decoding: chunk.readableBytesView, as: UTF8.self).components(separatedBy: "\r\n").contains(where: { $0.hasPrefix("slept") }) {
                     sleeps += 1
                 }

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -1,10 +1,11 @@
 @testable import Vapor
-import enum NIOHTTP1.HTTPParserError
+import NIOHTTP1
 import XCTest
 import AsyncHTTPClient
 import NIOEmbedded
 import NIOCore
 import NIOConcurrencyHelpers
+import class NIOPosix.ClientBootstrap
 
 final class PipelineTests: XCTestCase {
     var app: Application!
@@ -348,6 +349,52 @@ final class PipelineTests: XCTestCase {
         XCTAssertEqual(responses.count, 2)
         XCTAssertEqual(responses[0], "slept 100ms")
         XCTAssertEqual(responses[1], "slept 0ms")
+    }
+
+    func testCorrectResponseOrderOverVaporTCP() async throws {
+        app.get("sleep", ":ms") { req -> String in
+            let ms = try req.parameters.require("ms", as: Int64.self)
+            try await Task.sleep(for: .milliseconds(ms))
+            return "slept \(ms)ms"
+        }
+
+        app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
+        try await app.startup()
+
+        let channel = try await ClientBootstrap(group: app.eventLoopGroup)
+            .connect(host: "127.0.0.1", port: app.http.server.configuration.port) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try NIOAsyncChannel(
+                        wrappingChannelSynchronously: channel,
+                        configuration: NIOAsyncChannel.Configuration(
+                            inboundType: ByteBuffer.self,
+                            outboundType: ByteBuffer.self
+                        )
+                    )
+                }
+            }
+
+        _ = try await channel.executeThenClose { inbound, outbound in
+            try await outbound.write(ByteBuffer(string: "GET /sleep/100 HTTP/1.1\r\n\r\nGET /sleep/0 HTTP/1.1\r\n\r\n"))
+
+            var data = ByteBuffer()
+            var sleeps = 0
+            for try await chunk in inbound {
+                data.writeImmutableBuffer(chunk)
+                data.writeImmutableBuffer(ByteBuffer(string: "\r\n"))
+                if String(decoding: chunk.readableBytesView, as: UTF8.self).components(separatedBy: "\r\n").contains(where: { $0.hasPrefix("slept") }) {
+                    sleeps += 1
+                }
+                if sleeps == 2 {
+                    break
+                }
+            }
+
+            let sleptLines = String(decoding: data.readableBytesView, as: UTF8.self).components(separatedBy: "\r\n").filter { $0.contains("slept") }
+            XCTAssertEqual(sleptLines, ["slept 100ms", "slept 0ms"])
+            return sleptLines
+        }
     }
 
     override class func setUp() {

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -1,5 +1,5 @@
 @testable import Vapor
-import NIOHTTP1
+import enum NIOHTTP1.HTTPParserError
 import XCTest
 import AsyncHTTPClient
 import NIOEmbedded


### PR DESCRIPTION
This adds a test which makes sure that Vapor conforms to the pipelining spec by returning responses in the order they were made rather than the processing order