### PR TITLE
Add conditional Sendable conformance to RouteCollection

### DIFF
--- a/Sources/Vapor/Routing/RouteCollection.swift
+++ b/Sources/Vapor/Routing/RouteCollection.swift
@@ -1,4 +1,13 @@
 /// Groups collections of routes together for adding to a router.
+#if compiler(>=6.0)
+public protocol RouteCollection: Sendable {
+    /// Registers routes to the incoming router.
+    ///
+    /// - parameters:
+    ///     - routes: RoutesBuilder to register any new routes to.
+    func boot(routes: RoutesBuilder) throws
+}
+#else
 public protocol RouteCollection {
     /// Registers routes to the incoming router.
     ///
@@ -6,6 +15,7 @@ public protocol RouteCollection {
     ///     - routes: `RoutesBuilder` to register any new routes to.
     func boot(routes: RoutesBuilder) throws
 }
+#endif
 
 extension RoutesBuilder {
     /// Registers all of the routes in the group to this router.


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Conditionally made `RouteCollection` conform to `Sendable` only when compiled with Swift 6 or newer.  
This fixes `@Sendable` errors on controller methods without needing to annotate them manually.

Also, if your controller is `public`, you previously had to conform `Sendable` explicitly. 
That’s no longer required — conformance is automatically handled via conditional compilation.  
You **can still annotate methods with `@Sendable`** if you prefer, but it’s not necessary.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->

### ✅ Result

No need to add `@Sendable` on each route handler:

#### Before (Swift 6)
```swift
@Sendable
func index(req: Request) async throws -> [TodoDTO] {
    // ...
}
````

#### After (Swift 6)

```swift
func index(req: Request) async throws -> [TodoDTO] {
    // ...
}
```