### PR TITLE
Range eof

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -263,11 +263,12 @@ extension HTTPHeaders.Range.Value {
             }
             return .withinWithLimit(start: (limit - end), end: limit - 1, limit: limit)
         case .within(let start, let end):
-            guard start >= 0, end >= 0, start <= end, start <= limit, end <= limit else {
+            guard start >= 0, end >= 0, start < end, start <= limit else {
                 throw Abort(.badRequest)
             }
             
-            return .withinWithLimit(start: start, end: end, limit: limit)
+            let myEnd = min(end, limit)
+            return .withinWithLimit(start: start, end: myEnd, limit: limit)
         }
     }
 }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -267,8 +267,8 @@ extension HTTPHeaders.Range.Value {
                 throw Abort(.badRequest)
             }
             
-            let myEnd = min(end, limit)
-            return .withinWithLimit(start: start, end: myEnd, limit: limit)
+            let endToRequest = min(end, limit)
+            return .withinWithLimit(start: start, end: endToRequest, limit: limit)
         }
     }
 }

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+ContentRange.swift
@@ -263,7 +263,7 @@ extension HTTPHeaders.Range.Value {
             }
             return .withinWithLimit(start: (limit - end), end: limit - 1, limit: limit)
         case .within(let start, let end):
-            guard start >= 0, end >= 0, start < end, start <= limit else {
+            guard start >= 0, end >= 0, start <= end, start <= limit else {
                 throw Abort(.badRequest)
             }
             

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -614,7 +614,7 @@ extension HTTPHeaders.Range.Value {
                     throw Abort(.badRequest)
                 }
                     // Request past EOF, return up to EOF bytes
-                let end = min(end,size)
+                let end = min(end,size-start-1)
                 let (byteCount, overflow) =  (end - start).addingReportingOverflow(1)
                 guard !overflow else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -609,21 +609,18 @@ extension HTTPHeaders.Range.Value {
                 }
                 return (offset: numericCast(size - value), byteCount: value)
             case .within(let start, let end):
-                guard start >= 0, end >= 0, start < end, start <= size else {
+                guard start >= 0, end >= 0, start <= end, start <= size else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
+                    // Request past EOF, return up to EOF bytes
+                let end = min(end,size)
                 let (byteCount, overflow) =  (end - start).addingReportingOverflow(1)
                 guard !overflow else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
-                var byteCountToReqeust = byteCount
-                    // Request past EOF, return up to EOF bytes
-                if (end > size) {
-                    byteCountToReqeust = byteCount - (end - size)
-                }
-                return (offset: numericCast(start), byteCount: byteCountToReqeust)
+                return (offset: numericCast(start), byteCount: byteCount)
         }
     }
 }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -594,6 +594,7 @@ public struct FileIO: Sendable {
 extension HTTPHeaders.Range.Value {
     
     fileprivate func asByteBufferBounds(withMaxSize size: Int, logger: Logger) throws -> (offset: Int64, byteCount: Int) {
+
         switch self {
             case .start(let value):
                 guard value <= size, value >= 0 else {
@@ -608,7 +609,7 @@ extension HTTPHeaders.Range.Value {
                 }
                 return (offset: numericCast(size - value), byteCount: value)
             case .within(let start, let end):
-                guard start >= 0, end >= 0, start <= end, start <= size, end <= size else {
+                guard start >= 0, end >= 0, start < end, start <= size else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
@@ -617,7 +618,8 @@ extension HTTPHeaders.Range.Value {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
-                return (offset: numericCast(start), byteCount: byteCount)
+                let myByteCount = end <= size ? byteCount : byteCount - (end - size)
+                return (offset: numericCast(start), byteCount: myByteCount)
         }
     }
 }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -614,8 +614,8 @@ extension HTTPHeaders.Range.Value {
                     throw Abort(.badRequest)
                 }
                     // Request past EOF, return up to EOF bytes
-                let end = min(end,size-start-1)
-                let (byteCount, overflow) =  (end - start).addingReportingOverflow(1)
+                let validEnd = min(end,size-1)
+                let (byteCount, overflow) =  (validEnd - start).addingReportingOverflow(1)
                 guard !overflow else {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -618,8 +618,12 @@ extension HTTPHeaders.Range.Value {
                     logger.debug("Requested range was invalid: \(start)-\(end)")
                     throw Abort(.badRequest)
                 }
-                let myByteCount = end <= size ? byteCount : byteCount - (end - size)
-                return (offset: numericCast(start), byteCount: myByteCount)
+                var byteCountToReqeust = byteCount
+                    // Request past EOF, return up to EOF bytes
+                if (end > size) {
+                    byteCountToReqeust = byteCount - (end - size)
+                }
+                return (offset: numericCast(start), byteCount: byteCountToReqeust)
         }
     }
 }

--- a/Tests/VaporTests/AsyncFileTests.swift
+++ b/Tests/VaporTests/AsyncFileTests.swift
@@ -229,7 +229,7 @@ final class AsyncFileTests: XCTestCase, @unchecked Sendable {
 
         headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 10, end: 100000000)])
         try await app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res async in
-            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertEqual(res.status, .partialContent)
         }
     }
     
@@ -297,7 +297,7 @@ final class AsyncFileTests: XCTestCase, @unchecked Sendable {
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .range, value: "bytes=0-9223372036854775807")
         try await app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res async in
-            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertEqual(res.status, .partialContent)
         }
         
         headers.replaceOrAdd(name: .range, value: "bytes=-1-10")

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -254,9 +254,26 @@ final class FileTests: XCTestCase {
             XCTAssertEqual(res.status, .badRequest)
         }
 
-        headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 10, end: 100000000)])
+        let offset = 10
+        headerRequest.range = .init(unit: .bytes, ranges: [.within(start: offset, end: 100000000)])
         try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
             XCTAssertEqual(res.status, .partialContent)
+            // Test content-range and number of bytes returned
+            do {
+                var fileSize = 0
+                let attr: Dictionary? = try FileManager.default.attributesOfItem(atPath: #file)
+                if let _attr = attr {
+                    fileSize = _attr[.size] as? Int ?? 0
+                }
+                let range = res.headers.first(name: .contentRange)!.split(separator: "/").first!.split(separator: " ").last!
+                XCTAssertEqual(range, "10-\(fileSize)")
+                
+                let count = res.body.readableBytes
+                XCTAssertEqual(count, fileSize-offset)
+            }
+            catch {
+                XCTFail("Checking content-range should have succeeded")
+            }
         }
     }
     

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -256,7 +256,7 @@ final class FileTests: XCTestCase {
 
         headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 10, end: 100000000)])
         try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headerRequest) { res in
-            XCTAssertEqual(res.status, .badRequest)
+            XCTAssertEqual(res.status, .partialContent)
         }
     }
     

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -453,7 +453,7 @@ final class FileTests: XCTestCase {
         }
 
         var headers = HTTPHeaders()
-        headers.replaceOrAdd(name: .range, value: "bytes=0-9223372036854775807")
+        headers.replaceOrAdd(name: .range, value: "bytes=-9-9223372036854775807")
         try app.testable(method: .running(port: 0)).test(.GET, "/file-stream", headers: headers) { res in
             XCTAssertEqual(res.status, .badRequest)
         }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -365,6 +365,16 @@ final class HTTPHeaderTests: XCTestCase {
         )
     }
     
+    func testRangeLimit() throws {
+        let contentRanges = HTTPHeaders.Range(unit: .bytes, ranges: [
+            .within(start: 200, end: 1000)
+        ])
+
+        let firstRange = contentRanges.ranges.first
+        let accept = try firstRange!.asResponseContentRange(limit: 600)
+        XCTAssertEqual(accept.serialize(), "200-600/600")
+    }
+    
     func testLinkHeaderParsing() throws {
         let headers = HTTPHeaders([
             ("link", #"<https://localhost/?a=1>; rel="next", <https://localhost/?a=2>; rel="last"; custom1="whatever", </?a=-1>; rel=related, </?a=-2>; rel=related"#)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

Content range requests past EOF will fail witth the current version of vapor.   It is common practice to just return the remaining bytes rather than throw a bad request error. This helps  existing imperfect clients, still out there in the wild to continue to function.

This change captures an attempt to read past EOF (eg  a range request of 10-200, when there are only 180 bytes in the file), and returns a response of "partial content" and the remaining bytes.  It replaces code that returned a "bad request" error.

The existing tests have been updated to reflect this change and test for a response of type "partial content". 
In addition two new asserts have been added to a test:
- The response header content range meets expectation
- The response body byte count meets expectation

As well as passing all tests, the code has been tested with a real life test case.

NOTE: The test 'AsyncRouteTests.testGH2716()' does not not pass. However, it does not pass on the vapor/main branch from which this has been forked.