### PR TITLE
Empty responses should not be compressed

### DIFF
--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -554,6 +554,8 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         app.http.client.configuration.decompression = .enabled(limit: .none)
         
         app.get("compressed") { _ in compressiblePayload }
+      
+        app.get("emptyResponse") { _ in Response(status: .ok) }
         
         try await app.server.start(address: nil)
         
@@ -578,6 +580,13 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(unsupportedCompressedResponse.headers.first(name: .contentLength), "\(compressiblePayload.count)")
         XCTAssertEqual(unsupportedCompressedResponse.body?.string, compressiblePayload)
         
+        let unsupportedEmptyResponse = try await app.client.get("http://localhost:\(port)/emptyResponse") { request in
+            request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip, deflate, br, zstd")
+        }
+        XCTAssertEqual(unsupportedEmptyResponse.headers.first(name: .contentEncoding), nil)
+        XCTAssertEqual(unsupportedEmptyResponse.headers.first(name: .contentLength), "0")
+        XCTAssertEqual(unsupportedEmptyResponse.body?.string, nil)
+        
         app.http.server.configuration.responseCompression = .enabled
         
         let supportedUncompressedResponse = try await app.client.get("http://localhost:\(port)/compressed") { request in
@@ -593,6 +602,13 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(supportedCompressedResponse.headers.first(name: .contentEncoding), "gzip")
         XCTAssertNotEqual(supportedCompressedResponse.headers.first(name: .contentLength), "\(compressiblePayload.count)")
         XCTAssertEqual(supportedCompressedResponse.body?.string, compressiblePayload)
+        
+        let supportedEmptyResponse = try await app.client.get("http://localhost:\(port)/emptyResponse") { request in
+          request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip, deflate, br, zstd")
+        }
+        XCTAssertEqual(supportedEmptyResponse.headers.first(name: .contentEncoding), nil)
+        XCTAssertEqual(supportedEmptyResponse.headers.first(name: .contentLength), "0")
+        XCTAssertEqual(supportedEmptyResponse.body?.string, nil)
         
         await app.server.shutdown()
     }
@@ -637,6 +653,8 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         
         app.get("compressed") { _ in compressiblePayload }
         
+        app.get("emptyResponse") { _ in Response(status: .ok) }
+        
         try await app.server.start(address: nil)
         
         XCTAssertNotNil(app.http.server.shared.localAddress)
@@ -660,6 +678,13 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(unsupportedCompressedResponse.headers.first(name: .contentLength), "\(compressiblePayload.count)")
         XCTAssertEqual(unsupportedCompressedResponse.body?.string, compressiblePayload)
         
+        let unsupportedEmptyResponse = try await app.client.get("https://localhost:\(port)/emptyResponse") { request in
+            request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip, deflate, br, zstd")
+        }
+        XCTAssertEqual(unsupportedEmptyResponse.headers.first(name: .contentEncoding), nil)
+        XCTAssertEqual(unsupportedEmptyResponse.headers.first(name: .contentLength), "0")
+        XCTAssertEqual(unsupportedEmptyResponse.body?.string, nil)
+        
         app.http.server.configuration.responseCompression = .enabled
         
         let supportedUncompressedResponse = try await app.client.get("https://localhost:\(port)/compressed") { request in
@@ -675,6 +700,13 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(supportedCompressedResponse.headers.first(name: .contentEncoding), "gzip")
         XCTAssertNotEqual(supportedCompressedResponse.headers.first(name: .contentLength), "\(compressiblePayload.count)")
         XCTAssertEqual(supportedCompressedResponse.body?.string, compressiblePayload)
+        
+        let supportedEmptyResponse = try await app.client.get("https://localhost:\(port)/emptyResponse") { request in
+            request.headers.replaceOrAdd(name: .acceptEncoding, value: "gzip, deflate, br, zstd")
+        }
+        XCTAssertEqual(supportedEmptyResponse.headers.first(name: .contentEncoding), nil)
+        XCTAssertEqual(supportedEmptyResponse.headers.first(name: .contentLength), "0")
+        XCTAssertEqual(supportedEmptyResponse.body?.string, nil)
         
         await app.server.shutdown()
     }


### PR DESCRIPTION
When returning empty responses, such as `Response(status: .ok)` and the browser has sent `Accept-Encoding: gzip, deflate, br, zstd` headers, Vapor should not compress responses.

When compression is enabled on empty responses, some compression encodings, such as `deflate`, end up returning 8 bytes of data, so the final response that the browser receives has `Content-Length == 8`, but with no body. This ends up erroring with `net::ERR_CONTENT_LENGTH_MISMATCH` on the browser side.