### PR TITLE
Android support

### DIFF
--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -2,6 +2,8 @@
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Darwin.C
 #endif

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -2,6 +2,8 @@
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #else
 import Darwin
 #endif

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -7,6 +7,8 @@ import Glibc
 #else
 @preconcurrency import Glibc
 #endif
+#elseif canImport(Android)
+@preconcurrency import Android
 #elseif canImport(Musl)
 @preconcurrency import Musl
 #elseif canImport(WinSDK)

--- a/Sources/Vapor/Utilities/String+IsIPAddress.swift
+++ b/Sources/Vapor/Utilities/String+IsIPAddress.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Android)
+import Android
+#endif
 
 extension String {
     func isIPAddress() -> Bool {

--- a/Sources/VaporTesting/+TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/+TestingHTTPResponse.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 import Testing
 
 public func expectContent<D>(

--- a/Sources/VaporTesting/TestingApplicationTester.swift
+++ b/Sources/VaporTesting/TestingApplicationTester.swift
@@ -1,6 +1,6 @@
 import NIOHTTP1
 import NIOCore
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 import Testing
 #endif
 
@@ -27,7 +27,7 @@ extension Application: TestingApplicationTester {
     }
 }
 
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 extension TestingApplicationTester {
     @discardableResult
     public func test(

--- a/Sources/VaporTesting/VaporTestingContext.swift
+++ b/Sources/VaporTesting/VaporTestingContext.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 import Testing
 
 public enum VaporTestingContext {

--- a/Sources/XCTVapor/XCTVaporContext.swift
+++ b/Sources/XCTVapor/XCTVaporContext.swift
@@ -1,9 +1,9 @@
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 import Testing
 #endif
 
 public enum XCTVaporContext {
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
     @TaskLocal public static var emitWarningIfCurrentTestInfoIsAvailable: Bool?
 #endif
 
@@ -14,7 +14,7 @@ public enum XCTVaporContext {
         file: StaticString,
         line: UInt
     ) {
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
         let shouldWarn = XCTVaporContext.emitWarningIfCurrentTestInfoIsAvailable ?? true
         var isInSwiftTesting: Bool { Test.current != nil }
         if shouldWarn, isInSwiftTesting {

--- a/Tests/VaporTests/AsyncCacheTests.swift
+++ b/Tests/VaporTests/AsyncCacheTests.swift
@@ -2,6 +2,9 @@ import XCTVapor
 import XCTest
 import Vapor
 import NIOCore
+#if canImport(Android)
+import func Android.sleep
+#endif
 
 final class AsyncCacheTests: XCTestCase {
     var app: Application!

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -3,6 +3,9 @@ import XCTest
 import Vapor
 import NIOCore
 import NIOPosix
+#if canImport(Android)
+import func Android.sleep
+#endif
 
 final class AuthenticationTests: XCTestCase {
     func testBearerAuthenticator() throws {

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -2,6 +2,9 @@ import XCTVapor
 import XCTest
 import Vapor
 import NIOCore
+#if canImport(Android)
+import func Android.sleep
+#endif
 
 final class CacheTests: XCTestCase {
     func testInMemoryCache() throws {

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -2,6 +2,9 @@ import XCTVapor
 import XCTest
 import Vapor
 import NIOCore
+#if canImport(Android)
+import func Android.sleep
+#endif
 
 final class EndpointCacheTests: XCTestCase {
     

--- a/Tests/VaporTests/VaporTesting.swift
+++ b/Tests/VaporTests/VaporTesting.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0)
+#if compiler(>=6.0) && canImport(Testing)
 import VaporTesting
 import Testing
 


### PR DESCRIPTION
This PR adds experimental support for building and testing on Android. It simply involves adding some conditional imports.

Building is contingent on https://github.com/apple/swift-distributed-tracing/pull/163, https://github.com/apple/swift-http-structured-headers/pull/57, https://github.com/swift-server/async-http-client/pull/799, and https://github.com/apple/swift-nio-extras/pull/244, but if you use local snapshots of those packages, you can build with the [Android SDK](https://github.com/finagolfin/swift-android-sdk) using:

```
~/Library/Developer/Toolchains/swift-6.0.3-RELEASE.xctoolchain/usr/bin/swift build --swift-sdk aarch64-unknown-linux-android24 --build-tests
```