### PR TITLE
Fix WebSockets trait

### DIFF
--- a/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/WebSocket+Concurrency.swift
@@ -1,4 +1,4 @@
-#if Websockets
+#if WebSockets
 import NIOPosix
 import NIOCore
 import HTTPTypes

--- a/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerUpgradeHandler.swift
@@ -2,7 +2,7 @@ import NIOCore
 import NIOHTTP1
 import HTTPTypes
 import NIOHTTPTypes
-#if Websockets
+#if WebSockets
 import WebSocketKit
 import NIOWebSocket
 #endif
@@ -143,7 +143,7 @@ public protocol Upgrader: Sendable {
     func applyUpgrade(req: Request, res: Response) -> any HTTPServerProtocolUpgrader
 }
 
-#if Websockets
+#if WebSockets
 /// Handles upgrading an HTTP connection to a WebSocket
 public struct WebSocketUpgrader: Upgrader, Sendable {
     var maxFrameSize: WebSocketMaxFrameSize

--- a/Sources/Vapor/Routing/Request+WebSocket.swift
+++ b/Sources/Vapor/Routing/Request+WebSocket.swift
@@ -1,4 +1,4 @@
-#if Websockets
+#if WebSockets
 import NIOCore
 import WebSocketKit
 import HTTPTypes

--- a/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+WebSocket.swift
@@ -1,4 +1,4 @@
-#if Websockets
+#if WebSockets
 import RoutingKit
 import WebSocketKit
 import NIOCore

--- a/Sources/Vapor/Security/OTP.swift
+++ b/Sources/Vapor/Security/OTP.swift
@@ -1,9 +1,9 @@
 import Foundation
-#if os(Linux)
+#if canImport(Darwin)
+import Crypto
+#else
 // TODO - remove when Crypto finally updated
 @preconcurrency import Crypto
-#else
-import Crypto
 #endif
 
 /// Supported OTP output sizes.

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -415,7 +415,7 @@ struct RouteTests {
         }
     }
 
-    #if Websockets
+    #if WebSockets
     @Test("Test Websocket Upgrade", .disabled())
     func testWebsocketUpgrade() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/WebSocketTests.swift
+++ b/Tests/VaporTests/WebSocketTests.swift
@@ -1,4 +1,4 @@
-#if Websockets
+#if WebSockets
 import VaporTesting
 import Vapor
 import Testing


### PR DESCRIPTION
A recent commit changed the `Websocket` trait to match the casing of usages elsewhere, but I forgot to update the trait checks in the rest of the code. This fixes that.

Also fixes the Android CI