### PR TITLE
sessionID but customizable

### DIFF
--- a/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
+++ b/Sources/Vapor/Concurrency/AsyncSessionDriver.swift
@@ -4,17 +4,17 @@ import NIOCore
 ///
 /// This is an async version of `SessionDriver`
 public protocol AsyncSessionDriver: SessionDriver {
-    func createSession(_ data: SessionData, for request: Request) async throws -> SessionID
+    func createSession(_ sessionID: SessionID?, _ data: SessionData, for request: Request) async throws -> SessionID
     func readSession(_ sessionID: SessionID, for request: Request) async throws -> SessionData?
     func updateSession(_ sessionID: SessionID, to data: SessionData, for request: Request) async throws -> SessionID
     func deleteSession(_ sessionID: SessionID, for request: Request) async throws
 }
 
 extension AsyncSessionDriver {
-    public func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
+  public func createSession(_ sessionID: SessionID? = nil, _ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
         let promise = request.eventLoop.makePromise(of: SessionID.self)
         promise.completeWithTask {
-            try await self.createSession(data, for: request)
+            try await self.createSession(sessionID, data, for: request)
         }
         return promise.futureResult
     }

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -33,10 +33,11 @@ public struct MemorySessions: SessionDriver, Sendable {
     }
 
     public func createSession(
+        _ sessionID: SessionID? = nil,
         _ data: SessionData,
         for request: Request
     ) -> EventLoopFuture<SessionID> {
-        let sessionID = self.generateID()
+        let sessionID = sessionID ?? self.generateID()
         self.storage.queue.sync {
             self.storage.sessions[sessionID] = data
         }

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -3,6 +3,7 @@ import NIOCore
 /// Capable of managing CRUD operations for `Session`s.
 public protocol SessionDriver: Sendable {
     func createSession(
+        _ sessionID: SessionID?,
         _ data: SessionData,
         for request: Request
     ) -> EventLoopFuture<SessionID>

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -71,7 +71,7 @@ public final class SessionsMiddleware: Middleware {
                 createOrUpdate = self.session.updateSession(id, to: session.data, for: request)
             } else {
                 // No cookie, this is a new session.
-                createOrUpdate = self.session.createSession(session.data, for: request)
+                createOrUpdate = self.session.createSession(nil, session.data, for: request)
             }
 
             // After create or update, set cookie on the response.

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -29,7 +29,7 @@ final class SessionTests: XCTestCase {
                 self.ops = []
             }
 
-            func createSession(_ data: SessionData, for request: Request) async throws -> SessionID {
+            func createSession(_ sessionID: SessionID? = nil, _ data: SessionData, for request: Request) async throws -> SessionID {
                 self.ops.append("create \(data)")
                 return .init(string: "a")
             }


### PR DESCRIPTION
for monitoring purposes coinciding with ID's from
third party services. the capability to determine the sessionID beforehand is crucial.

* extend function member with optional sessionID
* default value provided for add cookie function

a custom session middleware will be necessary to customize sessionID accordingly. default behaviour is not affected.
