### PR TITLE
Use singleton NIOThreadPool by default

### DIFF
--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -43,6 +43,7 @@ extension Application {
                     try $0.syncShutdownGracefully()
                 } catch is NIOThreadPoolError.UnsupportedOperation {
                     // ignore, singleton thread pool throws this error on shutdown attempts
+                    // see https://github.com/apple/swift-nio/blob/c51907a839e63ebf0ba2076bba73dd96436bd1b9/Sources/NIOPosix/NIOThreadPool.swift#L142-L147
                 } catch {
                     fatalError("Unexpected error shutting down old thread pool")
                 }
@@ -105,6 +106,7 @@ extension Application {
                     try application.threadPool.syncShutdownGracefully()
                 } catch is NIOThreadPoolError.UnsupportedOperation {
                     // ignore, singleton thread pool throws this error on shutdown attempts
+                    // see https://github.com/apple/swift-nio/blob/c51907a839e63ebf0ba2076bba73dd96436bd1b9/Sources/NIOPosix/NIOThreadPool.swift#L142-L147
                 } catch {
                     application.logger.debug("Failed to shutdown thread pool", metadata: ["error": "\(error)"])
                 }
@@ -117,6 +119,7 @@ extension Application {
                     try await application.threadPool.shutdownGracefully()
                 } catch is NIOThreadPoolError.UnsupportedOperation {
                     // ignore, singleton thread pool throws this error on shutdown attempts
+                    // see https://github.com/apple/swift-nio/blob/c51907a839e63ebf0ba2076bba73dd96436bd1b9/Sources/NIOPosix/NIOThreadPool.swift#L142-L147
                 } catch {
                     application.logger.debug("Failed to shutdown thread pool", metadata: ["error": "\(error)"])
                 }

--- a/Sources/Vapor/Core/Core.swift
+++ b/Sources/Vapor/Core/Core.swift
@@ -39,7 +39,13 @@ extension Application {
             }
 
             self.core.storage.threadPool.withLockedValue({
-                try! $0.syncShutdownGracefully()
+                do {
+                    try $0.syncShutdownGracefully()
+                } catch is NIOThreadPoolError.UnsupportedOperation {
+                    // ignore, singleton thread pool throws this error on shutdown attempts
+                } catch {
+                    fatalError("Unexpected error shutting down old thread pool")
+                }
                 $0 = newValue
                 $0.start()
             })


### PR DESCRIPTION
All Vapor applications currently end up with at least two running thread pools - the global singleton and the one created by Vapor by default. This change configures the global singleton (whose thread count defaults to `System.coreCount` anyway) as the default, eliminating the additional thread pool. This is especially nice for backtraces, as it cuts down noticeably on the number of excess threads in a Vapor process.

We also now ignore `UnsupportedOperation` errors during thread pool shutdown, which is necessary for using the singleton pool, and was previously preventing users from explicitly configuring use of the singleton thread pool, due to the (inconsistent) use of `try!`.