### PR TITLE
Update minimum Swift version to 6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 import PackageDescription
 import Foundation
 
@@ -102,7 +102,7 @@ let package = Package(
                 .product(name: "_NIOFileSystem", package: "swift-nio"),
                 .product(name: "_NIOFileSystemFoundationCompat", package: "swift-nio"),
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+            swiftSettings: swiftSettings
         ),
 
         // Development
@@ -112,7 +112,7 @@ let package = Package(
                 .target(name: "Vapor"),
             ],
             resources: [.copy("Resources")],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+            swiftSettings: swiftSettings
         ),
 
         // Testing
@@ -121,7 +121,7 @@ let package = Package(
             dependencies: [
                 .target(name: "Vapor"),
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+            swiftSettings: swiftSettings
         ),
         .target(
             name: "VaporTesting",
@@ -129,7 +129,7 @@ let package = Package(
                 .target(name: "VaporTestUtils"),
                 .target(name: "Vapor"),
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+            swiftSettings: swiftSettings
         ),
         .target(
             name: "XCTVapor",
@@ -137,7 +137,7 @@ let package = Package(
                 .target(name: "VaporTestUtils"),
                 .target(name: "Vapor"),
             ],
-            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "VaporTests",
@@ -158,10 +158,16 @@ let package = Package(
                 .copy("Utilities/expired.key"),
                 .copy("Utilities/long-test-file.txt"),
             ],
-            swiftSettings: [
-                .enableUpcomingFeature("BareSlashRegexLiterals"),
-                .enableExperimentalFeature("StrictConcurrency=complete"),
-            ]
+            swiftSettings: swiftSettings
         ),
     ]
 )
+
+var swiftSettings: [SwiftSetting] { [
+    //.enableUpcomingFeature("ExistentialAny"),
+    //.enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    //.enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    .enableUpcomingFeature("ImmutableWeakCaptures"),
+] }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
         <img src="https://img.shields.io/codecov/c/github/vapor/vapor?style=plastic&logo=codecov&label=codecov" alt="Code Coverage">
     </a>
     <a href="https://swift.org">
-        <img src="https://design.vapor.codes/images/swift57up.svg" alt="Swift 5.7+">
+        <img src="https://design.vapor.codes/images/swift60up.svg" alt="Swift 6.0+">
     </a>
     <a href="https://hachyderm.io/@codevapor">
         <img src="https://img.shields.io/badge/%20-@codevapor-6364f6.svg?style=plastic&logo=mastodon&labelColor=gray&logoColor=%239394ff" alt="Mastodon">

--- a/Sources/Vapor/Content/JSONCoders+Content.swift
+++ b/Sources/Vapor/Content/JSONCoders+Content.swift
@@ -1,10 +1,11 @@
 import Foundation
 import NIOCore
+import NIOFoundationCompat
 import NIOHTTP1
 
-#if swift(<6.0)
-extension Foundation.JSONEncoder: @unchecked Swift.Sendable {}
-extension Foundation.JSONDecoder: @unchecked Swift.Sendable {}
+#if canImport(Darwin)
+extension JSONEncoder: @retroactive @unchecked Sendable {} // JSONEncoder Sendable conformance is not available before macOS 13.0/iOS 16.0/watchOS 9.0/tvOS 16.0
+extension JSONDecoder: @retroactive @unchecked Sendable {} // JSONDecoder Sendable conformance is not available before macOS 13.0/iOS 16.0/watchOS 9.0/tvOS 16.0
 #endif
 
 extension JSONEncoder: ContentEncoder {

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -73,7 +73,7 @@ private final class _PlaintextEncoder: Encoder, SingleValueEncodingContainer {
     func encode<T>(_ value: T) throws where T: Encodable {
         if let data = value as? Data {
             // special case for data
-            let utf8Maybe = data.withUnsafeBytes({ $0.withMemoryRebound(to: CChar.self, { String(validatingUTF8: $0.baseAddress!) }) })
+            let utf8Maybe = data.withUnsafeBytes({ $0.withMemoryRebound(to: CChar.self, { String(validatingCString: $0.baseAddress!) }) })
             if let utf8 = utf8Maybe {
                 self.plaintext = utf8
             } else {

--- a/Sources/Vapor/Docs.docc/Resources/vapor-vapor-logo.svg
+++ b/Sources/Vapor/Docs.docc/Resources/vapor-vapor-logo.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 47,31 c 0,0 2.6,21.9 7.7,26.6 7.5,7 17.5,7 23.9,1.9 6.5,-5.1 7.3,-13.9 -0.7,-20.9 -5.5,-4.8 -30.9,-7.7 -30.9,-7.7 z"/>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+</svg>
+

--- a/Sources/Vapor/HTTP/HTTPStatus.swift
+++ b/Sources/Vapor/HTTP/HTTPStatus.swift
@@ -12,12 +12,8 @@ extension HTTPStatus: ResponseEncodable {
     }
 }
 
-#if compiler(>=6.1)
 extension HTTPStatus: @retroactive Decodable {}
 extension HTTPStatus: @retroactive Encodable {}
-#else
-extension HTTPStatus: Codable {}
-#endif
 
 extension HTTPStatus {
     public init(from decoder: Decoder) throws {

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderCacheControl.swift
@@ -211,6 +211,4 @@ extension HTTPHeaders {
     }
 }
 
-#if !$InferSendableFromCaptures
-extension Swift.WritableKeyPath: @unchecked Swift.Sendable {}
-#endif
+extension WritableKeyPath: @retroactive @unchecked Sendable {}

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders.swift
@@ -34,12 +34,8 @@ extension HTTPHeaders {
     }
 }
 
-#if compiler(>=6.1)
 extension HTTPHeaders: @retroactive Decodable {}
 extension HTTPHeaders: @retroactive Encodable {}
-#else
-extension HTTPHeaders: Codable {}
-#endif
 
 extension HTTPHeaders {
     private enum CodingKeys: String, CodingKey { case name, value }

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -20,12 +20,8 @@ extension LoggingSystem {
     }
 }
 
-#if compiler(>=6.1)
-extension Logging.Logger.Level: @retroactive CustomStringConvertible {}
-extension Logging.Logger.Level: @retroactive Swift.LosslessStringConvertible {}
-#else
-extension Logging.Logger.Level: Swift.LosslessStringConvertible {}
-#endif
+extension Logger.Level: @retroactive CustomStringConvertible {}
+extension Logger.Level: @retroactive LosslessStringConvertible {}
 
 extension Logging.Logger.Level {
     public init?(_ description: String) { self.init(rawValue: description.lowercased()) }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -1,6 +1,7 @@
 @preconcurrency import Dispatch
 import Foundation
 import NIOCore
+import NIOFoundationCompat
 import NIOConcurrencyHelpers
 
 extension Response {

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -1,8 +1,4 @@
-#if os(Linux) && compiler(<6.0)
-@preconcurrency import Foundation
-#else
 import Foundation
-#endif
 import NIOCore
 import NIOConcurrencyHelpers
 

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -47,7 +47,7 @@ public struct DirectoryConfiguration: Sendable {
 
         let workingDirectory: String
 
-        if let cwd = cwd, let string = String(validatingUTF8: cwd) {
+        if let cwd, let string = String(validatingCString: cwd) {
             workingDirectory = string
         } else {
             workingDirectory = "./"

--- a/Sources/Vapor/Utilities/File.swift
+++ b/Sources/Vapor/Utilities/File.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIOCore
+import NIOFoundationCompat
 
 /// Represents a single file.
 public struct File: Codable, Equatable, Sendable {

--- a/Sources/Vapor/Utilities/RFC1123.swift
+++ b/Sources/Vapor/Utilities/RFC1123.swift
@@ -1,19 +1,13 @@
-#if swift(>=5.10)
 #if canImport(Darwin)
 @preconcurrency import Darwin
 #elseif canImport(Glibc)
-#if compiler(>=6.0)
 import Glibc
-#else
-@preconcurrency import Glibc
-#endif
 #elseif canImport(Android)
 @preconcurrency import Android
 #elseif canImport(Musl)
 @preconcurrency import Musl
 #elseif canImport(WinSDK)
 @preconcurrency import WinSDK
-#endif
 #endif
 import Foundation
 import NIOPosix
@@ -185,7 +179,4 @@ private let stringNumbers = [
 
 private let secondsInDay = 60 * 60 * 24
 
-#if compiler(>=6.0)
 extension tm: @retroactive @unchecked Sendable {}
-#endif
-

--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -1,8 +1,4 @@
-#if !canImport(Darwin) && compiler(<6.0)
-@preconcurrency import struct Foundation.URLComponents
-#else
 import struct Foundation.URLComponents
-#endif
 
 // MARK: - URI
 

--- a/Sources/Vapor/Validation/Validators/CharacterSet.swift
+++ b/Sources/Vapor/Validation/Validators/CharacterSet.swift
@@ -1,8 +1,4 @@
-#if os(Linux) && compiler(<6.0)
-@preconcurrency import Foundation
-#else
 import Foundation
-#endif
 
 extension Validator where T == String {
     /// Validates that all characters in a `String` are ASCII (bytes 0..<128).

--- a/Sources/Vapor/_Deprecations.swift
+++ b/Sources/Vapor/_Deprecations.swift
@@ -1,4 +1,3 @@
-
 // MARK: - Sessions
 
 extension SessionData {

--- a/Sources/VaporTesting/+TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/+TestingHTTPResponse.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0) && canImport(Testing)
 import Testing
 
 public func expectContent<D>(
@@ -114,4 +113,3 @@ where T: Codable & Equatable
         Issue.record("could not decode \(T.self): \(error)", sourceLocation: sourceLocation)
     }
 }
-#endif

--- a/Sources/VaporTesting/Docs.docc/Resources/vapor-vapor-logo.svg
+++ b/Sources/VaporTesting/Docs.docc/Resources/vapor-vapor-logo.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 47,31 c 0,0 2.6,21.9 7.7,26.6 7.5,7 17.5,7 23.9,1.9 6.5,-5.1 7.3,-13.9 -0.7,-20.9 -5.5,-4.8 -30.9,-7.7 -30.9,-7.7 z"/>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+</svg>
+

--- a/Sources/VaporTesting/TestingApplicationTester.swift
+++ b/Sources/VaporTesting/TestingApplicationTester.swift
@@ -1,8 +1,6 @@
 import NIOHTTP1
 import NIOCore
-#if compiler(>=6.0) && canImport(Testing)
 import Testing
-#endif
 
 public protocol TestingApplicationTester: Sendable {
     func performTest(request: TestingHTTPRequest) async throws -> TestingHTTPResponse
@@ -27,7 +25,6 @@ extension Application: TestingApplicationTester {
     }
 }
 
-#if compiler(>=6.0) && canImport(Testing)
 extension TestingApplicationTester {
     @discardableResult
     public func test(
@@ -130,4 +127,3 @@ extension TestingApplicationTester {
         }
     }
 }
-#endif

--- a/Sources/VaporTesting/VaporTestingContext.swift
+++ b/Sources/VaporTesting/VaporTestingContext.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0) && canImport(Testing)
 import Testing
 
 public enum VaporTestingContext {
@@ -34,4 +33,3 @@ public enum VaporTestingContext {
         }
     }
 }
-#endif

--- a/Sources/XCTVapor/Docs.docc/Resources/vapor-vapor-logo.svg
+++ b/Sources/XCTVapor/Docs.docc/Resources/vapor-vapor-logo.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 47,31 c 0,0 2.6,21.9 7.7,26.6 7.5,7 17.5,7 23.9,1.9 6.5,-5.1 7.3,-13.9 -0.7,-20.9 -5.5,-4.8 -30.9,-7.7 -30.9,-7.7 z"/>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+</svg>
+

--- a/Sources/XCTVapor/XCTVaporContext.swift
+++ b/Sources/XCTVapor/XCTVaporContext.swift
@@ -1,11 +1,7 @@
-#if compiler(>=6.0) && canImport(Testing)
 import Testing
-#endif
 
 public enum XCTVaporContext {
-#if compiler(>=6.0) && canImport(Testing)
     @TaskLocal public static var emitWarningIfCurrentTestInfoIsAvailable: Bool?
-#endif
 
     /// Throws an error if the test is being run in a swift-testing context.
     /// This is not fool-proof. Running tests in detached Tasks will bypass this detection.
@@ -14,7 +10,6 @@ public enum XCTVaporContext {
         file: StaticString,
         line: UInt
     ) {
-#if compiler(>=6.0) && canImport(Testing)
         let shouldWarn = XCTVaporContext.emitWarningIfCurrentTestInfoIsAvailable ?? true
         var isInSwiftTesting: Bool { Test.current != nil }
         if shouldWarn, isInSwiftTesting {
@@ -29,6 +24,5 @@ public enum XCTVaporContext {
             """)
             fflush(stdout)
         }
-#endif
     }
 }

--- a/Tests/VaporTests/AsyncClientTests.swift
+++ b/Tests/VaporTests/AsyncClientTests.swift
@@ -1,9 +1,9 @@
 import Vapor
 import NIOConcurrencyHelpers
 import NIOCore
+import NIOFoundationCompat
 import Logging
 import NIOEmbedded
-#if compiler(>=6.0) && canImport(Testing)
 import Testing
 import VaporTesting
 
@@ -93,7 +93,7 @@ struct AsyncClientTests {
         }
     }
 
-    @Test("Test Client Tiemout")
+    @Test("Test Client Timeout")
     func testClientTimeout() async throws {
         try await withRemoteApp { remoteApp, remoteAppPort in
             try await withApp { app in
@@ -219,7 +219,6 @@ struct AsyncClientTests {
         return result
     }
 }
-#endif
 
 final class CustomClient: Client, Sendable {
     let eventLoop: any EventLoop

--- a/Tests/VaporTests/AsyncRequestTests.swift
+++ b/Tests/VaporTests/AsyncRequestTests.swift
@@ -2,6 +2,7 @@ import XCTVapor
 import XCTest
 import Vapor
 import NIOCore
+import NIOFoundationCompat
 import AsyncHTTPClient
 import Atomics
 import NIOConcurrencyHelpers

--- a/Tests/VaporTests/AsyncRouteTests.swift
+++ b/Tests/VaporTests/AsyncRouteTests.swift
@@ -403,13 +403,8 @@ final class AsyncRouteTests: XCTestCase {
     }
 }
 
-#if compiler(>=6.1)
 extension WebSocket: @retroactive Equatable {}
-extension Vapor.WebSocket: @retroactive Swift.Hashable {}
-#else
-extension WebSocket: Equatable {}
-extension Vapor.WebSocket: Swift.Hashable {}
-#endif
+extension Vapor.WebSocket: @retroactive Hashable {}
 
 extension Vapor.WebSocket {
     public static func == (lhs: WebSocket, rhs: WebSocket) -> Bool {

--- a/Tests/VaporTests/BaseNTests.swift
+++ b/Tests/VaporTests/BaseNTests.swift
@@ -83,7 +83,7 @@ final class BaseNTests: XCTestCase {
                     XCTAssertEqual(Array(elem.utf8), decodedBytes, "byte decode", file: (file), line: line)
 
                     let utf8ReadyBytes = decodedBytes.map { Array(chain($0.map(Int8.init(bitPattern:)), [0])) }
-                    XCTAssertEqual(utf8ReadyBytes.flatMap { String(validatingUTF8: $0)?[...] }, elem, "\(name) - \(elem) - \(decodedBytes ?? [])")
+                    XCTAssertEqual(utf8ReadyBytes.flatMap { $0.withUnsafeBufferPointer { String(validatingCString: $0.baseAddress!)?[...] } }, elem, "\(name) - \(elem) - \(decodedBytes ?? [])")
                 }
             }
             if printVectors {

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -1,14 +1,12 @@
 #if !canImport(Darwin)
-#if compiler(>=6.0)
 import Dispatch
-#else
-@preconcurrency import Dispatch
-#endif
 #endif
 import Foundation
 import XCTest
 import Vapor
+import VaporTestUtils
 import NIOCore
+import NIOFoundationCompat
 import Logging
 import AsyncHTTPClient
 import NIOEmbedded
@@ -37,7 +35,7 @@ final class ClientTests: XCTestCase {
                 $0[$1.0] = $1.1
             }
             
-            guard let json:[String:Any] = try JSONSerialization.jsonObject(with: req.body.data!) as? [String:Any] else {
+            guard let json:[String:Any] = try JSONSerialization.jsonObject(with: req.body.data!) as? [String: Any] else {
                 throw Abort(.badRequest)
             }
             

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -3,6 +3,7 @@
 #endif
 import Foundation
 import Vapor
+import VaporTestUtils
 import XCTest
 import AsyncHTTPClient
 import NIOCore

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -531,17 +531,10 @@ final class ContentTests: XCTestCase {
             let badJson: String
         }
         XCTAssertThrowsError(try req.content.decode(DecodeModel.self)) { error in
-            #if compiler(>=6.0)
             XCTAssertContains(
                 (error as? AbortError)?.reason,
                 #"Data corrupted at path ''. The given data was not valid JSON"#
             )
-            #else
-            XCTAssertContains(
-                (error as? AbortError)?.reason,
-                #"Data corrupted at path ''. The given data was not valid JSON. Underlying error: "#
-            )
-            #endif
         }
     }
 

--- a/Tests/VaporTests/ErrorTests.swift
+++ b/Tests/VaporTests/ErrorTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+import XCTVapor
 import Vapor
+import VaporTestUtils
 import Logging
 
 final class ErrorTests: XCTestCase {

--- a/Tests/VaporTests/PipelineTests.swift
+++ b/Tests/VaporTests/PipelineTests.swift
@@ -1,4 +1,6 @@
 @testable import Vapor
+import VaporTestUtils
+import XCTVapor
 import enum NIOHTTP1.HTTPParserError
 import XCTest
 import AsyncHTTPClient
@@ -351,7 +353,7 @@ final class PipelineTests: XCTestCase {
     func testCorrectResponseOrder() async throws {
         app.get("sleep", ":ms") { req -> String in
             let ms = try req.parameters.require("ms", as: Int64.self)
-            try await Task.sleep(for: .milliseconds(ms))
+            try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
             return "slept \(ms)ms"
         }
 
@@ -390,7 +392,7 @@ final class PipelineTests: XCTestCase {
     func testCorrectResponseOrderOverVaporTCP() async throws {
         app.get("sleep", ":ms") { req -> String in
             let ms = try req.parameters.require("ms", as: Int64.self)
-            try await Task.sleep(for: .milliseconds(ms))
+            try await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
             return "slept \(ms)ms"
         }
 

--- a/Tests/VaporTests/URITests.swift
+++ b/Tests/VaporTests/URITests.swift
@@ -184,7 +184,7 @@ final class URITests: XCTestCase {
     }
     
     // Disable tests on Linux 6.0 until behaviour is fixed
-    #if compiler(<6.0)
+//    #if compiler(<6.0)
     func testVariousSchemesAndWeirdHosts() {
         // N.B.: This test previously asserted that the resulting string did _not_ start with the `//` "authority"
         // prefix. Again, according to RFC 3986, this was always semantically incorrect.
@@ -206,7 +206,7 @@ final class URITests: XCTestCase {
             generate: "http+unix://%2Fpath/test?query#fragment"
         )
     }
-    #endif
+//    #endif
     
     func testDefaultInitializer() {
         let uri = URI.init()

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+import XCTVapor
 import Vapor
+import VaporTestUtils
 import NIOCore
 
 class ValidationTests: XCTestCase {

--- a/Tests/VaporTests/VaporTesting.swift
+++ b/Tests/VaporTests/VaporTesting.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0) && canImport(Testing)
 import VaporTesting
 import Testing
 
@@ -79,4 +78,3 @@ struct VaporTestingTests {
         }
     }
 }
-#endif


### PR DESCRIPTION
Clean up all the relevant `#if` conditionals, add theme settings to the API documentation, and clean up the tests. (FileTests and AsyncFileTests no longer crash on ten different force-unwraps when `#file` (now `#filePath`) is inaccessible.)

The tests now also build and pass on iOS, watchOS, tvOS, and visionOS.