### PR TITLE
Improve `VaporTesting`'s `withApp` method

### DIFF
--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -17,7 +17,7 @@ import Vapor
 /// ```
 ///
 /// - Parameters:
-///   - configure: The method where you should register services like routes, databases, providers, and more.
+///   - configure: A closure where you can register routes, databases, providers, and more.
 ///   - test: The method where you can perform your tests with the configured application.
 @discardableResult
 public func withApp<T>(

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -27,9 +27,7 @@ public func withApp<T>(
     let app = try await Application.make(.testing)
     let result: T
     do {
-        if let configure {
-            try await configure(app)
-        }
+        try await configure?(app)
         result = try await test(app)
     } catch {
         try? await app.asyncShutdown()

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -19,7 +19,8 @@ import Vapor
 /// - Parameters:
 ///   - configure: The method where you should register services like routes, databases, providers, and more.
 ///   - test: The method where you can perform your tests with the configured application.
-@discardableResult public func withApp<T>(
+@discardableResult
+public func withApp<T>(
     configure: ((Application) async throws -> Void)? = nil,
     _ test: (Application) async throws -> T
 ) async throws -> T {

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -36,3 +36,26 @@ public func withApp<T>(
     try await app.asyncShutdown()
     return result
 }
+
+
+/// Perform a test while handling lifecycle of the application.
+/// Feel free to create a custom function like this, tailored to your project.
+///
+/// Usage:
+/// ```swift
+/// @Test
+/// func helloWorld() async throws {
+///     try await withApp { app in
+///         try await app.testing().test(.GET, "hello", afterResponse: { res async in
+///             #expect(res.status == .ok)
+///             #expect(res.body.string == "Hello, world!")
+///         })
+///     }
+/// }
+/// ```
+@discardableResult
+public func withApp<T>(
+    _ test: (Application) async throws -> T
+) async throws -> T {
+    try await withApp(configure: nil, test)
+}

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -18,7 +18,7 @@ import Vapor
 ///
 /// - Parameters:
 ///   - configure: A closure where you can register routes, databases, providers, and more.
-///   - test: The method where you can perform your tests with the configured application.
+///   - test: A closure which performs your actual test with the configured application.
 @discardableResult
 public func withApp<T>(
     configure: ((Application) async throws -> Void)? = nil,

--- a/Tests/VaporTests/VaporTesting.swift
+++ b/Tests/VaporTests/VaporTesting.swift
@@ -56,5 +56,27 @@ struct VaporTestingTests {
             }
         }
     }
+
+    @Test
+    func withAppConfiguration() async throws {
+        try await withApp { app in         
+            try await app.testing().test(.GET, "hello") { res in
+                #expect(res.status == .notFound)
+            }
+        }
+        
+        func configure(_ app: Application) async throws {
+            app.get("hello") { req async -> String in
+                "Hello, world!"
+            }
+        }
+
+        try await withApp(configure: configure) { app in         
+            try await app.testing().test(.GET, "hello") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "Hello, world!")
+            }
+        }
+    }
 }
 #endif


### PR DESCRIPTION
**These changes are now available in [4.115.0](https://github.com/vapor/vapor/releases/tag/4.115.0)**


This PR makes the `withApp` helper method work as advertised, allowing an optional configuration method for the `Application` to be passed.

Also, marks it with `@discardableResult` to avoid unnecessary warnings.