### PR TITLE
Add typed Retry-After HTTP header accessor

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderRetryAfter.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderRetryAfter.swift
@@ -1,0 +1,85 @@
+import Foundation
+import NIOHTTP1
+
+extension HTTPHeaders {
+    /// Represents the HTTP `Retry-After` header.
+    ///
+    /// The value is either a number of seconds to wait before retrying, or a specific
+    /// date after which the client may retry. This is typically sent with `429 Too Many
+    /// Requests` or `503 Service Unavailable` responses.
+    /// - See Also:
+    /// [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
+    public enum RetryAfter {
+        /// The number of seconds to wait before retrying.
+        case seconds(Int)
+        /// The date after which the client may retry.
+        case date(Date)
+
+        internal static func parse(_ value: String) -> RetryAfter? {
+            let trimmed = value.trimmingCharacters(in: .whitespaces)
+
+            // `delay-seconds` is a non-negative integer (RFC 9110 § 10.2.3).
+            if let seconds = Int(trimmed) {
+                return seconds >= 0 ? .seconds(seconds) : nil
+            }
+
+            // Otherwise the value is an HTTP-date.
+            if let date = Self.parseHTTPDate(trimmed) {
+                return .date(date)
+            }
+
+            return nil
+        }
+
+        public func serialize() -> String {
+            switch self {
+            case .seconds(let seconds):
+                return String(seconds)
+            case .date(let date):
+                let fmt = DateFormatter()
+                fmt.locale = Locale(identifier: "en_US_POSIX")
+                fmt.timeZone = TimeZone(secondsFromGMT: 0)
+                fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+                return fmt.string(from: date)
+            }
+        }
+
+        private static func parseHTTPDate(_ dateString: String) -> Date? {
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(secondsFromGMT: 0)
+
+            // Preferred IMF-fixdate format (RFC 7231 § 7.1.1.1).
+            fmt.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+            if let date = fmt.date(from: dateString) {
+                return date
+            }
+
+            // Obsolete RFC 850 format.
+            fmt.dateFormat = "EEEE, dd-MMM-yy HH:mm:ss zzz"
+            if let date = fmt.date(from: dateString) {
+                return date
+            }
+
+            // Obsolete ANSI C asctime() format.
+            fmt.dateFormat = "EEE MMM d HH:mm:s yyyy"
+            if let date = fmt.date(from: dateString) {
+                return date
+            }
+
+            return nil
+        }
+    }
+
+    /// Gets or sets the `Retry-After` header.
+    public var retryAfter: RetryAfter? {
+        get { self.first(name: .retryAfter).flatMap(RetryAfter.parse) }
+        set {
+            if let new = newValue?.serialize() {
+                self.replaceOrAdd(name: .retryAfter, value: new)
+            } else {
+                self.remove(name: .retryAfter)
+            }
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaderRetryAfter.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaderRetryAfter.swift
@@ -7,13 +7,47 @@ extension HTTPHeaders {
     /// The value is either a number of seconds to wait before retrying, or a specific
     /// date after which the client may retry. This is typically sent with `429 Too Many
     /// Requests` or `503 Service Unavailable` responses.
+    ///
+    ///     headers.retryAfter = .seconds(120)
+    ///     headers.retryAfter?.seconds // 120
+    ///
     /// - See Also:
     /// [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)
-    public enum RetryAfter {
-        /// The number of seconds to wait before retrying.
-        case seconds(Int)
-        /// The date after which the client may retry.
-        case date(Date)
+    public struct RetryAfter: Sendable, Equatable {
+        private enum Storage: Sendable, Equatable {
+            case seconds(Int)
+            case date(Date)
+        }
+
+        private let storage: Storage
+
+        private init(_ storage: Storage) {
+            self.storage = storage
+        }
+
+        /// A number of seconds to wait before retrying.
+        public static func seconds(_ seconds: Int) -> Self {
+            .init(.seconds(seconds))
+        }
+
+        /// A date after which the client may retry.
+        public static func date(_ date: Date) -> Self {
+            .init(.date(date))
+        }
+
+        /// The number of seconds to wait before retrying, or `nil` if this value
+        /// is expressed as a date instead.
+        public var seconds: Int? {
+            guard case .seconds(let seconds) = self.storage else { return nil }
+            return seconds
+        }
+
+        /// The date after which the client may retry, or `nil` if this value is
+        /// expressed as a number of seconds instead.
+        public var date: Date? {
+            guard case .date(let date) = self.storage else { return nil }
+            return date
+        }
 
         internal static func parse(_ value: String) -> RetryAfter? {
             let trimmed = value.trimmingCharacters(in: .whitespaces)
@@ -32,10 +66,12 @@ extension HTTPHeaders {
         }
 
         public func serialize() -> String {
-            switch self {
+            switch self.storage {
             case .seconds(let seconds):
                 return String(seconds)
             case .date(let date):
+                // The formatter is created per call rather than cached in a
+                // `static let`, since `DateFormatter` is not `Sendable`.
                 let fmt = DateFormatter()
                 fmt.locale = Locale(identifier: "en_US_POSIX")
                 fmt.timeZone = TimeZone(secondsFromGMT: 0)

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -451,7 +451,49 @@ final class HTTPHeaderTests: XCTestCase {
         XCTAssertEqual(cacheControl.serialize(), "immutable")
 
     }
-    
+
+    /// Test parse and serialize of `Retry-After` header with `delay-seconds`
+    func testRetryAfterHeaderSeconds() throws {
+        var headers = HTTPHeaders()
+        headers.retryAfter = .seconds(120)
+        guard case .seconds(let seconds) = headers.retryAfter else {
+            XCTFail("HTTPHeaders.RetryAfter parsing failed")
+            return
+        }
+        XCTAssertEqual(seconds, 120)
+        XCTAssertEqual(headers.first(name: .retryAfter), "120")
+    }
+
+    /// Test parse and serialize of `Retry-After` header with an HTTP-date
+    func testRetryAfterHeaderDate() throws {
+        var headers = HTTPHeaders()
+        headers.retryAfter = .date(Date(timeIntervalSince1970: 18*3600))
+        guard case .date(let date) = headers.retryAfter else {
+            XCTFail("HTTPHeaders.RetryAfter parsing failed")
+            return
+        }
+        XCTAssertEqual(date.timeIntervalSince1970, 18*3600)
+        XCTAssertEqual(headers.first(name: .retryAfter), "Thu, 01 Jan 1970 18:00:00 GMT")
+    }
+
+    /// Test that a negative or otherwise invalid `Retry-After` value parses as nil
+    func testRetryAfterHeaderInvalid() throws {
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .retryAfter, value: "-5")
+        XCTAssertNil(headers.retryAfter)
+        headers.replaceOrAdd(name: .retryAfter, value: "not-a-date")
+        XCTAssertNil(headers.retryAfter)
+    }
+
+    /// Test that setting `Retry-After` to nil removes the header
+    func testRetryAfterHeaderRemoval() throws {
+        var headers = HTTPHeaders()
+        headers.retryAfter = .seconds(5)
+        XCTAssertNotNil(headers.first(name: .retryAfter))
+        headers.retryAfter = nil
+        XCTAssertNil(headers.first(name: .retryAfter))
+    }
+
     /// Test that multiple same-named headers round-trip through Codable
     func testCodableMultipleHeadersRountrip() throws {
         let encoder = JSONEncoder()

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -456,11 +456,9 @@ final class HTTPHeaderTests: XCTestCase {
     func testRetryAfterHeaderSeconds() throws {
         var headers = HTTPHeaders()
         headers.retryAfter = .seconds(120)
-        guard case .seconds(let seconds) = headers.retryAfter else {
-            XCTFail("HTTPHeaders.RetryAfter parsing failed")
-            return
-        }
-        XCTAssertEqual(seconds, 120)
+        XCTAssertEqual(headers.retryAfter, .seconds(120))
+        XCTAssertEqual(headers.retryAfter?.seconds, 120)
+        XCTAssertNil(headers.retryAfter?.date)
         XCTAssertEqual(headers.first(name: .retryAfter), "120")
     }
 
@@ -468,11 +466,8 @@ final class HTTPHeaderTests: XCTestCase {
     func testRetryAfterHeaderDate() throws {
         var headers = HTTPHeaders()
         headers.retryAfter = .date(Date(timeIntervalSince1970: 18*3600))
-        guard case .date(let date) = headers.retryAfter else {
-            XCTFail("HTTPHeaders.RetryAfter parsing failed")
-            return
-        }
-        XCTAssertEqual(date.timeIntervalSince1970, 18*3600)
+        XCTAssertEqual(headers.retryAfter?.date?.timeIntervalSince1970, 18*3600)
+        XCTAssertNil(headers.retryAfter?.seconds)
         XCTAssertEqual(headers.first(name: .retryAfter), "Thu, 01 Jan 1970 18:00:00 GMT")
     }
 


### PR DESCRIPTION
The `.retryAfter` header name constant already exists in Vapor, but there was no
typed accessor for it. This adds one, following the existing `Expires` and
`Last-Modified` helpers in the same directory.

`HTTPHeaders.retryAfter` exposes a `RetryAfter` enum with two cases: `.seconds(Int)`
for a delay and `.date(Date)` for an HTTP-date. The getter parses the raw header
value (negative delay-seconds and unparseable dates return nil), the setter
serializes it, and setting nil removes the header. Date parsing reuses the same
three formats as the `Expires` helper (IMF-fixdate plus the two obsolete formats).

This is commonly paired with 429 and 503 responses.

Tests cover the seconds case, the date case, invalid/negative input, and removal.
Ran the header suite on Linux (swift:6.0-jammy): 45 passed, 0 failed.
