### PR TITLE
Omit ACAO header instead of empty value

### DIFF
--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -139,7 +139,10 @@ public final class CORSMiddleware: Middleware {
             // Modify response headers based on CORS settings
             let originBasedAccessControlAllowHeader = self.configuration.allowedOrigin.header(forRequest: request)
             response.responseBox.withLockedValue { box in
-                box.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: originBasedAccessControlAllowHeader)
+                if !originBasedAccessControlAllowHeader.isEmpty {
+                    box.headers.replaceOrAdd(name: .accessControlAllowOrigin, value: originBasedAccessControlAllowHeader)
+                }
+
                 box.headers.replaceOrAdd(name: .accessControlAllowHeaders, value: self.configuration.allowedHeaders)
                 box.headers.replaceOrAdd(name: .accessControlAllowMethods, value: self.configuration.allowedMethods)
                 

--- a/Tests/VaporTests/AsyncMiddlewareTests.swift
+++ b/Tests/VaporTests/AsyncMiddlewareTests.swift
@@ -100,7 +100,7 @@ final class AsyncMiddlewareTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "done")
             XCTAssertEqual(res.headers[.vary], [])
-            XCTAssertEqual(res.headers[.accessControlAllowOrigin], [""])
+            XCTAssertEqual(res.headers[.accessControlAllowOrigin], [])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], [""])
         }
     }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -105,7 +105,7 @@ final class MiddlewareTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             XCTAssertEqual(res.body.string, "done")
             XCTAssertEqual(res.headers[.vary], [])
-            XCTAssertEqual(res.headers[.accessControlAllowOrigin], [""])
+            XCTAssertEqual(res.headers[.accessControlAllowOrigin], [])
             XCTAssertEqual(res.headers[.accessControlAllowHeaders], [""])
         }
     }


### PR DESCRIPTION
_For context, Vapor currently sends an empty Access-Control-Allow-Origin (ACAO) header when the origin does not match or is set to none._

We recently had a pentest done against our Vapor server and the tester reported the following regarding the empty ACAO header:

> When the header is empty, browsers might reject the request without detailed error messages, making it harder for developers to debug or even realize there is a problem. This lack of transparency can lead to extended periods of vulnerability before the issue is discovered.

Looking at some other sources as well, an empty header doesn't appear to be a valid value and so could result in unexpected behaviour.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers
https://fetch.spec.whatwg.org/#http-access-control-allow-origin