### PR TITLE
The RouteNotFound that is used when the router finds nothing is now public

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -141,16 +141,16 @@ private struct NotFoundResponder: Responder {
     }
 }
 
-struct RouteNotFound: Error {}
+public struct RouteNotFound: Error {}
 
-extension RouteNotFound: AbortError {    
-    var status: HTTPResponseStatus {
+extension RouteNotFound: AbortError {
+    public var status: HTTPResponseStatus {
         .notFound
     }
 }
 
 extension RouteNotFound: DebuggableError {
-    var logLevel: Logger.Level { 
+    public var logLevel: Logger.Level {
         .debug
     }
 }


### PR DESCRIPTION
When no routes match the current request, `DefaultResponder` throws the `RouteNotFound` error.

This PR makes that error public, allowing any middleware to handle that specific scenario.

Unlike the CatchAll route `**`, a middleware catching the `RouteNotFound` works across all HTTP methods automatically.

This would be used in a middleware like so:

```swift
public struct CatchAllMiddleware: AsyncMiddleware {
    public func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
        do {
            return try await next.respond(to: request)
        } catch is RouteNotFound {
            // No route was found, so this would normally result in a 404. 
            // We can now handle this like any other request.
            // Or we can make treat it like an ErrorMiddleware where we 
            // log purposeful 404s different than `RouteNotFound` 404s.
            ...
        }
    }
}
```