### PR TITLE
Test the proper variable in testComplexCookieParsing

### DIFF
--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -157,8 +157,8 @@ final class HTTPHeaderTests: XCTestCase {
             let vaporSession = try XCTUnwrap(headers.setCookie?["vapor-session"])
             XCTAssertEqual(vaporSession.sameSite, HTTPCookies.SameSitePolicy.none)
             XCTAssertEqual(vaporSession.expires, Date(timeIntervalSince1970: 1622645877))
-            XCTAssertTrue(siwaState.isHTTPOnly)
-            XCTAssertTrue(siwaState.isSecure)
+            XCTAssertTrue(vaporSession.isHTTPOnly)
+            XCTAssertTrue(vaporSession.isSecure)
         }
     }
 


### PR DESCRIPTION
This is a dummy fix for the incorrect variable being tested in testComplexCookieParsing.