### PR TITLE
docs: fix `allow`/`disallow` mentions

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -193,7 +193,7 @@ public struct HTTPMediaTypeSet: Sendable {
         guard let mediaSubTypeLookup = mediaTypeLookup[mediaType.type]
         else { return false }
         
-        /// If we alow any of the subtypes, stop here.
+        /// If we allow any of the subtypes, stop here.
         if mediaSubTypeLookup["*"] != nil { return true }
         
         /// Make sure we have an entry for the specific sub type:

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+ResponseCompressionConfiguration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+ResponseCompressionConfiguration.swift
@@ -37,7 +37,7 @@ extension HTTPServer.Configuration {
             )
         }
         
-        /// Enables compression by default, dissallowing already compressed types such as images or video, unless a route overrides the preference.
+        /// Enables compression by default, disallowing already compressed types such as images or video, unless a route overrides the preference.
         ///
         /// - SeeAlso: See ``ResponseCompressionMiddleware`` for more information on overriding compression preferences in routes.
         public static var enabled: Self {
@@ -80,7 +80,7 @@ extension HTTPServer.Configuration {
             ))
         }
         
-        /// Enables compression by default, but offers options to dissallow it for the specified types.
+        /// Enables compression by default, but offers options to disallow it for the specified types.
         ///
         /// - Parameters:
         ///   - initialByteBufferCapacity: The initial buffer capacity to use when instanciating the compressor.


### PR DESCRIPTION
Fixed mentions of `Allow` and `Disallow` throughout the code.
All changes are backward compatible.