### PR TITLE
Test MUSL and iOS compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     with:
       with_tsan: false
       with_musl: true
-      extra_musl_flags: --product Vapor
+      extra_musl_flags: --target Vapor
     secrets: inherit
 
   test-parallel:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
       with_tsan: false
       with_musl: true
       extra_musl_flags: --target Vapor
+      ios_xcodebuild_action: ''
+      ios_scheme_name: Vapor
     secrets: inherit
 
   test-parallel:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_tsan: false
+      with_musl: true
+      extra_musl_flags: --product Vapor
     secrets: inherit
 
   test-parallel:
@@ -52,18 +54,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Run tests
         run: swift test --parallel
-
-  test-musl:
-    if: ${{ !(github.event.pull_request.draft || false) }}
-    runs-on: ubuntu-latest
-    container: swift:6.0
-    steps:
-      - name: Check out Vapor
-        uses: actions/checkout@v4
-      - name: Install SDK
-        run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
-      - name: Build
-        run: swift build --swift-sdk x86_64-swift-linux-musl
 
   run-codeql: 
     if: ${{ !(github.event.pull_request.draft || false) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,18 @@ jobs:
       - name: Run tests
         run: swift test --parallel
 
+  test-musl:
+    if: ${{ !(github.event.pull_request.draft || false) }}
+    runs-on: ubuntu-latest
+    container: swift:6.0
+    steps:
+      - name: Check out Vapor
+        uses: actions/checkout@v4
+      - name: Install SDK
+        run: swift sdk install https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
+      - name: Build
+        run: swift build --swift-sdk x86_64-swift-linux-musl
+
   run-codeql: 
     if: ${{ !(github.event.pull_request.draft || false) }}
     permissions: { security-events: write, packages: read, actions: read, contents: read }

--- a/Package.swift
+++ b/Package.swift
@@ -119,6 +119,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIOTestUtils", package: "swift-nio"),
                 .target(name: "XCTVapor"),
+                "Vapor",
             ],
             resources: [
                 .copy("Utilities/foo.txt"),


### PR DESCRIPTION
Adds a CI step to ensure Vapor compiles with MUSL and iOS

@gwynne should we just add this to vapor/ci behind a flag so any package can opt in?