### PR TITLE
Decode percent-encoded path segments to fix Unicode route matching (#3309)

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -79,7 +79,13 @@ internal struct DefaultResponder: Responder {
         let pathComponents = request.url.path
             .split(separator: "/")
             .map(String.init)
-        
+            .map { path in
+                guard path.contains("%") else {
+                    return path
+                }
+                return path.removingPercentEncoding ?? path
+            }
+
         // If it's a HEAD request and a HEAD route exists, return that route...
         if request.method == .HEAD, let route = self.router.route(
             path: [HTTPMethod.HEAD.rawValue] + pathComponents,

--- a/Tests/VaporTests/AsyncRouteTests.swift
+++ b/Tests/VaporTests/AsyncRouteTests.swift
@@ -401,6 +401,29 @@ final class AsyncRouteTests: XCTestCase {
             XCTAssertEqual(res.body.string, "foopbarp")
         }
     }
+
+    func testUnicodePath() throws {
+        app.get("Good👍") { req in
+            "👍"
+        }
+        app.get("ようこそ世界へ") { req in
+            "おめでとう"
+        }
+        app.get("ascii", "🙆‍♂️") { req in
+            "🙅‍♂️"
+        }
+        
+        try app.testable(method: .running(port: 0)).test(.GET, "/Good👍") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "👍")
+        }.test(.GET, "/ようこそ世界へ") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "おめでとう")
+        }.test(.GET, "/ascii/🙆‍♂️") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "🙅‍♂️")
+        }
+    }
 }
 
 extension Vapor.WebSocket: Swift.Hashable {


### PR DESCRIPTION
**Summary**

This pull request addresses an issue where routes containing Unicode characters (such as emojis or Japanese text) always return a `NotFound` response. The root cause was that incoming path segments are percent-encoded, causing mismatches with the stored routes. By decoding any segments that contain `%` in `DefaultResponder.getRoute()`, we ensure that the router can correctly match Unicode paths.

**Changes**

- Modified `DefaultResponder.getRoute(for:)` to decode percent-encoded segments before routing.
- Added a new `testUnicodePath` test case in `AsyncRouteTests` to verify that routes with emojis and other multi-byte characters can now be matched correctly.

**Reasoning**

- Attempting to register already-encoded routes was problematic, as different HTTP clients may use varying cases (uppercase vs lowercase) for percent-encoded characters.
- Decoding on-the-fly in the responder is more robust and ensures consistent matching regardless of the client’s encoding style.

**Testing**

- A new test `testUnicodePath` has been added. It defines routes with emojis and Japanese text and verifies that they return the expected response. All tests pass locally.

**Issue Reference**

- Resolves #3309

Thank you for reviewing this PR! If you have any questions or suggestions, please let me know.
