### PR TITLE
test: fix `configuration` argument

### DIFF
--- a/Sources/VaporTesting/TestingApplicationNew.swift
+++ b/Sources/VaporTesting/TestingApplicationNew.swift
@@ -39,7 +39,7 @@ extension VaporTestingRunner {
             url: .init(scheme: "http", host: hostname, port: port, path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfigurtion: .default()
+            contentConfiguration: .default()
         )
         try await beforeRequest(&request)
         do {

--- a/Sources/VaporTesting/TestingApplicationTester.swift
+++ b/Sources/VaporTesting/TestingApplicationTester.swift
@@ -65,7 +65,7 @@ extension TestingApplicationTester {
             url: .init(path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfigurtion: .default()
+            contentConfiguration: .default()
         )
         try await beforeRequest(&request)
         do {
@@ -92,7 +92,7 @@ extension TestingApplicationTester {
             url: .init(scheme: "http", host: hostname, port: port, path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfigurtion: .default()
+            contentConfiguration: .default()
         )
         try await beforeRequest(&request)
         do {

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -10,12 +10,17 @@ public struct TestingHTTPRequest: Sendable {
     public var body: ByteBuffer
     public var contentConfiguration: ContentConfiguration
 
-    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfigurtion: ContentConfiguration) {
+    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfiguration: ContentConfiguration) {
         self.method = method
         self.url = url
         self.headers = headers
         self.body = body
-        self.contentConfiguration = contentConfigurtion
+        self.contentConfiguration = contentConfiguration
+    }
+
+    @available(*, deprecated, renamed: "init(method:url:headers:body:contentConfiguration:)")
+    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfigurtion: ContentConfiguration) {
+        self.init(method: HTTPRequest.Method, url: url, headers: headers, body: body, contentConfiguration: contentConfigurtion)
     }
 
     private struct _ContentContainer: ContentContainer {

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -18,11 +18,6 @@ public struct TestingHTTPRequest: Sendable {
         self.contentConfiguration = contentConfiguration
     }
 
-    @available(*, deprecated, renamed: "init(method:url:headers:body:contentConfiguration:)")
-    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfigurtion: ContentConfiguration) {
-        self.init(method: method, url: url, headers: headers, body: body, contentConfiguration: contentConfigurtion)
-    }
-
     private struct _ContentContainer: ContentContainer {
         var body: ByteBuffer
         var headers: HTTPFields

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -18,6 +18,11 @@ public struct TestingHTTPRequest: Sendable {
         self.contentConfiguration = contentConfiguration
     }
 
+    @available(*, deprecated, renamed: "init(method:url:headers:body:contentConfiguration:)")
+    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfigurtion: ContentConfiguration) {
+        self.init(method: method, url: url, headers: headers, body: body, contentConfiguration: contentConfigurtion)
+    }
+
     private struct _ContentContainer: ContentContainer {
         var body: ByteBuffer
         var headers: HTTPFields

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -18,11 +18,6 @@ public struct TestingHTTPRequest: Sendable {
         self.contentConfiguration = contentConfiguration
     }
 
-    @available(*, deprecated, renamed: "init(method:url:headers:body:contentConfiguration:)")
-    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfigurtion: ContentConfiguration) {
-        self.init(method: HTTPRequest.Method, url: url, headers: headers, body: body, contentConfiguration: contentConfigurtion)
-    }
-
     private struct _ContentContainer: ContentContainer {
         var body: ByteBuffer
         var headers: HTTPFields


### PR DESCRIPTION
Fixed all occurrences of `configuration` throughout the code. (This was only present in test files.)

Although I initially added a soft-deprecation shim to preserve backward compatibility, I ultimately removed it because:
1. The affected code only exists in the v5 branch, which has not yet been released.
2. ~~The typo appears exclusively in test files, not in the public API of the library itself.~~
3. Even if it is used somehow by the outside world, with a new major version, breaking changes are expected and acceptable.

Given these points, the shim was unnecessary and has been omitted.

Please let me know if this needs anymore work from me.
Thanks