### PR TITLE
Expose peer certificates in request handlers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
 
         // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.34.0"),
 
         // HTTP/2 support for SwiftNIO
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.28.0"),
@@ -66,6 +66,12 @@ let package = Package(
 
         // Low-level atomic operations
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+
+        // X509 certificate types for the Swift ecosystem
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.14.0"),
+
+        // Work with certificate encoding schemes
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0")
     ],
     targets: [
         // C helpers
@@ -101,6 +107,8 @@ let package = Package(
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "_NIOFileSystemFoundationCompat", package: "swift-nio"),
+                .product(name: "X509", package: "swift-certificates"),
+                .product(name: "SwiftASN1", package: "swift-asn1"),
             ],
             swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
         ),

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -5,6 +5,7 @@ import Logging
 import RoutingKit
 import NIOConcurrencyHelpers
 import ServiceContextModule
+import X509
 
 /// Represents an HTTP request in an application.
 public final class Request: CustomStringConvertible, Sendable {
@@ -95,6 +96,12 @@ public final class Request: CustomStringConvertible, Sendable {
         }
 
         return self.remoteAddress
+    }
+
+    /// The validated certificate chain. This returns nil if the peer did not authenticate with a certificate. Requires
+    /// configuring a `customCertificateVerifyCallbackWithMetadata` that performs the verification.
+    public var peerCertificateChain: ValidatedCertificateChain? {
+        return self.requestBox.withLockedValue { $0.peerCertificateChain }
     }
 
     // MARK: Content
@@ -276,6 +283,7 @@ public final class Request: CustomStringConvertible, Sendable {
         var isKeepAlive: Bool
         var route: Route?
         var parameters: Parameters
+        var peerCertificateChain: ValidatedCertificateChain?
         var byteBufferAllocator: ByteBufferAllocator
     }
     
@@ -293,6 +301,7 @@ public final class Request: CustomStringConvertible, Sendable {
         headers: HTTPHeaders = .init(),
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
+        peerCertificateChain: ValidatedCertificateChain? = nil,
         logger: Logger = .init(label: "codes.vapor.request"),
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         on eventLoop: EventLoop
@@ -305,6 +314,7 @@ public final class Request: CustomStringConvertible, Sendable {
             headersNoUpdate: headers,
             collectedBody: collectedBody,
             remoteAddress: remoteAddress,
+            peerCertificateChain: peerCertificateChain,
             logger: logger,
             byteBufferAllocator: byteBufferAllocator,
             on: eventLoop
@@ -322,6 +332,7 @@ public final class Request: CustomStringConvertible, Sendable {
         headersNoUpdate headers: HTTPHeaders = .init(),
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
+        peerCertificateChain: ValidatedCertificateChain? = nil,
         logger: Logger = .init(label: "codes.vapor.request"),
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         on eventLoop: EventLoop
@@ -347,6 +358,7 @@ public final class Request: CustomStringConvertible, Sendable {
             isKeepAlive: true,
             route: nil,
             parameters: .init(),
+            peerCertificateChain: peerCertificateChain,
             byteBufferAllocator: byteBufferAllocator
         )
         self.requestBox = .init(storageBox)

--- a/Sources/Vapor/Security/ValidatedCertificateChain.swift
+++ b/Sources/Vapor/Security/ValidatedCertificateChain.swift
@@ -1,0 +1,23 @@
+import X509
+import NIOSSL
+import SwiftASN1
+
+extension NIOSSLCertificate {
+    // Convert NIOSSL certificate to X509 certificate. Currently requires to go
+    // to throught the DER representation. This only used in few cases and
+    // should not impact the performance of most users.
+    @inlinable
+    func toX509Certificate() throws -> X509.Certificate {
+        let derBytes = try self.toDERBytes()
+        return try X509.Certificate(derEncoded: derBytes)
+    }
+}
+
+extension NIOSSL.ValidatedCertificateChain {
+    // The precondition holds because the `NIOSSL.ValidatedCertificateChain` always contains one `NIOSSLCertificate`.
+    @inlinable
+    func usingX509Certificates() throws -> X509.ValidatedCertificateChain {
+        // This is safe because we this certificate chain is verified in NIOSSL.
+        return .init(uncheckedCertificateChain: try self.map { try $0.toX509Certificate() })
+    }
+}

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -15,6 +15,7 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOSSL
 import Atomics
+import X509
 
 final class ServerTests: XCTestCase, @unchecked Sendable {
     var app: Application!
@@ -1228,7 +1229,7 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         
         let cert = try NIOSSLCertificate.fromPEMFile(clientCertPath.path).first!
         let key = try NIOSSLPrivateKey(file: clientKeyPath.path, format: .pem)
-                
+
         app.http.server.configuration.hostname = "127.0.0.1"
         app.http.server.configuration.port = 0
         
@@ -1273,7 +1274,63 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         let a = try app.http.client.shared.execute(request: request).wait()
         XCTAssertEqual(a.body, ByteBuffer(string: "world"))
     }
-    
+
+    func testCanOverrideCertValidationWithMetadata() async throws {
+        guard let clientCertPath = Bundle.module.url(forResource: "expired", withExtension: "crt"),
+              let clientKeyPath = Bundle.module.url(forResource: "expired", withExtension: "key") else {
+            XCTFail("Cannot load expired cert and associated key")
+            return
+        }
+
+        let certs = try NIOSSLCertificate.fromPEMFile(clientCertPath.path)
+        let certSources = certs.map { NIOSSLCertificateSource.certificate($0) }
+        let key = try NIOSSLPrivateKey(file: clientKeyPath.path, format: .pem)
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(certificateChain: certSources, privateKey: .privateKey(key))
+        serverConfig.certificateVerification = .noHostnameVerification
+
+        app.http.server.configuration.tlsConfiguration = serverConfig
+        app.http.server.configuration.customCertificateVerifyCallbackWithMetadata = { @Sendable peerCerts, successPromise in
+            // This lies and accepts the above cert, which has actually expired.
+            XCTAssertEqual(peerCerts, certs)
+            successPromise.succeed(
+                .certificateVerified(
+                    VerificationMetadata(ValidatedCertificateChain(peerCerts))
+                )
+            )
+        }
+
+        // We need to disable verification on the client, because the cert we're using has expired, and we want to
+        // _send_ a client cert.
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .none
+        clientConfig.certificateChain = certSources
+        clientConfig.privateKey = .privateKey(key)
+        app.http.client.configuration.tlsConfiguration = clientConfig
+
+        app.environment.arguments = ["serve"]
+
+        app.get("hello") { req in
+            let certChain: X509.ValidatedCertificateChain = try XCTUnwrap(req.peerCertificateChain)
+            XCTAssertEqual(certChain.count, 1)
+            XCTAssertEqual(certChain.leaf, try X509.Certificate(derEncoded: try certs.first!.toDERBytes()))
+            return "world"
+        }
+
+        try await app.server.start(address: BindAddress.hostname("127.0.0.1", port: 0))
+
+        let localAddress = try XCTUnwrap(app.http.server.shared.localAddress)
+        guard let ip = localAddress.ipAddress, let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        let a = try await app.client.get("https://\(ip):\(port)/hello")
+        XCTAssertEqual(a.body, ByteBuffer(string: "world"))
+
+        await app.server.shutdown()
+    }
+
     func testCanChangeConfigurationDynamically() throws {
         guard let clientCertPath = Bundle.module.url(forResource: "expired", withExtension: "crt"),
               let clientKeyPath = Bundle.module.url(forResource: "expired", withExtension: "key") else {


### PR DESCRIPTION
Additional certificate information can be relevant in mTLS deployments. This PR exposes the certificate chain of the peer per request. In contrast to #3352, this includes not just the leaf but the validated peer certificate chain, i.e., the certificates that establish trust of the peer identity from the leaf to (and including) the root certificate.

The validated certificate chain is only available when setting a custom verification callback with metadata. Configuration of this callback is made available in this PR. It also adds a dependency on `swift-certificates` to use `X509.ValidatedCertificateChain` for the certificate chain.

Example usage:

```swift
app.get { req async in
  if let chain = req.peerCertificateChain {
    return "I am trusting you because I trust: \(chain.root.description)"
  } else {
    return "I am not trusting you."
  }
}
```

I suggest close #3352 in favor of this PR.