### PR TITLE
Adds Support for Tracing Header Extraction

### DIFF
--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -7,10 +7,15 @@ public final class TracingMiddleware: AsyncMiddleware {
     private let setCustomAttributes: @Sendable (inout SpanAttributes, Request) -> Void
     
     /// Create a TracingMiddleware
+    public init() {
+        self.setCustomAttributes = { _, _ in }
+    }
+    
+    /// Create a TracingMiddleware
     /// - Parameter setCustomAttributes: Closure that allows setting custom span attributes for a particular request. A custom span attribute could be extracted from a request
     /// header, for example. This closure is called during span creation on every request, so should be lightweight.
     public init(
-        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in }
+        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void
     ) {
         self.setCustomAttributes = setCustomAttributes
     }

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -4,7 +4,16 @@ import Tracing
 ///
 /// See https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 public final class TracingMiddleware: AsyncMiddleware {
-    public init() {}
+    private let setCustomAttributes: @Sendable (inout SpanAttributes, Request) -> Void
+    
+    /// Create a TracingMiddleware
+    /// - Parameter setCustomAttributes: Closure that allows setting custom span attributes for a particular request. A custom span attribute could be extracted from a request
+    /// header, for example. This closure is called during span creation on every request, so should be lightweight.
+    public init(
+        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in }
+    ) {
+        self.setCustomAttributes = setCustomAttributes
+    }
     
     public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
         let parentContext = request.serviceContext
@@ -49,6 +58,9 @@ public final class TracingMiddleware: AsyncMiddleware {
                 attributes["network.peer.port"] = request.remoteAddress?.port
                 attributes["network.protocol.version"] = "\(request.version.major).\(request.version.minor)"
                 attributes["user_agent.original"] = request.headers[.userAgent].first
+                
+                // Custom defined
+                setCustomAttributes(&attributes, request)
             }
             let response = try await next.respond(to: request)
             

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -178,10 +178,10 @@ final class MiddlewareTests: XCTestCase {
         try await app.testable(method: .running(hostname: "127.0.0.1", port: 8080)).test(
             .GET,
             "/testTracing?foo=bar",
-            beforeRequest: { request in
+            beforeRequest: { request async in
                 request.headers.add(name: HTTPHeaders.Name.userAgent.description, value: "test")
             },
-            afterResponse: { response in
+            afterResponse: { response async in
                 XCTAssertEqual(response.status, .ok)
                 XCTAssertEqual(response.body.string, "done")
             }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -159,7 +159,9 @@ final class MiddlewareTests: XCTestCase {
         }
         
         app.grouped(
-            TracingMiddleware()
+            TracingMiddleware() { attributes, _ in
+                attributes["custom"] = "custom"
+            }
         ).grouped(
             TestServiceContextMiddleware()
         ).get("testTracing") { req -> String in
@@ -203,6 +205,8 @@ final class MiddlewareTests: XCTestCase {
         XCTAssertNotNil(span.attributes["network.peer.port"]?.toSpanAttribute())
         XCTAssertEqual(span.attributes["network.protocol.version"]?.toSpanAttribute(), "1.1")
         XCTAssertEqual(span.attributes["user_agent.original"]?.toSpanAttribute(), "test")
+        
+        XCTAssertEqual(span.attributes["custom"]?.toSpanAttribute(), "custom")
         
         XCTAssertEqual(span.attributes["http.response.status_code"]?.toSpanAttribute(), 200)
     }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -167,6 +167,8 @@ final class MiddlewareTests: XCTestCase {
         ).get("testTracing") { req -> String in
             // Validates that TracingMiddleware sets the serviceContext
             XCTAssertNotNil(req.serviceContext)
+            // Validates that TracingMiddleware exposes header extraction to backend
+            XCTAssertEqual(req.serviceContext.extracted, "extracted")
             // Validates that the span's service context is propagated into the
             // Task.local storage of the responder closure, thereby ensuring that
             // spans created in the closure are nested under the request span.
@@ -180,6 +182,7 @@ final class MiddlewareTests: XCTestCase {
             "/testTracing?foo=bar",
             beforeRequest: { request async in
                 request.headers.add(name: HTTPHeaders.Name.userAgent.description, value: "test")
+                request.headers.add(name: TestTracer.extractKey, value: "extracted")
             },
             afterResponse: { response async in
                 XCTAssertEqual(response.status, .ok)

--- a/Tests/VaporTests/Utilities/TestTracer.swift
+++ b/Tests/VaporTests/Utilities/TestTracer.swift
@@ -3,6 +3,7 @@ import Tracing
 final class TestTracer: Tracer {
     typealias Span = TestSpan
     
+    static let extractKey = "to-extract"
     var spans: [TestSpan] = []
     
     func startSpan(
@@ -27,6 +28,7 @@ final class TestTracer: Tracer {
     }
     
     func extract<Carrier, Extract>(_ carrier: Carrier, into context: inout ServiceContextModule.ServiceContext, using extractor: Extract) where Carrier == Extract.Carrier, Extract : Instrumentation.Extractor {
+        context.extracted = extractor.extract(key: Self.extractKey, from: carrier)
         return
     }
     
@@ -72,3 +74,17 @@ final class TestSpan: Span {
 
 extension TestTracer: @unchecked Sendable {}
 extension TestSpan: @unchecked Sendable {}
+
+extension ServiceContext {
+    var extracted: String? {
+        get {
+            self[ExtractedKey.self]
+        } set {
+            self[ExtractedKey.self] = newValue
+        }
+    }
+    
+    private enum ExtractedKey: ServiceContextKey {
+        typealias Value = String
+    }
+}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

This adds header extraction support for tracing backends as described in [this document](https://swiftpackageindex.com/apple/swift-distributed-tracing/main/documentation/tracing/instrumentyourlibrary#Handling-inbound-requests). In the context of OTEL, this is used to correlate trace data across the HTTP boundary by passing the `traceparent` and `tracestate` header, as [documented here](https://www.w3.org/TR/trace-context/#header-name) and implemented in the [swift-otel package here](https://github.com/swift-otel/swift-otel/blob/main/Sources/OTel/Tracing/Propagating/OTelW3CPropagator.swift).

It also adds a closure to `TracingMiddleware` that allows users to set custom span metadata on requests.

Finally, it fixes a few warnings caused by the MiddlewareTest function introduced in https://github.com/vapor/vapor/pull/3253

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
