### PR TITLE
Fix `request.body.data` becomes nil instead of empty when the request body is empty

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerRequestDecoder.swift
@@ -105,6 +105,7 @@ final class HTTPServerRequestDecoder: ChannelDuplexHandler, RemovableChannelHand
             switch self.requestState {
             case .ready: assertionFailure("Unexpected state: \(self.requestState)")
             case .awaitingBody(let request):
+                request.bodyStorage.withLockedValue { $0 = .collected(ByteBuffer()) }
                 context.fireChannelRead(self.wrapInboundOut(request))
             case .awaitingEnd(let request, let buffer):
                 request.bodyStorage.withLockedValue { $0 = .collected(buffer) }


### PR DESCRIPTION
When parsing a request, if it is determined that the body is empty, the `request.bodyStorage` is set to `.collected(ByteBuffer())`, resulting in `request.body.data` being empty data.
This ensures that even with an empty body, such as with `x-www-form-urlencoded`, decoding can proceed correctly.

- Fixes: https://github.com/vapor/vapor/issues/3288