### PR TITLE
Emit Accept-Ranges for partial file responses

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -244,7 +244,7 @@ public struct FileIO: Sendable {
         let byteCount: Int
         if let contentRange = contentRange {
             response.status = .partialContent
-            response.headers[.accept] = contentRange.unit.serialize()
+            response.headers[.acceptRanges] = contentRange.unit.serialize()
             if let firstRange = contentRange.ranges.first {
                 do {
                     let range = try firstRange.asResponseContentRange(limit: Int(fileInfo.size))

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -230,6 +230,7 @@ struct FileTests {
             headers.range = .init(unit: .bytes, ranges: [.within(start: 0, end: 0)])
             try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res async in
                 #expect(res.status == .partialContent)
+                #expect(res.headers[.acceptRanges] == "bytes")
 
                 #expect(res.headers[.contentLength] == "1")
                 let range = res.headers[.contentRange]!.split(separator: "/").first!.split(separator: " ").last!


### PR DESCRIPTION
Fixes #3408

### What changed

The partial file-response path now emits the `Accept-Ranges` response header rather than assigning the range unit to the request-oriented `Accept` header. The existing file-header test now asserts `Accept-Ranges: bytes`.

### Validation

- `git diff --check` passed.
- `swift test --filter FileTests` is blocked before compilation in this checkout because the resolved `swift-http-server` dependency requires Swift tools 6.4.0 while the installed toolchain is Swift 6.3.3. No passing test result is claimed.
