### PR TITLE
Fix warnings from NIO 2.79.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.79.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/routing-kit.git", from: "4.9.0"),
 
         // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.77.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.79.0"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -124,6 +124,7 @@ public final class Application: Sendable {
     private let _locks: NIOLockedValueBox<Locks>
     
     @available(*, noasync, message: "This initialiser cannot be used in async contexts, use Application.make(_:_:) instead")
+    @available(*, deprecated, message: "Migrate to using the async APIs. Use use Application.make(_:_:) instead")
     public convenience init(
         _ environment: Environment = .development,
         _ eventLoopGroupProvider: EventLoopGroupProvider = .singleton

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -28,7 +28,7 @@ extension Environment {
     ///
     /// - Important: Do _not_ use `.wait()` if loading a secret at any time after the app has booted, such as while
     ///   handling a `Request`. Chain the result as you would any other future instead.
-    @available(*, deprecated, message: "Use an async version of load instead")
+    @available(*, deprecated, message: "Use an async version of secret instead")
     public static func secret(key: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
         guard let filePath = self.get(key) else {
             return eventLoop.future(nil)
@@ -47,7 +47,7 @@ extension Environment {
     /// - Returns:
     ///   - On success, a succeeded future with the loaded content of the file.
     ///   - On any kind of error, a succeeded future with a value of `nil`. It is not currently possible to get error details.
-    @available(*, deprecated, message: "Use an async version of load instead")
+    @available(*, deprecated, message: "Use an async version of secret instead")
     public static func secret(path: String, fileIO: NonBlockingFileIO, on eventLoop: EventLoop) -> EventLoopFuture<String?> {
         return fileIO
             .openFile(path: path, eventLoop: eventLoop)
@@ -86,5 +86,32 @@ extension Environment {
         } catch {
             return nil
         }
+    }
+
+    /// Reads a file's content for a secret. The secret key is the name of the environment variable that is expected to
+    /// specify the path of the file containing the secret.
+    ///
+    /// - Parameters:
+    ///   - key: The environment variable name
+    ///   - fileIO: `NonBlockingFileIO` handler provided by NIO
+    ///   - eventLoop: `EventLoop` for NIO to use for working with the file
+    ///
+    /// Example usage:
+    ///
+    /// ````
+    /// func configure(_ app: Application) async throws {
+    ///     // ...
+    ///
+    ///     let databasePassword = try await Environment.secret(key: "DATABASE_PASSWORD_FILE")
+    ///
+    /// ````
+    ///
+    /// - Important: Do _not_ use `.wait()` if loading a secret at any time after the app has booted, such as while
+    ///   handling a `Request`. Chain the result as you would any other future instead.
+    public static func secret(key: String) async throws -> String? {
+        guard let filePath = self.get(key) else {
+            return nil
+        }
+        return try await self.secret(path: filePath)
     }
 }

--- a/Sources/Vapor/Environment/Environment+Secret.swift
+++ b/Sources/Vapor/Environment/Environment+Secret.swift
@@ -93,8 +93,6 @@ extension Environment {
     ///
     /// - Parameters:
     ///   - key: The environment variable name
-    ///   - fileIO: `NonBlockingFileIO` handler provided by NIO
-    ///   - eventLoop: `EventLoop` for NIO to use for working with the file
     ///
     /// Example usage:
     ///
@@ -105,9 +103,6 @@ extension Environment {
     ///     let databasePassword = try await Environment.secret(key: "DATABASE_PASSWORD_FILE")
     ///
     /// ````
-    ///
-    /// - Important: Do _not_ use `.wait()` if loading a secret at any time after the app has booted, such as while
-    ///   handling a `Request`. Chain the result as you would any other future instead.
     public static func secret(key: String) async throws -> String? {
         guard let filePath = self.get(key) else {
             return nil

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -29,14 +29,14 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
         self.httpHandlers = httpHandlers
     }
     
-    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) throws {
         let req = self.unwrapInboundIn(data)
         
         // check if request is upgrade
         let connectionHeaders = Set(req.headers[canonicalForm: "connection"].map { $0.lowercased() })
         if connectionHeaders.contains("upgrade") {
             let buffer = UpgradeBufferHandler()
-            _ = context.channel.pipeline.addHandler(buffer, position: .before(self.httpRequestDecoder))
+            _ = try context.channel.pipeline.syncOperations.addHandler(buffer, position: .before(self.httpRequestDecoder))
             self.upgradeState = .pending(req, buffer)
         }
         
@@ -88,19 +88,21 @@ final class HTTPServerUpgradeHandler: ChannelDuplexHandler, RemovableChannelHand
                     let sendableBox = box.value
                     let handlers: [RemovableChannelHandler] = [sendableBox.handler] + sendableBox.handler.httpHandlers
                     return .andAllComplete(handlers.map { handler in
-                        return sendableBox.context.pipeline.removeHandler(handler)
+                        sendableBox.context.pipeline.syncOperations.removeHandler(handler)
                     }, on: box.value.context.eventLoop)
                 }.flatMap {
                     let sendableBox = box.value
                     return sendableBox.protocolUpgrader.upgrade(context: sendableBox.context, upgradeRequest: head)
                 }.flatMap {
                     let sendableBox = box.value
-                    return sendableBox.context.pipeline.removeHandler(sendableBox.buffer)
+                    return sendableBox.context.eventLoop.makeCompletedFuture {
+                        sendableBox.context.pipeline.syncOperations.removeHandler(sendableBox.buffer)
+                    }
                 }.cascadeFailure(to: promise)
             } else {
                 // reset handlers
                 self.upgradeState = .ready
-                context.channel.pipeline.removeHandler(buffer, promise: nil)
+                context.channel.pipeline.syncOperations.removeHandler(buffer, promise: nil)
                 context.write(self.wrapOutboundOut(res), promise: promise)
             }
         case .ready, .upgraded:

--- a/Sources/Vapor/Utilities/DotEnv.swift
+++ b/Sources/Vapor/Utilities/DotEnv.swift
@@ -45,6 +45,7 @@ public struct DotEnvFile: Sendable {
     ///     - fileio: NonBlockingFileIO that is used to read the .env file(s).
     ///     - logger: Optionally provide an existing logger.
     @available(*, noasync, message: "Use an async version of load instead")
+    @available(*, deprecated, message: "Use an async version of load instead")
     public static func load(
         for environment: Environment = .development,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,
@@ -93,6 +94,7 @@ public struct DotEnvFile: Sendable {
     ///     - fileio: NonBlockingFileIO that is used to read the .env file(s).
     ///     - logger: Optionally provide an existing logger.
     @available(*, noasync, message: "Use an async version of load instead")
+    @available(*, deprecated, message: "Use an async version of load instead")
     public static func load(
         path: String,
         on eventLoopGroupProvider: Application.EventLoopGroupProvider = .singleton,

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -447,13 +447,15 @@ public struct FileIO: Sendable {
     ///     let data = ByteBuffer(string: "ByteBuffer")
     ///     try await req.fileio.writeFile(data, at: "/path/to/file.txt")
     ///
+    /// **WARNING**: this will overwrite the file if it already exists.
+    ///
     /// - parameters:
     ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.
     /// - returns: `Void` when the file write is finished.
     public func writeFile(_ buffer: ByteBuffer, at path: String) async throws {
         // This returns the number of bytes written which we don't need
-        _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: false)) { handle in
+        _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: true)) { handle in
             try await handle.write(contentsOf: buffer, toAbsoluteOffset: 0)
         }
     }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -332,7 +332,7 @@ public struct FileIO: Sendable {
     /// - Parameters:
     ///   - path: The file's path.
     ///   - lastModified: When the file was last modified.
-    /// - Returns: An `EventLoopFuture<String>` which holds the ETag.
+    /// - Returns: A `String` which holds the ETag.
     private func generateETagHash(path: String, lastModified: Date) async throws -> String {
         if let hash = request.application.storage[FileMiddleware.ETagHashes.self]?[path], hash.lastModified == lastModified {
             return hash.digestHex
@@ -411,7 +411,7 @@ public struct FileIO: Sendable {
     ///        print("chunk: \(data)")
     ///    }
     ///
-    ///    **Warning** it's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
+    ///    > Warning: It's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
     ///
     /// - parameters:
     ///     - path: Path to file on the disk.

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -411,11 +411,13 @@ public struct FileIO: Sendable {
     ///        print("chunk: \(data)")
     ///    }
     ///
-    ///    > Warning: It's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
+    /// > Warning: It's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
     ///
     /// - parameters:
     ///     - path: Path to file on the disk.
     ///     - chunkSize: Maximum size for the file data chunks.
+    ///     - offset: The offset to start reading from.
+    ///     - byteCount: The number of bytes to read from the file. If `nil`, the file will be read to the end.
     /// - returns: `FileChunks` containing the file data chunks.
     public func readFile(
         at path: String,
@@ -450,8 +452,8 @@ public struct FileIO: Sendable {
     /// > Warning: This method will overwrite the file if it already exists.
     ///
     /// - parameters:
-    ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.
+    ///     - path: Path to file on the disk.
     public func writeFile(_ buffer: ByteBuffer, at path: String) async throws {
         // This returns the number of bytes written which we don't need
         _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: true)) { handle in

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -447,12 +447,11 @@ public struct FileIO: Sendable {
     ///     let data = ByteBuffer(string: "ByteBuffer")
     ///     try await req.fileio.writeFile(data, at: "/path/to/file.txt")
     ///
-    /// **WARNING**: this will overwrite the file if it already exists.
+    /// > Warning: This method will overwrite the file if it already exists.
     ///
     /// - parameters:
     ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.
-    /// - returns: `Void` when the file write is finished.
     public func writeFile(_ buffer: ByteBuffer, at path: String) async throws {
         // This returns the number of bytes written which we don't need
         _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: true)) { handle in

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -69,6 +69,7 @@ public struct FileIO: Sendable {
     /// - parameters:
     ///     - path: Path to file on the disk.
     /// - returns: `Future` containing the file data as a `ByteBuffer`.
+    @available(*, deprecated, message: "Migrate to async API")
     public func collectFile(at path: String) -> EventLoopFuture<ByteBuffer> {
         let dataWrapper: NIOLockedValueBox<ByteBuffer> = .init(self.allocator.buffer(capacity: 0))
         return self.readFile(at: path) { new in
@@ -89,6 +90,7 @@ public struct FileIO: Sendable {
     ///     - chunkSize: Maximum size for the file data chunks.
     ///     - onRead: Closure to be called sequentially for each file data chunk.
     /// - returns: `Future` that will complete when the file read is finished.
+    @available(*, deprecated, message: "Migrate to async API")
     @preconcurrency public func readFile(
         at path: String,
         chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
@@ -123,6 +125,7 @@ public struct FileIO: Sendable {
     ///     - mediaType: HTTPMediaType, if not specified, will be created from file extension.
     ///     - onCompleted: Closure to be run on completion of stream.
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.
+    @available(*, deprecated, message: "Migrate to asyncStreamFile")
     @preconcurrency public func streamFile(
         at path: String,
         chunkSize: Int = NonBlockingFileIO.defaultChunkSize,
@@ -256,6 +259,7 @@ public struct FileIO: Sendable {
 
     /// Private read method. `onRead` closure uses ByteBuffer and expects future return.
     /// There may be use in publicizing this in the future for reads that must be async.
+    @available(*, deprecated, message: "Migrate to the async API for this")
     private func read(
         path: String,
         fromOffset offset: Int64,
@@ -293,11 +297,9 @@ public struct FileIO: Sendable {
         fromOffset offset: Int64,
         byteCount: Int
     ) async throws -> ByteBuffer {
-        let fd = try NIOFileHandle(path: path)
-        defer {
-            try? fd.close()
+        return try await FileSystem.shared.withFileHandle(forReadingAt: .init(path)) { handle in
+            return try await handle.readChunk(fromAbsoluteOffset: offset, length: .bytes(Int64(byteCount)))
         }
-        return try await self.io.read(fileHandle: fd, fromOffset: offset, byteCount: byteCount, allocator: allocator)
     }
     
     /// Write the contents of buffer to a file at the supplied path.
@@ -309,6 +311,7 @@ public struct FileIO: Sendable {
     ///     - path: Path to file on the disk.
     ///     - buffer: The `ByteBuffer` to write.
     /// - returns: `Future` that will complete when the file write is finished.
+    @available(*, deprecated, message: "Migrate to the async API for this")
     public func writeFile(_ buffer: ByteBuffer, at path: String) -> EventLoopFuture<Void> {
         self.request.eventLoop.flatSubmit {
             do {
@@ -330,16 +333,17 @@ public struct FileIO: Sendable {
     ///   - path: The file's path.
     ///   - lastModified: When the file was last modified.
     /// - Returns: An `EventLoopFuture<String>` which holds the ETag.
-    private func generateETagHash(path: String, lastModified: Date) -> EventLoopFuture<String> {
+    private func generateETagHash(path: String, lastModified: Date) async throws -> String {
         if let hash = request.application.storage[FileMiddleware.ETagHashes.self]?[path], hash.lastModified == lastModified {
-            return request.eventLoop.makeSucceededFuture(hash.digestHex)
+            return hash.digestHex
         } else {
-            return collectFile(at: path).map { buffer in
+            return try await FileSystem.shared.withFileHandle(forReadingAt: .init(path)) { handle in
+                let buffer = try await handle.readToEnd(maximumSizeAllowed: .bytes(.max))
                 let digest = SHA256.hash(data: buffer.readableBytesView)
-                
+
                 // update hash in dictionary
                 request.application.storage[FileMiddleware.ETagHashes.self]?[path] = FileMiddleware.ETagHashes.FileHash(lastModified: lastModified, digestHex: digest.hex)
-                
+
                 return digest.hex
             }
         }
@@ -407,6 +411,8 @@ public struct FileIO: Sendable {
     ///        print("chunk: \(data)")
     ///    }
     ///
+    ///    **Warning** it's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
+    ///
     /// - parameters:
     ///     - path: Path to file on the disk.
     ///     - chunkSize: Maximum size for the file data chunks.
@@ -446,13 +452,12 @@ public struct FileIO: Sendable {
     ///     - buffer: The `ByteBuffer` to write.
     /// - returns: `Void` when the file write is finished.
     public func writeFile(_ buffer: ByteBuffer, at path: String) async throws {
-        let fd = try NIOFileHandle(path: path, mode: .write, flags: .allowFileCreation())
-        defer {
-            try? fd.close()
+        // This returns the number of bytes written which we don't need
+        _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: false)) { handle in
+            try await handle.write(contentsOf: buffer, toAbsoluteOffset: 0)
         }
-        try await self.io.write(fileHandle: fd, buffer: buffer)
     }
-    
+
     /// Generates a chunked `Response` for the specified file. This method respects values in
     /// the `"ETag"` header and is capable of responding `304 Not Modified` if the file in question
     /// has not been modified since last served. If `advancedETagComparison` is set to true,
@@ -504,7 +509,7 @@ public struct FileIO: Sendable {
         let eTag: String
 
         if advancedETagComparison {
-            eTag = try await generateETagHash(path: path, lastModified: fileInfo.lastDataModificationTime.date).get()
+            eTag = try await generateETagHash(path: path, lastModified: fileInfo.lastDataModificationTime.date)
         } else {
             // Generate ETag value, "last modified date in epoch time" + "-" + "file size"
             eTag = "\"\(fileInfo.lastDataModificationTime.seconds)-\(fileInfo.size)\""

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -7,10 +7,18 @@ import NIOEmbedded
 import NIOConcurrencyHelpers
 
 final class ApplicationTests: XCTestCase {
-    func testApplicationStop() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    @available(*, deprecated, message: "Test future APIs")
+    func testApplicationStopFuture() throws {
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
         try app.start()
@@ -22,6 +30,19 @@ final class ApplicationTests: XCTestCase {
         try running.onStop.wait()
     }
 
+    func testApplicationStop() async throws {
+        app.environment.arguments = ["serve"]
+        app.http.server.configuration.port = 0
+        try await app.startup()
+        guard let running = app.running else {
+            XCTFail("app started without setting 'running'")
+            return
+        }
+        running.stop()
+        try await running.onStop.get()
+    }
+
+    @available(*, deprecated, message: "Test future APIs")
     func testLifecycleHandler() throws {
         final class Foo: LifecycleHandler {
             let willBootFlag: NIOLockedValueBox<Bool>
@@ -170,6 +191,7 @@ final class ApplicationTests: XCTestCase {
         XCTAssertEqual(foo.shutdownAsyncFlag.withLockedValue({ $0 }), true)
     }
 
+    @available(*, deprecated, message: "Test future APIs")
     func testBootDoesNotTriggerLifecycleHandlerMultipleTimes() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
@@ -210,7 +232,8 @@ final class ApplicationTests: XCTestCase {
         
         try await app.asyncShutdown()
     }
-    
+
+    @available(*, deprecated, message: "Test future APIs")
     func testThrowDoesNotCrash() throws {
         enum Static {
             static let app: NIOLockedValueBox<Application?> = .init(nil)
@@ -221,9 +244,6 @@ final class ApplicationTests: XCTestCase {
 
     func testSwiftError() throws {
         struct Foo: Error { }
-        
-        let app = Application(.testing)
-        defer { app.shutdown() }
         
         app.get("error") { req -> String in
             throw Foo()
@@ -248,9 +268,6 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testBoilerplate() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.get("hello") { req in
             "Hello, world!"
         }
@@ -271,10 +288,8 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testAutomaticPortPickingWorks() {
-        let app = Application(.testing)
         app.http.server.configuration.hostname = "127.0.0.1"
         app.http.server.configuration.port = 0
-        defer { app.shutdown() }
 
         app.get("hello") { req in
             "Hello, world!"
@@ -301,11 +316,9 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testConfigurationAddressDetailsReflectedAfterBeingSet() throws {
-        let app = Application(.testing)
         app.http.server.configuration.hostname = "0.0.0.0"
         app.http.server.configuration.port = 0
-        defer { app.shutdown() }
-        
+
         struct AddressConfig: Content {
             let hostname: String
             let port: Int
@@ -336,9 +349,6 @@ final class ApplicationTests: XCTestCase {
     }
 
     func testConfigurationAddressDetailsReflectedWhenProvidedThroughServeCommand() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         struct AddressConfig: Content {
             let hostname: String
             let port: Int

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -22,10 +22,7 @@ final class ApplicationTests: XCTestCase {
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
         try app.start()
-        guard let running = app.running else {
-            XCTFail("app started without setting 'running'")
-            return
-        }
+        let running = try XCTUnwrap(app.running, "app started without setting 'running'")
         running.stop()
         try running.onStop.wait()
     }
@@ -34,10 +31,7 @@ final class ApplicationTests: XCTestCase {
         app.environment.arguments = ["serve"]
         app.http.server.configuration.port = 0
         try await app.startup()
-        guard let running = app.running else {
-            XCTFail("app started without setting 'running'")
-            return
-        }
+        let running = try XCTUnwrap(app.running, "app started without setting 'running'")
         running.stop()
         try await running.onStop.get()
     }

--- a/Tests/VaporTests/AsyncAuthTests.swift
+++ b/Tests/VaporTests/AsyncAuthTests.swift
@@ -124,6 +124,42 @@ final class AsyncAuthenticationTests: XCTestCase {
         }
     }
 
+    func testBasicAuthenticatorWithEmptyPassword() throws {
+        struct Test: Authenticatable {
+            static func authenticator() -> Authenticator {
+                TestAuthenticator()
+            }
+
+            var name: String
+        }
+
+        struct TestAuthenticator: BasicAuthenticator {
+            typealias User = Test
+
+            func authenticate(basic: BasicAuthorization, for request: Request) -> EventLoopFuture<Void> {
+                if basic.username == "test" && basic.password == "" {
+                    let test = Test(name: "Vapor")
+                    request.auth.login(test)
+                }
+                return request.eventLoop.makeSucceededFuture(())
+            }
+        }
+
+        app.routes.grouped([
+            Test.authenticator(), Test.guardMiddleware()
+        ]).get("test") { req -> String in
+            return try req.auth.require(Test.self).name
+        }
+
+        let basic = Data("test:".utf8).base64EncodedString()
+        try app.testable().test(.GET, "/test") { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }
+    }
+
     func testBasicAuthenticatorWithRedirect() async throws {
         struct Test: Authenticatable {
             static func authenticator() -> AsyncAuthenticator {
@@ -243,5 +279,49 @@ final class AsyncAuthenticationTests: XCTestCase {
 
         var config = Middlewares()
         config.use(Test.authenticator())
+    }
+
+    func testAsyncAuthenticator() throws {
+        struct Test: Authenticatable {
+            static func authenticator(threadPool: NIOThreadPool) -> Authenticator {
+                TestAuthenticator(threadPool: threadPool)
+            }
+            var name: String
+        }
+
+        struct TestAuthenticator: BasicAuthenticator {
+            typealias User = Test
+            let threadPool: NIOThreadPool
+
+            func authenticate(basic: BasicAuthorization, for request: Request) -> EventLoopFuture<Void> {
+                let promise = request.eventLoop.makePromise(of: Void.self)
+                self.threadPool.submit { _ in
+                    sleep(1)
+                    request.eventLoop.execute {
+                        if basic.username == "test" && basic.password == "secret" {
+                            let test = Test(name: "Vapor")
+                            request.auth.login(test)
+                        }
+                        promise.succeed(())
+                    }
+                }
+                return promise.futureResult
+            }
+        }
+
+        app.routes.grouped([
+            Test.authenticator(threadPool: app.threadPool),
+            Test.guardMiddleware()
+        ]).get("test") { req -> String in
+            return try req.auth.require(Test.self).name
+        }
+
+        let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
+        try app.testable().test(.GET, "/test") { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }.test(.GET, "/test", headers: ["Authorization": "Basic \(basic)"]) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "Vapor")
+        }
     }
 }

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -6,8 +6,8 @@ import NIOCore
 import Logging
 import NIOEmbedded
 
-final class AsyncClientTests: XCTestCase {
-    
+final class AsyncClientTests: XCTestCase, @unchecked Sendable {
+
     var remoteAppPort: Int!
     var remoteApp: Application!
     var app: Application!
@@ -126,6 +126,26 @@ final class AsyncClientTests: XCTestCase {
         XCTAssertEqual(data.headers["content-type"], "application/json; charset=utf-8")
     }
 
+    func testClientContent() async throws {
+        try await app.asyncBoot()
+
+        let res = try await app.client.post("http://localhost:\(remoteAppPort!)/anything", content: ["hello": "world"])
+
+        let data = try res.content.decode(AnythingResponse.self)
+        XCTAssertEqual(data.json, ["hello": "world"])
+        XCTAssertEqual(data.headers["content-type"], "application/json; charset=utf-8")
+    }
+
+    func testClientTimeout() async throws {
+        try await app.asyncBoot()
+
+        XCTAssertNoThrow(try app.client.get("http://localhost:\(remoteAppPort!)/json") { $0.timeout = .seconds(1) }.wait())
+        XCTAssertThrowsError(try app.client.get("http://localhost:\(remoteAppPort!)/stalling") { $0.timeout = .seconds(1) }.wait()) {
+            XCTAssertTrue(type(of: $0) == HTTPClientError.self, "\(type(of: $0)) is not a \(HTTPClientError.self)")
+            XCTAssertEqual($0 as? HTTPClientError, .deadlineExceeded)
+        }
+    }
+
     func testBoilerplateClient() async throws {
         app.http.server.configuration.port = 0
         let remotePort = self.remoteAppPort!
@@ -157,6 +177,31 @@ final class AsyncClientTests: XCTestCase {
         XCTAssertEqual(res.body?.string, "bar")
 
         try await app.running?.onStop.get()
+    }
+
+    func testApplicationClientThreadSafety() throws {
+        let startingPistol = DispatchGroup()
+        startingPistol.enter()
+        startingPistol.enter()
+
+        let finishLine = DispatchGroup()
+        finishLine.enter()
+        Thread.async {
+            startingPistol.leave()
+            startingPistol.wait()
+            XCTAssert(type(of: self.app.http.client.shared) == HTTPClient.self)
+            finishLine.leave()
+        }
+
+        finishLine.enter()
+        Thread.async {
+            startingPistol.leave()
+            startingPistol.wait()
+            XCTAssert(type(of: self.app.http.client.shared) == HTTPClient.self)
+            finishLine.leave()
+        }
+
+        finishLine.wait()
     }
 
     func testCustomClient() async throws {

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -1,43 +1,200 @@
 import Vapor
-import XCTest
-import XCTVapor
 import NIOConcurrencyHelpers
 import NIOCore
 import Logging
 import NIOEmbedded
+#if compiler(>=6.0) && canImport(Testing)
+import Testing
+import VaporTesting
 
-final class AsyncClientTests: XCTestCase, @unchecked Sendable {
+@Suite("Async Client Tests")
+struct AsyncClientTests {
+    @Test("Test changing the client configuration")
+    func clientConfigurationChange() async throws {
+        try await withApp { app in
+            app.http.client.configuration.redirectConfiguration = .disallow
 
-    var remoteAppPort: Int!
-    var remoteApp: Application!
-    var app: Application!
-    
-    override func setUp() async throws {
-        remoteApp = try await Application.make(.testing)
+            app.get("redirect") {
+                $0.redirect(to: "foo")
+            }
+
+            try await app.server.start(address: .hostname("localhost", port: 0))
+
+            let port = try #require(app.http.server.shared.localAddress?.port, "Failed to get port")
+            let res = try await app.client.get("http://localhost:\(port)/redirect")
+
+            #expect(res.status == .seeOther)
+
+            await app.server.shutdown()
+        }
+    }
+
+    @Test("Test that the client config can be changed after the client has already been used")
+    func clientConfigurationCantBeChangedAfterClientHasBeenUsed() async throws {
+        try await withApp { app in
+            app.http.client.configuration.redirectConfiguration = .disallow
+
+            app.get("redirect") {
+                $0.redirect(to: "foo")
+            }
+
+            try await app.server.start(address: .hostname("localhost", port: 0))
+
+            let port = try #require(app.http.server.shared.localAddress?.port, "Failed to get port")
+            _ = try await app.client.get("http://localhost:\(port)/redirect")
+
+            app.http.client.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
+            let res = try await app.client.get("http://localhost:\(port)/redirect")
+            #expect(res.status == .seeOther)
+
+            await app.server.shutdown()
+        }
+    }
+
+    @Test("TestClient Response Codable")
+    func testClientResponseCodable() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                let res = try await app.client.get("http://localhost:\(remoteAppPort)/json")
+
+                let encoded = try JSONEncoder().encode(res)
+                let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
+
+                #expect(res == decoded)
+            }
+        }
+    }
+
+    @Test("Test Client beforeSend()")
+    func testClientBeforeSend() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                let res = try await app.client.post("http://localhost:\(remoteAppPort)/anything") { req in
+                    try req.content.encode(["hello": "world"])
+                }
+
+                let data = try res.content.decode(AnythingResponse.self)
+                #expect(data.json == ["hello": "world"])
+                #expect(data.headers["content-type"] == "application/json; charset=utf-8")
+            }
+        }
+    }
+
+    @Test("Test Client Content")
+    func testClientContent() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                let res = try await app.client.post("http://localhost:\(remoteAppPort)/anything", content: ["hello": "world"])
+
+                let data = try res.content.decode(AnythingResponse.self)
+                #expect(data.json == ["hello": "world"])
+                #expect(data.headers["content-type"] == "application/json; charset=utf-8")
+            }
+        }
+    }
+
+    @Test("Test Client Tiemout")
+    func testClientTimeout() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                await #expect(throws: Never.self, performing: {
+                    try await app.client.get("http://localhost:\(remoteAppPort)/json") { $0.timeout = .seconds(1) }
+                })
+                await #expect(throws: HTTPClientError.deadlineExceeded) {
+                    try await app.client.get("http://localhost:\(remoteAppPort)/stalling") {
+                        $0.timeout = .milliseconds(200)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("Test Boilerplate Content")
+    func testBoilerplateClient() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                app.http.server.configuration.port = 0
+
+                app.get("foo") { req async throws -> String in
+                    do {
+                        let response = try await req.client.get("http://localhost:\(remoteAppPort)/status/201")
+                        #expect(response.status.code == 201)
+                        req.application.running?.stop()
+                        return "bar"
+                    } catch {
+                        req.application.running?.stop()
+                        throw error
+                    }
+                }
+
+                app.environment.arguments = ["serve"]
+                try await app.asyncBoot()
+                try await app.startup()
+
+                let port = try #require(app.http.server.shared.localAddress?.port)
+                let res = try await app.client.get("http://localhost:\(port)/foo")
+                #expect(res.body?.string == "bar")
+
+                try await app.running?.onStop.get()
+            }
+        }
+    }
+
+    @Test("Test Custom Client")
+    func testCustomClient() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                app.clients.use(.custom)
+                _ = try await app.client.get("https://vapor.codes")
+
+                #expect(app.customClient.requests.count == 1)
+                #expect(app.customClient.requests.first?.url.host == "vapor.codes")
+            }
+        }
+    }
+
+    @Test("Test Client Content")
+    func testClientLogging() async throws {
+        try await withRemoteApp { remoteApp, remoteAppPort in
+            try await withApp { app in
+                let logs = TestLogHandler()
+                app.logger = logs.logger
+
+                _ = try await app.client.get("http://localhost:\(remoteAppPort)/status/201")
+
+                let metadata = logs.getMetadata()
+                #expect(metadata["ahc-request-id"] != nil)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+    func withRemoteApp<T>(_ block: (Application, Int) async throws -> T) async throws -> T {
+        let remoteApp = try await Application.make(.testing)
         remoteApp.http.server.configuration.port = 0
-        
+
         remoteApp.get("json") { _ in
             SomeJSON()
         }
-        
+
         remoteApp.get("status", ":status") { req -> HTTPStatus in
             let status = try req.parameters.require("status", as: Int.self)
             return HTTPStatus(statusCode: status)
         }
-        
+
         remoteApp.post("anything") { req -> AnythingResponse in
             let headers = req.headers.reduce(into: [String: String]()) {
                 $0[$1.0] = $1.1
             }
-            
+
             guard let json:[String:Any] = try JSONSerialization.jsonObject(with: req.body.data!) as? [String:Any] else {
                 throw Abort(.badRequest)
             }
-            
+
             let jsonResponse = json.mapValues {
                 return "\($0)"
             }
-            
+
             return AnythingResponse(headers: headers, json: jsonResponse)
         }
 
@@ -48,185 +205,21 @@ final class AsyncClientTests: XCTestCase, @unchecked Sendable {
         remoteApp.environment.arguments = ["serve"]
         try await remoteApp.asyncBoot()
         try await remoteApp.startup()
-        
-        XCTAssertNotNil(remoteApp.http.server.shared.localAddress)
-        guard let localAddress = remoteApp.http.server.shared.localAddress,
-              let port = localAddress.port else {
-            XCTFail("couldn't get ip/port from \(remoteApp.http.server.shared.localAddress.debugDescription)")
-            return
+
+        let remotePort = try #require(remoteApp.http.server.shared.localAddress?.port, "Failed to get port")
+
+        let result: T
+        do {
+            result = try await block(remoteApp, remotePort)
+        } catch {
+            try? await remoteApp.asyncShutdown()
+            throw error
         }
-        
-        self.remoteAppPort = port
-        
-        app = try await Application.make(.testing)
-    }
-    
-    override func tearDown() async throws {
         try await remoteApp.asyncShutdown()
-    }
-    
-    func testClientConfigurationChange() async throws {
-        app.http.client.configuration.redirectConfiguration = .disallow
-
-        app.get("redirect") {
-            $0.redirect(to: "foo")
-        }
-
-        try await app.server.start(address: .hostname("localhost", port: 0))
-        
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-
-        let res = try await app.client.get("http://localhost:\(port)/redirect")
-
-        XCTAssertEqual(res.status, .seeOther)
-        
-        await app.server.shutdown()
-    }
-
-    func testClientConfigurationCantBeChangedAfterClientHasBeenUsed() async throws {
-        app.http.client.configuration.redirectConfiguration = .disallow
-
-        app.get("redirect") {
-            $0.redirect(to: "foo")
-        }
-
-        try await app.server.start(address: .hostname("localhost", port: 0))
-        
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-
-        _ = try await app.client.get("http://localhost:\(port)/redirect")
-
-        app.http.client.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)
-        let res = try await app.client.get("http://localhost:\(port)/redirect")
-        XCTAssertEqual(res.status, .seeOther)
-        
-        await app.server.shutdown()
-    }
-
-    func testClientResponseCodable() async throws {
-        let res = try await app.client.get("http://localhost:\(remoteAppPort!)/json")
-
-        let encoded = try JSONEncoder().encode(res)
-        let decoded = try JSONDecoder().decode(ClientResponse.self, from: encoded)
-
-        XCTAssertEqual(res, decoded)
-    }
-
-    func testClientBeforeSend() async throws {
-        try await app.asyncBoot()
-
-        let res = try await app.client.post("http://localhost:\(remoteAppPort!)/anything") { req in
-            try req.content.encode(["hello": "world"])
-        }
-
-        let data = try res.content.decode(AnythingResponse.self)
-        XCTAssertEqual(data.json, ["hello": "world"])
-        XCTAssertEqual(data.headers["content-type"], "application/json; charset=utf-8")
-    }
-
-    func testClientContent() async throws {
-        try await app.asyncBoot()
-
-        let res = try await app.client.post("http://localhost:\(remoteAppPort!)/anything", content: ["hello": "world"])
-
-        let data = try res.content.decode(AnythingResponse.self)
-        XCTAssertEqual(data.json, ["hello": "world"])
-        XCTAssertEqual(data.headers["content-type"], "application/json; charset=utf-8")
-    }
-
-    func testClientTimeout() async throws {
-        try await app.asyncBoot()
-
-        XCTAssertNoThrow(try app.client.get("http://localhost:\(remoteAppPort!)/json") { $0.timeout = .seconds(1) }.wait())
-        XCTAssertThrowsError(try app.client.get("http://localhost:\(remoteAppPort!)/stalling") { $0.timeout = .milliseconds(200) }.wait()) {
-            XCTAssertTrue(type(of: $0) == HTTPClientError.self, "\(type(of: $0)) is not a \(HTTPClientError.self)")
-            XCTAssertEqual($0 as? HTTPClientError, .deadlineExceeded)
-        }
-    }
-
-    func testBoilerplateClient() async throws {
-        app.http.server.configuration.port = 0
-        let remotePort = self.remoteAppPort!
-
-        app.get("foo") { req async throws -> String in
-            do {
-                let response = try await req.client.get("http://localhost:\(remotePort)/status/201")
-                XCTAssertEqual(response.status.code, 201)
-                req.application.running?.stop()
-                return "bar"
-            } catch {
-                req.application.running?.stop()
-                throw error
-            }
-        }
-
-        app.environment.arguments = ["serve"]
-        try await app.asyncBoot()
-        try await app.startup()
-        
-        XCTAssertNotNil(app.http.server.shared.localAddress)
-        guard let localAddress = app.http.server.shared.localAddress,
-              let port = localAddress.port else {
-            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
-            return
-        }
-
-        let res = try await app.client.get("http://localhost:\(port)/foo")
-        XCTAssertEqual(res.body?.string, "bar")
-
-        try await app.running?.onStop.get()
-    }
-
-    func testApplicationClientThreadSafety() throws {
-        let startingPistol = DispatchGroup()
-        startingPistol.enter()
-        startingPistol.enter()
-
-        let finishLine = DispatchGroup()
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: self.app.http.client.shared) == HTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: self.app.http.client.shared) == HTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.wait()
-    }
-
-    func testCustomClient() async throws {
-        app.clients.use(.custom)
-        _ = try await app.client.get("https://vapor.codes")
-
-        XCTAssertEqual(app.customClient.requests.count, 1)
-        XCTAssertEqual(app.customClient.requests.first?.url.host, "vapor.codes")
-    }
-
-    func testClientLogging() async throws {
-        let logs = TestLogHandler()
-        app.logger = logs.logger
-
-        _ = try await app.client.get("http://localhost:\(remoteAppPort!)/status/201")
-
-        let metadata = logs.getMetadata()
-        XCTAssertNotNil(metadata["ahc-request-id"])
+        return result
     }
 }
-
+#endif
 
 final class CustomClient: Client, Sendable {
     let eventLoop: any EventLoop

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -42,7 +42,7 @@ final class AsyncClientTests: XCTestCase, @unchecked Sendable {
         }
 
         remoteApp.get("stalling") {
-            $0.eventLoop.scheduleTask(in: .seconds(5)) { SomeJSON() }.futureResult
+            $0.eventLoop.scheduleTask(in: .seconds(1)) { SomeJSON() }.futureResult
         }
 
         remoteApp.environment.arguments = ["serve"]
@@ -144,7 +144,7 @@ final class AsyncClientTests: XCTestCase, @unchecked Sendable {
         try await app.asyncBoot()
 
         XCTAssertNoThrow(try app.client.get("http://localhost:\(remoteAppPort!)/json") { $0.timeout = .seconds(1) }.wait())
-        XCTAssertThrowsError(try app.client.get("http://localhost:\(remoteAppPort!)/stalling") { $0.timeout = .seconds(1) }.wait()) {
+        XCTAssertThrowsError(try app.client.get("http://localhost:\(remoteAppPort!)/stalling") { $0.timeout = .milliseconds(200) }.wait()) {
             XCTAssertTrue(type(of: $0) == HTTPClientError.self, "\(type(of: $0)) is not a \(HTTPClientError.self)")
             XCTAssertEqual($0 as? HTTPClientError, .deadlineExceeded)
         }

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -40,7 +40,11 @@ final class AsyncClientTests: XCTestCase, @unchecked Sendable {
             
             return AnythingResponse(headers: headers, json: jsonResponse)
         }
-        
+
+        remoteApp.get("stalling") {
+            $0.eventLoop.scheduleTask(in: .seconds(5)) { SomeJSON() }.futureResult
+        }
+
         remoteApp.environment.arguments = ["serve"]
         try await remoteApp.asyncBoot()
         try await remoteApp.startup()

--- a/Tests/VaporTests/AsyncEnvironmentTests.swift
+++ b/Tests/VaporTests/AsyncEnvironmentTests.swift
@@ -1,0 +1,51 @@
+@testable import Vapor
+import XCTVapor
+import XCTest
+
+final class AsyncEnvironmentSecretTests: XCTestCase {
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testNonExistingSecretFile() async throws {
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/non-existing-secret"
+
+        let secretContent = try await Environment.secret(path: path)
+        XCTAssertNil(secretContent)
+    }
+
+    func testExistingSecretFile() async throws {
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let secretContent = try await Environment.secret(path: path)
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testExistingSecretFileFromEnvironmentKey() async throws {
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/my-secret-env-content"
+
+        let key = "MY_ENVIRONMENT_SECRET"
+        setenv(key, path, 1)
+        defer {
+            unsetenv(key)
+        }
+
+        let secretContent = try await Environment.secret(key: key)
+        XCTAssertEqual(secretContent, "password")
+    }
+
+    func testLoadingSecretFromEnvKeyWhichDoesNotExist() async throws {
+        let key = "MY_NON_EXISTING_ENVIRONMENT_SECRET"
+        let secretContent = try await Environment.secret(key: key)
+        XCTAssertNil(secretContent)
+    }
+}

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -362,10 +362,7 @@ final class AsyncRequestTests: XCTestCase {
         try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
 
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
 
         XCTAssertEqual(
             try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -231,6 +231,159 @@ final class AsyncRequestTests: XCTestCase {
             XCTAssertEqual(body.string, "Received \(fiftyMB.readableBytes) bytes")
         }
     }
+
+    func testCustomHostAddress() throws {
+        app.get("vapor", "is", "fun") {
+            return $0.remoteAddress?.hostname ?? "n/a"
+        }
+
+        let ipV4Hostname = "127.0.0.1"
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "vapor/is/fun") { res in
+            XCTAssertEqual(res.body.string, ipV4Hostname)
+        }
+    }
+
+    func testRequestIdsAreUnique() throws {
+        let request1 = Request(application: app, on: app.eventLoopGroup.next())
+        let request2 = Request(application: app, on: app.eventLoopGroup.next())
+
+        XCTAssertNotEqual(request1.id, request2.id)
+    }
+
+    func testRequestIdInLoggerMetadata() throws {
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        guard case .string(let string) = request.logger[metadataKey: "request-id"] else {
+            XCTFail("Did not find request-id key in logger metadata.")
+            return
+        }
+        XCTAssertEqual(string, request.id)
+    }
+
+    func testRequestPeerAddressForwarded() throws {
+        app.get("remote") { req -> String in
+            req.headers.add(name: .forwarded, value: "for=192.0.2.60; proto=http; by=203.0.113.43")
+            guard let peerAddress = req.peerAddress else {
+                return "n/a"
+            }
+            return peerAddress.description
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
+            XCTAssertEqual(res.body.string, "[IPv4]192.0.2.60:80")
+        }
+    }
+
+    func testRequestPeerAddressXForwardedFor() throws {
+        app.get("remote") { req -> String in
+            req.headers.add(name: .xForwardedFor, value: "5.6.7.8")
+            guard let peerAddress = req.peerAddress else {
+                return "n/a"
+            }
+            return peerAddress.description
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
+            XCTAssertEqual(res.body.string, "[IPv4]5.6.7.8:80")
+        }
+    }
+
+    func testRequestPeerAddressRemoteAddress() throws {
+        app.get("remote") { req -> String in
+            guard let peerAddress = req.peerAddress else {
+                return "n/a"
+            }
+            return peerAddress.description
+        }
+
+        let ipV4Hostname = "127.0.0.1"
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "remote") { res in
+            XCTAssertContains(res.body.string, "[IPv4]\(ipV4Hostname)")
+        }
+    }
+
+    func testRequestPeerAddressMultipleHeadersOrder() throws {
+        app.get("remote") { req -> String in
+            req.headers.add(name: .xForwardedFor, value: "5.6.7.8")
+            req.headers.add(name: .forwarded, value: "for=192.0.2.60; proto=http; by=203.0.113.43")
+            guard let peerAddress = req.peerAddress else {
+                return "n/a"
+            }
+            return peerAddress.description
+        }
+
+        let ipV4Hostname = "127.0.0.1"
+        try app.testable(method: .running(hostname: ipV4Hostname, port: 0)).test(.GET, "remote") { res in
+            XCTAssertEqual(res.body.string, "[IPv4]192.0.2.60:80")
+        }
+    }
+
+    func testRequestIdForwarding() throws {
+         app.get("remote") {
+            if case .string(let string) = $0.logger[metadataKey: "request-id"], string == $0.id {
+                return string
+            } else {
+                throw Abort(.notFound)
+            }
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "remote", beforeRequest: { req in
+            req.headers.add(name: .xRequestId, value: "test")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.body.string, "test")
+        })
+    }
+
+    func testRequestRemoteAddress() throws {
+        app.get("remote") {
+            $0.remoteAddress?.description ?? "n/a"
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "remote") { res in
+            XCTAssertContains(res.body.string, "IP")
+        }
+    }
+
+    func testRedirect() throws {
+        app.http.client.configuration.redirectConfiguration = .disallow
+
+        app.get("redirect_normal") {
+            $0.redirect(to: "foo", redirectType: .normal)
+        }
+        app.get("redirect_permanent") {
+            $0.redirect(to: "foo", redirectType: .permanent)
+        }
+        app.post("redirect_temporary") {
+            $0.redirect(to: "foo", redirectType: .temporary)
+        }
+        app.post("redirect_permanentPost") {
+            $0.redirect(to: "foo", redirectType: .permanentPost)
+        }
+
+        try app.server.start(address: .hostname("localhost", port: 0))
+        defer { app.server.shutdown() }
+
+        guard let port = app.http.server.shared.localAddress?.port else {
+            XCTFail("Failed to get port for app")
+            return
+        }
+
+        XCTAssertEqual(
+            try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,
+            .seeOther
+        )
+        XCTAssertEqual(
+            try app.client.get("http://localhost:\(port)/redirect_permanent").wait().status,
+            .movedPermanently
+        )
+        XCTAssertEqual(
+            try app.client.post("http://localhost:\(port)/redirect_temporary").wait().status,
+            .temporaryRedirect
+        )
+        XCTAssertEqual(
+            try app.client.post("http://localhost:\(port)/redirect_permanentPost").wait().status,
+            .permanentRedirect
+        )
+    }
 }
 
 // This was taken from AsyncHTTPClients's AsyncRequestTests.swift code.

--- a/Tests/VaporTests/AsyncRouteTests.swift
+++ b/Tests/VaporTests/AsyncRouteTests.swift
@@ -13,7 +13,118 @@ final class AsyncRouteTests: XCTestCase {
     override func tearDown() async throws {
         try await app.asyncShutdown()
     }
-    
+
+    func testParameter() throws {
+        app.routes.get("hello", ":a") { req in
+            return req.parameters.get("a") ?? ""
+        }
+        app.routes.get("hello", ":a", ":b") { req in
+            return [req.parameters.get("a") ?? "", req.parameters.get("b") ?? ""]
+        }
+        try app.testable().test(.GET, "/hello/vapor") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, "vapor")
+        }.test(.POST, "/hello/vapor") { res in
+            XCTAssertEqual(res.status, .notFound)
+        }.test(.GET, "/hello/vapor/development") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, #"["vapor","development"]"#)
+        }
+    }
+
+    func testRequiredParameter() throws {
+        app.routes.get("string", ":value") { req in
+            return try req.parameters.require("value")
+        }
+
+        app.routes.get("int", ":value") { req -> String in
+            let value = try req.parameters.require("value", as: Int.self)
+            return String(value)
+        }
+
+        app.routes.get("missing") { req in
+            return try req.parameters.require("value")
+        }
+
+        try app.testable().test(.GET, "/string/test") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertContains(res.body.string, "test")
+        }.test(.GET, "/int/123") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "123")
+        }.test(.GET, "/int/not-int") { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
+        }.test(.GET, "/missing") { res in
+            XCTAssertEqual(res.status, .internalServerError)
+        }
+    }
+
+    func testJSON() throws {
+        app.routes.get("json") { req -> [String: String] in
+            return ["foo": "bar"]
+        }
+
+        try app.testable().test(.GET, "/json") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, #"{"foo":"bar"}"#)
+        }
+    }
+
+    func testRootGet() throws {
+        app.routes.get("") { req -> String in
+                return "root"
+        }
+        app.routes.get("foo") { req -> String in
+            return "foo"
+        }
+
+        try app.testable().test(.GET, "/") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "root")
+        }.test(.GET, "/foo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foo")
+        }
+    }
+
+    func testInsensitiveRoutes() throws {
+        app.routes.caseInsensitive = true
+
+        app.routes.get("foo") { req -> String in
+            return "foo"
+        }
+
+        try app.testable().test(.GET, "/foo") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foo")
+        }.test(.GET, "/FOO") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foo")
+        }
+    }
+
+    func testAnyResponse() throws {
+        app.get("foo") { req -> AnyResponse in
+            if try req.query.get(String.self, at: "number") == "true" {
+                return AnyResponse(42)
+            } else {
+                return AnyResponse("string")
+            }
+        }
+
+        try app.testable().test(.GET, "/foo", beforeRequest: { req in
+            try req.query.encode(["number": "true"])
+        }) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "42")
+        }.test(.GET, "/foo", beforeRequest: { req in
+            try req.query.encode(["number": "false"])
+        }) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "string")
+        }
+    }
+
     func testEnumResponse() async throws {
         enum IntOrString: AsyncResponseEncodable {
             case int(Int)
@@ -46,6 +157,38 @@ final class AsyncRouteTests: XCTestCase {
         }
     }
 
+    func testValidationError() throws {
+        struct User: Content, Validatable {
+            static func validations(_ v: inout Validations) {
+                v.add("email", is: .email)
+            }
+
+            var name: String
+            var email: String
+        }
+
+        app.post("users") { req -> User in
+            try User.validate(content: req)
+            return try req.content.decode(User.self)
+        }
+
+        try app.testable().test(.POST, "/users", beforeRequest: { req in
+            try req.content.encode([
+                "name": "vapor",
+                "email": "foo"
+            ], as: .json)
+        }) { res in
+            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertContains(res.body.string, "email is not a valid email address")
+        }.test(.POST, "/users") { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertContains(res.body.string.replacingOccurrences(of: "\\", with: ""), "Missing \"Content-Type\" header")
+        }.test(.POST, "/users", headers: ["Content-Type":"application/json"]) { res in
+            XCTAssertEqual(res.status, .unprocessableEntity)
+            XCTAssertContains(res.body.string, "Empty Body")
+        }
+    }
+
     func testResponseEncodableStatus() async throws {
         struct User: Content {
             var name: String
@@ -68,6 +211,134 @@ final class AsyncRouteTests: XCTestCase {
         }
     }
 
+    func testHeadRequestForwardedToGet() throws {
+        app.get("hello") { req -> String in
+            XCTAssertEqual(req.method, .HEAD)
+            return "hi"
+        }
+
+        try app.testable(method: .running(port: 0)).test(.HEAD, "/hello") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.first(name: .contentLength), "2")
+            XCTAssertEqual(res.body.readableBytes, 0)
+        }
+    }
+
+    func testExplicitHeadRouteOverridesForwardingToGet() throws {
+        app.get("hello") { req -> Response in
+            return Response(status: .badRequest)
+        }
+
+        app.on(.HEAD, "hello") { req -> Response in
+            return Response(status: .found)
+        }
+
+        try app.testable(method: .running(port: 0)).test(.HEAD, "/hello") { res in
+            XCTAssertEqual(res.status, .found)
+            XCTAssertEqual(res.headers.first(name: .contentLength), "0")
+            XCTAssertEqual(res.body.readableBytes, 0)
+        }
+    }
+
+    func testInvalidCookie() throws {
+        app.grouped(SessionsMiddleware(session: app.sessions.driver))
+            .get("get") { req -> String in
+                return req.session.data["name"] ?? "n/a"
+            }
+
+        var headers = HTTPHeaders()
+        var cookies = HTTPCookies()
+        cookies["vapor-session"] = "asdf"
+        headers.cookie = cookies
+        try app.testable().test(.GET, "/get", headers: headers) { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertNotNil(res.headers[.setCookie])
+            XCTAssertEqual(res.body.string, "n/a")
+        }
+    }
+
+    // https://github.com/vapor/vapor/issues/1787
+    func testGH1787() throws {
+        app.get("no-content") { req -> String in
+            throw Abort(.noContent)
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "/no-content") { res in
+            XCTAssertEqual(res.status.code, 204)
+            XCTAssertEqual(res.body.readableBytes, 0)
+        }
+    }
+
+    func testSimilarRoutingPath() throws {
+        app.get("api","addresses") { req in
+            "a"
+        }
+        app.get("api", "addresses","search", ":id") { req in
+            "b"
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "/api/addresses/") { res in
+            XCTAssertEqual(res.body.string, "a")
+        }.test(.GET, "/api/addresses/search/test") { res in
+            XCTAssertEqual(res.body.string, "b")
+        }.test(.GET, "/api/addresses/search/") { res in
+            XCTAssertEqual(res.status, .notFound)
+        }.test(.GET, "/api/addresses/search") { res in
+            XCTAssertEqual(res.status, .notFound)
+        }
+    }
+
+    func testThrowingGroup() throws {
+        XCTAssertThrowsError(try app.routes.group("foo") { router in
+            throw Abort(.internalServerError, reason: "Test")
+        })
+    }
+
+    func testCollection() throws {
+        struct Foo: RouteCollection {
+            func boot(routes: RoutesBuilder) throws {
+                routes.get("foo") { _ in "bar" }
+            }
+        }
+
+        try app.register(collection: Foo())
+
+        try app.test(.GET, "foo") { res in
+            XCTAssertEqual(res.body.string, "bar")
+        }
+    }
+
+    func testConfigurableMaxBodySize() throws {
+        XCTAssertEqual(app.routes.defaultMaxBodySize, 16384)
+        app.routes.defaultMaxBodySize = 1
+        XCTAssertEqual(app.routes.defaultMaxBodySize, 1)
+
+        app.on(.POST, "default") { request in
+            HTTPStatus.ok
+        }
+        app.on(.POST, "1kb", body: .collect(maxSize: "1kb")) { request in
+            HTTPStatus.ok
+        }
+        app.on(.POST, "1mb", body: .collect(maxSize: "1mb")) { request in
+            HTTPStatus.ok
+        }
+        app.on(.POST, "1gb", body: .collect(maxSize: "1gb")) { request in
+            HTTPStatus.ok
+        }
+
+        var buffer = ByteBufferAllocator().buffer(capacity: 0)
+        buffer.writeBytes(Array(repeating: 0, count: 500_000))
+        try app.testable(method: .running(port: 0)).test(.POST, "/default", body: buffer) { res in
+            XCTAssertEqual(res.status, .payloadTooLarge)
+        }.test(.POST, "/1kb", body: buffer) { res in
+            XCTAssertEqual(res.status, .payloadTooLarge)
+        }.test(.POST, "/1mb", body: buffer) { res in
+            XCTAssertEqual(res.status, .ok)
+        }.test(.POST, "/1gb", body: buffer) { res in
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+
     func testWebsocketUpgrade() async throws {
         let testMarkerHeaderKey = "TestMarker"
         let testMarkerHeaderValue = "addedInShouldUpgrade"
@@ -84,5 +355,60 @@ final class AsyncRouteTests: XCTestCase {
         }) { res in
             XCTAssertEqual(res.headers.first(name: testMarkerHeaderKey), testMarkerHeaderValue)
         }
+    }
+
+    // https://github.com/vapor/vapor/issues/2716
+    func testGH2716() throws {
+        app.get("client") { req in
+            return req.client.get("http://localhost/status/2 1").map { $0.description }
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "/client") { res in
+            XCTAssertEqual(res.status.code, 500)
+        }
+    }
+
+    // https://github.com/vapor/vapor/issues/3137
+    // https://github.com/vapor/vapor/issues/3142
+    func testDoubleSlashRouteAccess() throws {
+        app.get(":foo", ":bar", "buz") { req -> String in
+            "\(try req.parameters.require("foo"))\(try req.parameters.require("bar"))"
+        }
+
+        try app.testable(method: .running(port: 0)).test(.GET, "/foop/barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "//foop/barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "//foop//barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "//foop//barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "/foop//barp/buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "/foop//barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "/foop/barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }.test(.GET, "//foop/barp//buz") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "foopbarp")
+        }
+    }
+}
+
+extension Vapor.WebSocket: Swift.Hashable {
+    public static func == (lhs: WebSocket, rhs: WebSocket) -> Bool {
+        lhs === rhs
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        ObjectIdentifier(self).hash(into: &hasher)
     }
 }

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -301,29 +301,21 @@ final class AuthenticationTests: XCTestCase {
 
     func testAsyncAuthenticator() throws {
         struct Test: Authenticatable {
-            static func authenticator(threadPool: NIOThreadPool) -> Authenticator {
+            static func authenticator(threadPool: NIOThreadPool) -> AsyncAuthenticator {
                 TestAuthenticator(threadPool: threadPool)
             }
             var name: String
         }
 
-        struct TestAuthenticator: BasicAuthenticator {
+        struct TestAuthenticator: AsyncBasicAuthenticator {
             typealias User = Test
             let threadPool: NIOThreadPool
 
-            func authenticate(basic: BasicAuthorization, for request: Request) -> EventLoopFuture<Void> {
-                let promise = request.eventLoop.makePromise(of: Void.self)
-                self.threadPool.submit { _ in
-                    sleep(1)
-                    request.eventLoop.execute {
-                        if basic.username == "test" && basic.password == "secret" {
-                            let test = Test(name: "Vapor")
-                            request.auth.login(test)
-                        }
-                        promise.succeed(())
-                    }
+            func authenticate(basic: BasicAuthorization, for request: Request) async throws {
+                if basic.username == "test" && basic.password == "secret" {
+                    let test = Test(name: "Vapor")
+                    request.auth.login(test)
                 }
-                return promise.futureResult
             }
         }
 

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -4,6 +4,7 @@ import Vapor
 import NIOCore
 import NIOPosix
 
+@available(*, deprecated, message: "Test old future APIs")
 final class AuthenticationTests: XCTestCase {
     func testBearerAuthenticator() throws {
         struct Test: Authenticatable {

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import Vapor
 import NIOCore
 
+@available(*, deprecated, message: "Test old future APIs")
 final class CacheTests: XCTestCase {
     func testInMemoryCache() throws {
         let app = Application(.testing)

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -202,34 +202,6 @@ final class ClientTests: XCTestCase {
 
         try app.running?.onStop.wait()
     }
-    
-    func testApplicationClientThreadSafety() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        let startingPistol = DispatchGroup()
-        startingPistol.enter()
-        startingPistol.enter()
-
-        let finishLine = DispatchGroup()
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: app.http.client.shared) == HTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.enter()
-        Thread.async {
-            startingPistol.leave()
-            startingPistol.wait()
-            XCTAssert(type(of: app.http.client.shared) == HTTPClient.self)
-            finishLine.leave()
-        }
-
-        finishLine.wait()
-    }
 
     func testCustomClient() throws {
         let app = Application(.testing)

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -14,6 +14,7 @@ import AsyncHTTPClient
 import NIOEmbedded
 import NIOConcurrencyHelpers
 
+@available(*, deprecated, message: "Testing deprecated future APIs")
 final class ClientTests: XCTestCase {
     var remoteAppPort: Int!
     var remoteApp: Application!

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -49,7 +49,7 @@ final class ClientTests: XCTestCase {
         }
 
         remoteApp.get("stalling") {
-            $0.eventLoop.scheduleTask(in: .seconds(5)) { SomeJSON() }.futureResult
+            $0.eventLoop.scheduleTask(in: .seconds(2)) { SomeJSON() }.futureResult
         }
         
         remoteApp.environment.arguments = ["serve"]

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -83,11 +83,7 @@ final class ClientTests: XCTestCase {
         try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         let res = try app.client.get("http://localhost:\(port)/redirect").wait()
 
         XCTAssertEqual(res.status, .seeOther)
@@ -106,11 +102,7 @@ final class ClientTests: XCTestCase {
         try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         _ = try app.client.get("http://localhost:\(port)/redirect").wait()
         
         app.http.client.configuration.redirectConfiguration = .follow(max: 1, allowCycles: false)

--- a/Tests/VaporTests/DotEnvTests.swift
+++ b/Tests/VaporTests/DotEnvTests.swift
@@ -37,10 +37,7 @@ final class DotEnvTests: XCTestCase {
     }
 
     func testReadFile() async throws {
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let pool = NIOThreadPool(numberOfThreads: 1)
-        pool.start()
-        let fileio = NonBlockingFileIO(threadPool: pool)
+        let fileio = NonBlockingFileIO(threadPool: NIOThreadPool.singleton)
         let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
         let path = "/" + folder + "/Utilities/test.env"
         let file = try await DotEnvFile.read(path: path, fileio: fileio)
@@ -62,8 +59,6 @@ final class DotEnvTests: XCTestCase {
         INCLUDE_SPACE=some spaced out string
         USERNAME=therealnerdybeast@example.tld
         """)
-        try await pool.shutdownGracefully()
-        try await elg.shutdownGracefully()
     }
 
     func testNoTrailingNewline() throws {

--- a/Tests/VaporTests/DotEnvTests.swift
+++ b/Tests/VaporTests/DotEnvTests.swift
@@ -5,7 +5,8 @@ import NIOPosix
 import NIOCore
 
 final class DotEnvTests: XCTestCase {
-    func testReadFile() throws {
+    @available(*, deprecated, message: "Test future API")
+    func testReadFileFuture() throws {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let pool = NIOThreadPool(numberOfThreads: 1)
         pool.start()
@@ -33,6 +34,36 @@ final class DotEnvTests: XCTestCase {
         """)
         try pool.syncShutdownGracefully()
         try elg.syncShutdownGracefully()
+    }
+
+    func testReadFile() async throws {
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let pool = NIOThreadPool(numberOfThreads: 1)
+        pool.start()
+        let fileio = NonBlockingFileIO(threadPool: pool)
+        let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")
+        let path = "/" + folder + "/Utilities/test.env"
+        let file = try await DotEnvFile.read(path: path, fileio: fileio)
+        let test = file.lines.map { $0.description }.joined(separator: "\n")
+        XCTAssertEqual(test, """
+        NODE_ENV=development
+        BASIC=basic
+        AFTER_LINE=after_line
+        UNDEFINED_EXPAND=$TOTALLY_UNDEFINED_ENV_KEY
+        EMPTY=
+        SINGLE_QUOTES=single_quotes
+        DOUBLE_QUOTES=double_quotes
+        EXPAND_NEWLINES=expand\nnewlines
+        DONT_EXPAND_NEWLINES_1=dontexpand\\nnewlines
+        DONT_EXPAND_NEWLINES_2=dontexpand\\nnewlines
+        EQUAL_SIGNS=equals==
+        RETAIN_INNER_QUOTES={"foo": "bar"}
+        RETAIN_INNER_QUOTES_AS_STRING={"foo": "bar"}
+        INCLUDE_SPACE=some spaced out string
+        USERNAME=therealnerdybeast@example.tld
+        """)
+        try await pool.shutdownGracefully()
+        try await elg.shutdownGracefully()
     }
 
     func testNoTrailingNewline() throws {

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -4,7 +4,17 @@ import Vapor
 import NIOCore
 
 final class EndpointCacheTests: XCTestCase {
-    
+
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
     actor CurrentActor {
         var current = 0
         
@@ -19,9 +29,6 @@ final class EndpointCacheTests: XCTestCase {
     
     
     func testEndpointCacheNoCache() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         let currentActor = CurrentActor()
         struct Test: Content {
             let number: Int
@@ -55,9 +62,6 @@ final class EndpointCacheTests: XCTestCase {
     }
 
     func testEndpointCacheMaxAge() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         let currentActor = CurrentActor()
         struct Test: Content {
             let number: Int

--- a/Tests/VaporTests/EnvironmentSecretTests.swift
+++ b/Tests/VaporTests/EnvironmentSecretTests.swift
@@ -2,6 +2,7 @@
 import XCTVapor
 import XCTest
 
+@available(*, deprecated, message: "Testing old future APIs")
 final class EnvironmentSecretTests: XCTestCase {
     func testNonExistingSecretFile() throws {
         let folder = #filePath.split(separator: "/").dropLast().joined(separator: "/")

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -3,6 +3,16 @@ import Vapor
 import Logging
 
 final class ErrorTests: XCTestCase {
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
     func testPrintable() throws {
         let expectedPrintable = """
         FooError.noFoo: You do not have a `foo`.
@@ -67,9 +77,6 @@ final class ErrorTests: XCTestCase {
     }
 
     func testAbortError() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.get("foo") { req -> String in
             throw Abort(.internalServerError, reason: "Foo")
         }
@@ -96,9 +103,6 @@ final class ErrorTests: XCTestCase {
     }
     
     func testErrorMiddlewareUsesContentConfiguration() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-        
         app.get("foo") { req -> String in
             throw Abort(.internalServerError, reason: "Foo")
         }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -305,8 +305,9 @@ final class FileTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         }
     }
-    
-    func testFileWrite() throws {
+
+    @available(*, deprecated, message: "Test future API")
+    func testFileWriteFuture() throws {
         let request = Request(application: app, on: app.eventLoopGroup.next())
         
         let data = "Hello"
@@ -315,6 +316,19 @@ final class FileTests: XCTestCase {
         try request.fileio.writeFile(ByteBuffer(string: data), at: path).wait()
         defer { try? FileManager.default.removeItem(atPath: path) }
         
+        let result = try String(contentsOfFile: path)
+        XCTAssertEqual(result, data)
+    }
+
+    func testFileWrite() async throws {
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+
+        let data = "Hello"
+        let path = "/tmp/fileio_write.txt"
+
+        try await request.fileio.writeFile(ByteBuffer(string: data), at: path)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
         let result = try String(contentsOfFile: path)
         XCTAssertEqual(result, data)
     }

--- a/Tests/VaporTests/LoggingTests.swift
+++ b/Tests/VaporTests/LoggingTests.swift
@@ -3,10 +3,17 @@ import Vapor
 import XCTest
 
 final class LoggingTests: XCTestCase {
-    func testChangeRequestLogLevel() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
+    var app: Application!
 
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testChangeRequestLogLevel() throws {
         app.get("trace") { req -> String in
             req.logger.logLevel = .trace
             req.logger.trace("foo")

--- a/Tests/VaporTests/MetricsTests.swift
+++ b/Tests/VaporTests/MetricsTests.swift
@@ -5,12 +5,19 @@ import Metrics
 import XCTest
 
 class MetricsTests: XCTestCase {
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
     func testMetricsIncreasesCounter() {
         let metrics = CapturingMetricsSystem()
         MetricsSystem.bootstrapInternal(metrics)
-
-        let app = Application(.testing)
-        defer { app.shutdown() }
 
         struct User: Content {
             let id: Int
@@ -54,9 +61,6 @@ class MetricsTests: XCTestCase {
         let metrics = CapturingMetricsSystem()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         struct User: Content {
             let id: Int
             let name: String
@@ -98,9 +102,6 @@ class MetricsTests: XCTestCase {
         let metrics = CapturingMetricsSystem()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         XCTAssertNoThrow(try app.testable().test(.GET, "/not/found") { res in
             XCTAssertEqual(res.status, .notFound)
             XCTAssertEqual(metrics.counters.count, 1)
@@ -127,9 +128,7 @@ class MetricsTests: XCTestCase {
         let metrics = CapturingMetricsSystem()
         MetricsSystem.bootstrapInternal(metrics)
 
-        let app = Application(.testing)
         app.http.server.configuration.reportMetrics = false
-        defer { app.shutdown() }
 
         struct User: Content {
             let id: Int

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -178,11 +178,7 @@ final class MiddlewareTests: XCTestCase {
 
         try await app.server.start(address: .hostname("127.0.0.1", port: 0))
 
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         let response = try await app.client.get("http://localhost:\(port)/testTracing?foo=bar") { req in
             req.headers.add(name: HTTPHeaders.Name.userAgent.description, value: "test")
             req.headers.add(name: TestTracer.extractKey, value: "extracted")

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -185,6 +185,7 @@ final class MiddlewareTests: XCTestCase {
 
         let response = try await app.client.get("http://localhost:\(port)/testTracing?foo=bar") { req in
             req.headers.add(name: HTTPHeaders.Name.userAgent.description, value: "test")
+            req.headers.add(name: TestTracer.extractKey, value: "extracted")
         }
 
         XCTAssertEqual(response.status, .ok)

--- a/Tests/VaporTests/PasswordTests.swift
+++ b/Tests/VaporTests/PasswordTests.swift
@@ -4,11 +4,17 @@ import Vapor
 import NIOCore
 
 final class PasswordTests: XCTestCase {
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
     func testSyncBCryptService() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
-        
         let hash = try app.password.hash("vapor")
         XCTAssertTrue(try BCryptDigest().verify("vapor", created: hash))
         
@@ -17,9 +23,6 @@ final class PasswordTests: XCTestCase {
     }
     
     func testSyncPlaintextService() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
         app.passwords.use(.plaintext)
         
         let hash = try app.password.hash("vapor")
@@ -30,41 +33,22 @@ final class PasswordTests: XCTestCase {
     }
     
     func testAsyncBCryptRequestPassword() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
-        
         try assertAsyncRequestPasswordVerifies(.bcrypt, on: app)
     }
     
     func testAsyncPlaintextRequestPassword() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
-        
         try assertAsyncRequestPasswordVerifies(.plaintext, on: app)
     }
     
     func testAsyncBCryptApplicationPassword() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
-        
         try assertAsyncApplicationPasswordVerifies(.bcrypt, on: app)
     }
     
     func testAsyncPlaintextApplicationPassword() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
-        
         try assertAsyncApplicationPasswordVerifies(.plaintext, on: app)
     }
     
     func testAsyncUsesProvider() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
         app.passwords.use(.plaintext)
         let hash = try app.password.async(
             on: app.threadPool,
@@ -74,9 +58,6 @@ final class PasswordTests: XCTestCase {
     }
 
     func testAsyncApplicationDefault() throws {
-        let test = Environment(name: "testing", arguments: ["vapor"])
-        let app = Application(test)
-        defer { app.shutdown() }
         app.passwords.use(.plaintext)
         let hash = try app.password.async.hash("vapor").wait()
         XCTAssertEqual(hash, "vapor")

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -155,7 +155,7 @@ final class PipelineTests: XCTestCase {
         let client = HTTPClient()
 
         do {
-            try await client.post(url: "http://localhost:\(port)/fail").get()
+            _ = try await client.post(url: "http://localhost:\(port)/fail").get()
             XCTFail("Client has failed to detect broken server response")
         } catch {
             if let error = error as? HTTPParserError {

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -5,10 +5,17 @@ import NIOCore
 import NIOHTTP1
 
 final class QueryTests: XCTestCase {
-    func testQuery() throws {
-        let app = Application()
-        defer { app.shutdown() }
+    var app: Application!
 
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testQuery() throws {
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json
         request.url.path = "/foo"
@@ -17,9 +24,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testQueryAsArray() throws {
-        let app = Application()
-        defer { app.shutdown() }
-
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json
         request.url.path = "/foo"
@@ -30,9 +34,6 @@ final class QueryTests: XCTestCase {
 
     // https://github.com/vapor/vapor/pull/2163
     func testWrappedSingleValueQueryDecoding() throws {
-        let app = Application()
-        defer { app.shutdown() }
-
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json
         request.url.path = "/foo"
@@ -52,9 +53,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testNotCrashingArrayWithPercentEncoding() throws {
-        let app = Application()
-        defer { app.shutdown() }
-
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json
         request.url.path = "/"
@@ -64,9 +62,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testQueryGet() throws {
-        let app = Application()
-        defer { app.shutdown() }
-
         var req: Request
 
         //
@@ -115,9 +110,6 @@ final class QueryTests: XCTestCase {
 
     // https://github.com/vapor/vapor/issues/1537
     func testQueryStringRunning() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.routes.get("todos") { req in
             return "hi"
         }
@@ -140,9 +132,6 @@ final class QueryTests: XCTestCase {
             var name: String
             var age: Int
         }
-
-        let app = Application(.testing)
-        defer { app.shutdown() }
 
         app.get("urlencodedform") { req -> HTTPStatus in
             let foo = try req.query.decode(User.self)
@@ -173,9 +162,6 @@ final class QueryTests: XCTestCase {
             var age: Int
         }
 
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.get("urlencodedform") { req -> HTTPStatus in
             let foo = try req.query.decode(User.self)
             XCTAssertEqual(foo.name, "Vapor")
@@ -193,9 +179,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testCustomEncode() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.get("custom-encode") { req -> Response in
             let res = Response(status: .ok)
             let jsonEncoder = JSONEncoder()
@@ -220,9 +203,6 @@ final class QueryTests: XCTestCase {
             var missing: String
         }
 
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.post("decode-fail") { req -> String in
             _ = try req.content.decode(DecodeFail.self)
             return "ok"
@@ -242,9 +222,6 @@ final class QueryTests: XCTestCase {
 
     // https://github.com/vapor/vapor/issues/1687
     func testRequestQueryStringPercentEncoding() throws {
-        let app = Application()
-        defer { app.shutdown() }
-
         struct TestQueryStringContainer: Content {
             var name: String
         }
@@ -277,8 +254,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testOptionalGet() throws {
-        let app = Application()
-        defer { app.shutdown() }
         let req = Request(
             application: app,
             method: .GET,
@@ -302,8 +277,6 @@ final class QueryTests: XCTestCase {
     }
 
     func testValuelessParamGet() throws {
-        let app = Application()
-        defer { app.shutdown() }
         let req = Request(
             application: app,
             method: .GET,
@@ -344,8 +317,6 @@ final class QueryTests: XCTestCase {
             let closedRange: ClosedRange<Double>
         }
         
-        let app = Application()
-        defer { app.shutdown() }
         
         let request = Request(application: app, on: app.eventLoopGroup.next())
         request.headers.contentType = .json

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -166,11 +166,7 @@ final class RequestTests: XCTestCase {
         try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-        
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         XCTAssertEqual(
             try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,
             .seeOther
@@ -211,11 +207,7 @@ final class RequestTests: XCTestCase {
         try app.server.start(address: .hostname("localhost", port: 0))
         defer { app.server.shutdown() }
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port for app")
-            return
-        }
-        
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         XCTAssertEqual(
             try app.client.get("http://localhost:\(port)/redirect_normal").wait().status,
             .seeOther

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import Vapor
 import NIOCore
 
+@available(*, deprecated, message: "Test old future APIs")
 final class RequestTests: XCTestCase {
     
     func testCustomHostAddress() throws {

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -4,6 +4,7 @@ import Vapor
 import NIOCore
 import NIOHTTP1
 
+@available(*, deprecated, message: "Test old future APIs")
 final class RouteTests: XCTestCase {
     func testParameter() throws {
         let app = Application(.testing)

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -879,11 +879,7 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         app.environment.arguments = ["serve"]
         try app.start()
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port")
-            return
-        }
-        
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/echo",
             method: .POST,
@@ -946,11 +942,7 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         app.environment.arguments = ["serve"]
         try await app.startup()
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port")
-            return
-        }
-        
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/echo",
             method: .POST,
@@ -1076,11 +1068,7 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         app.environment.arguments = ["serve"]
         try app.start()
         
-        guard let port = app.http.server.shared.localAddress?.port else {
-            XCTFail("Failed to get port")
-            return
-        }
-        
+        let port = try XCTUnwrap(app.http.server.shared.localAddress?.port, "Failed to get port")
         let request = try HTTPClient.Request(
             url: "http://localhost:\(port)/hello",
             method: .GET,

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -28,22 +28,23 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         try await app.asyncShutdown()
     }
     
-    func testPortOverride() throws {
+    func testPortOverride() async throws {
         let env = Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--port", "8123"]
         )
         
-        let app = Application(env)
-        defer { app.shutdown() }
+        let app = try await Application.make(env)
         
         app.get("foo") { req in
             return "bar"
         }
-        try app.start()
-        
-        let res = try app.client.get("http://127.0.0.1:8123/foo").wait()
+        try await app.startup()
+
+        let res = try await app.client.get("http://127.0.0.1:8123/foo")
         XCTAssertEqual(res.body?.string, "bar")
+
+        try await app.asyncShutdown()
     }
     
     // `httpUnixDomainSocket` is currently broken in 6.0
@@ -70,8 +71,8 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
     }
     #endif
     
-    func testIncompatibleStartupOptions() throws {
-        func checkForError(_ app: Application) {
+    func testIncompatibleStartupOptions() async throws {
+        func checkForError(_ app: Application) async throws {
             XCTAssertThrowsError(try app.start()) { error in
                 XCTAssertNotNil(error as? ServeCommand.Error)
                 guard let serveError = error as? ServeCommand.Error else {
@@ -81,62 +82,62 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
                 
                 XCTAssertEqual(ServeCommand.Error.incompatibleFlags, serveError)
             }
-            app.shutdown()
+            try await app.asyncShutdown()
         }
         
-        var app = Application(Environment(
+        var app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--port", "8123", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--hostname", "localhost", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--hostname", "1.2.3.4"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--port", "8081"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--port", "8081", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--hostname", "1.2.3.4", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--hostname", "1.2.3.4", "--port", "8081", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
-        
-        app = Application(Environment(
+        try await checkForError(app)
+
+        app = try await Application.make(Environment(
             name: "testing",
             arguments: ["vapor", "serve", "--bind", "localhost:8123", "--hostname", "1.2.3.4", "--port", "8081", "--unix-socket", "/path/to/socket"]
         ))
-        checkForError(app)
+        try await checkForError(app)
     }
     
     @available(*, deprecated)
@@ -933,10 +934,9 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(client, ["foo", "bar", "baz"])
     }
     
-    func testSkipStreaming() throws {
+    func testSkipStreaming() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let app = Application(.testing, .shared(eventLoopGroup))
-        defer { app.shutdown() }
+        let app = try await Application.make(.testing, .shared(eventLoopGroup))
         
         app.on(.POST, "echo", body: .stream) { request in
             "hello, world"
@@ -944,7 +944,7 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         
         app.http.server.configuration.port = 0
         app.environment.arguments = ["serve"]
-        try app.start()
+        try await app.startup()
         
         guard let port = app.http.server.shared.localAddress?.port else {
             XCTFail("Failed to get port")
@@ -969,10 +969,12 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
             })
         )
         
-        let a = try app.http.client.shared.execute(request: request).wait()
+        let a = try await app.http.client.shared.execute(request: request).get()
         XCTAssertEqual(a.status, .ok)
-        let b = try app.http.client.shared.execute(request: request).wait()
+        let b = try await app.http.client.shared.execute(request: request).get()
         XCTAssertEqual(b.status, .ok)
+
+        try await app.asyncShutdown()
     }
     
     func testStartWithValidSocketFile() throws {

--- a/Tests/VaporTests/ServiceTests.swift
+++ b/Tests/VaporTests/ServiceTests.swift
@@ -4,10 +4,17 @@ import Vapor
 import NIOCore
 
 final class ServiceTests: XCTestCase {
-    func testReadOnly() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
+    var app: Application!
 
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testReadOnly() throws {
         app.get("test") { req in
             req.readOnly.foos()
         }
@@ -19,16 +26,11 @@ final class ServiceTests: XCTestCase {
     }
 
     func testWritable() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.writable = .init(apiKey: "foo")
         XCTAssertEqual(app.writable?.apiKey, "foo")
     }
 
     func testLifecycle() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
         app.http.server.configuration.port = 0
 
         app.lifecycle.use(Hello())
@@ -48,9 +50,6 @@ final class ServiceTests: XCTestCase {
     }
 
     func testLocks() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
         app.sync.withLock {
             // Do something.
         }
@@ -64,9 +63,6 @@ final class ServiceTests: XCTestCase {
     }
     
     func testServiceHelpers() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-        
         let testString = "This is a test - \(Int.random())"
         let myFakeServicce = MyTestService(cannedResponse: testString, eventLoop: app.eventLoopGroup.next(), logger: app.logger)
         

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -4,17 +4,24 @@ import Vapor
 import NIOCore
 
 final class ViewTests: XCTestCase {
-    func testViewResponse() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
+    var app: Application!
 
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testViewResponse() async throws {
         app.get("view") { req -> View in
             var data = ByteBufferAllocator().buffer(capacity: 0)
             data.writeString("<h1>hello</h1>")
             return View(data: data)
         }
 
-        try app.testable().test(.GET, "/view") { res in
+        try await app.testable().test(.GET, "/view") { res async in
             XCTAssertEqual(res.status.code, 200)
             XCTAssertEqual(res.headers.contentType, .html)
             XCTAssertEqual(res.body.string, "<h1>hello</h1>")

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import WebSocketKit
 import NIOPosix
 
+@available(*, deprecated, message: "Test old future APIs")
 final class WebSocketTests: XCTestCase {
     func testWebSocketClient() throws {
         let server = Application(.testing)
@@ -152,15 +153,5 @@ final class WebSocketTests: XCTestCase {
 
     override class func setUp() {
         XCTAssertTrue(isLoggingConfigured)
-    }
-}
-
-extension Vapor.WebSocket: Swift.Hashable {
-    public static func == (lhs: WebSocket, rhs: WebSocket) -> Bool {
-        lhs === rhs
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        ObjectIdentifier(self).hash(into: &hasher)
     }
 }


### PR DESCRIPTION
Fixes a number of `Sendable` warnings introduced by https://github.com/apple/swift-nio/releases/tag/2.79.0

This also deprecates the main `Application.init()` API that was blocking on an event loop that has been marked as `noasync` for a while. Vapor users should migrate to the async APIs.