### PR TITLE
Add HTTP/2 support to the server

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
@@ -1,8 +1,10 @@
 extension ServerConfiguration {
     /// HTTP/2 specific configuration.
     ///
-    /// HTTP/2 is only negotiated over TLS (via ALPN). Adding an ``ServerConfiguration/HTTPVersion/http2(config:)``
-    /// version without also setting ``ServerConfiguration/tlsConfiguration`` will cause the server to fail to start.
+    /// HTTP/2 is only negotiated over TLS (via ALPN). If an ``ServerConfiguration/HTTPVersion/http2(config:)``
+    /// version is added to ``ServerConfiguration/httpVersions`` without also setting a
+    /// ``ServerConfiguration/tlsConfiguration``, the server throws an error when it starts (rather than
+    /// serving over plaintext), so callers can catch it and decide how to handle it.
     public struct HTTP2: Sendable, Hashable {
         /// The maximum frame size to be used in an HTTP/2 connection.
         public var maxFrameSize: Int
@@ -54,12 +56,16 @@ extension ServerConfiguration {
             self.gracefulShutdown = gracefulShutdown
         }
 
+        /// `2^14` (16 KiB) — the smallest, and default, `SETTINGS_MAX_FRAME_SIZE` defined by HTTP/2 (RFC 9113 §6.5.2).
         @inlinable
         static var defaultMaxFrameSize: Int { 1 << 14 }
 
+        /// `2^16 - 1` (65 535) — the default `SETTINGS_INITIAL_WINDOW_SIZE` (flow-control window) defined by
+        /// HTTP/2 (RFC 9113 §6.9.2).
         @inlinable
         static var defaultTargetWindowSize: Int { (1 << 16) - 1 }
 
+        /// `100` — the minimum concurrent streams RFC 9113 (§8.2.2) recommends endpoints allow; used as the default.
         @inlinable
         static var defaultMaxConcurrentStreams: Int { 100 }
 
@@ -110,8 +116,14 @@ extension ServerConfiguration {
             Self.init(version: .http2(config: config))
         }
 
-        /// Two values are equal if they represent the same protocol version, regardless of any differences in the
-        /// HTTP/2 configuration.
+        /// Equality is by protocol version only: two values are equal when they represent the same HTTP
+        /// version, ignoring any associated configuration.
+        ///
+        /// This is intentional, and the reason `==`/`hash` are written by hand instead of synthesised. It
+        /// makes a `Set<HTTPVersion>` behave as *the set of supported protocols*: it holds at most one entry
+        /// per version, so the same protocol can't be added twice with conflicting configuration. Synthesised
+        /// conformances would fold the associated config into identity and allow such duplicates. This mirrors
+        /// `NIOHTTPServerConfiguration.HTTPVersion`, which does the same.
         public static func == (lhs: Self, rhs: Self) -> Bool {
             switch (lhs.version, rhs.version) {
             case (.http1_1, .http1_1), (.http2, .http2):
@@ -122,7 +134,7 @@ extension ServerConfiguration {
             }
         }
 
-        /// Hashes by protocol version only, consistent with the `Equatable` conformance.
+        /// Hashes by protocol version only, consistent with the `Equatable` conformance above.
         public func hash(into hasher: inout Hasher) {
             switch self.version {
             case .http1_1:

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
@@ -1,0 +1,136 @@
+extension ServerConfiguration {
+    /// HTTP/2 specific configuration.
+    ///
+    /// HTTP/2 is only negotiated over TLS (via ALPN). Adding an ``ServerConfiguration/HTTPVersion/http2(config:)``
+    /// version without also setting ``ServerConfiguration/tlsConfiguration`` will cause the server to fail to start.
+    public struct HTTP2: Sendable, Hashable {
+        /// The maximum frame size to be used in an HTTP/2 connection.
+        public var maxFrameSize: Int
+
+        /// The target window size for the connection.
+        ///
+        /// - Note: This is also used as the initial window size for the connection.
+        public var targetWindowSize: Int
+
+        /// The maximum number of concurrent streams permitted on the connection.
+        public var maxConcurrentStreams: Int
+
+        /// The graceful shutdown configuration.
+        public var gracefulShutdown: GracefulShutdownConfiguration
+
+        /// Configuration options for HTTP/2 graceful shutdown behavior.
+        public struct GracefulShutdownConfiguration: Sendable, Hashable {
+            /// The maximum amount of time that the connection has to close gracefully.
+            ///
+            /// When `nil`, no time limit is enforced on the graceful shutdown process.
+            public var maximumGracefulShutdownDuration: Duration?
+
+            /// Creates a graceful shutdown configuration.
+            ///
+            /// - Parameter maximumGracefulShutdownDuration: The maximum amount of time the connection has to close
+            ///   gracefully. When `nil`, no time limit is enforced.
+            public init(maximumGracefulShutdownDuration: Duration? = nil) {
+                self.maximumGracefulShutdownDuration = maximumGracefulShutdownDuration
+            }
+        }
+
+        /// Creates a new HTTP/2 configuration.
+        ///
+        /// - Parameters:
+        ///   - maxFrameSize: The maximum frame size to be used in a connection. Defaults to `2^14`.
+        ///   - targetWindowSize: The target window size for a connection, also used as the initial window size.
+        ///     Defaults to `2^16 - 1`.
+        ///   - maxConcurrentStreams: The maximum number of concurrent streams permitted. Defaults to `100`.
+        ///   - gracefulShutdown: The graceful shutdown configuration.
+        public init(
+            maxFrameSize: Int = Self.defaultMaxFrameSize,
+            targetWindowSize: Int = Self.defaultTargetWindowSize,
+            maxConcurrentStreams: Int = Self.defaultMaxConcurrentStreams,
+            gracefulShutdown: GracefulShutdownConfiguration = .init()
+        ) {
+            self.maxFrameSize = maxFrameSize
+            self.targetWindowSize = targetWindowSize
+            self.maxConcurrentStreams = maxConcurrentStreams
+            self.gracefulShutdown = gracefulShutdown
+        }
+
+        @inlinable
+        static var defaultMaxFrameSize: Int { 1 << 14 }
+
+        @inlinable
+        static var defaultTargetWindowSize: Int { (1 << 16) - 1 }
+
+        @inlinable
+        static var defaultMaxConcurrentStreams: Int { 100 }
+
+        /// The default HTTP/2 configuration.
+        ///
+        /// The max frame size defaults to `2^14`, the target window size to `2^16 - 1`, and the max concurrent
+        /// streams to `100`.
+        public static var defaults: Self {
+            Self(
+                maxFrameSize: Self.defaultMaxFrameSize,
+                targetWindowSize: Self.defaultTargetWindowSize,
+                maxConcurrentStreams: Self.defaultMaxConcurrentStreams,
+                gracefulShutdown: GracefulShutdownConfiguration()
+            )
+        }
+    }
+
+    /// An HTTP protocol version the server can advertise and serve.
+    ///
+    /// Use ``http1_1`` and ``http2(config:)`` to build the set passed to ``ServerConfiguration/httpVersions``.
+    public struct HTTPVersion: Sendable, Hashable {
+        /// The underlying protocol version, carrying the HTTP/2 configuration when applicable.
+        enum Version: Sendable, Hashable {
+            case http1_1
+            case http2(config: HTTP2)
+
+            var http2Config: HTTP2? {
+                switch self {
+                case .http1_1:
+                    return nil
+                case .http2(let config):
+                    return config
+                }
+            }
+        }
+
+        var version: Version
+
+        /// The HTTP/1.1 protocol version.
+        public static var http1_1: Self {
+            Self.init(version: .http1_1)
+        }
+
+        /// The HTTP/2 protocol version.
+        ///
+        /// - Parameter config: The configuration to use for HTTP/2 connections.
+        public static func http2(config: HTTP2) -> Self {
+            Self.init(version: .http2(config: config))
+        }
+
+        /// Two values are equal if they represent the same protocol version, regardless of any differences in the
+        /// HTTP/2 configuration.
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            switch (lhs.version, rhs.version) {
+            case (.http1_1, .http1_1), (.http2, .http2):
+                return true
+
+            default:
+                return false
+            }
+        }
+
+        /// Hashes by protocol version only, consistent with the `Equatable` conformance.
+        public func hash(into hasher: inout Hasher) {
+            switch self.version {
+            case .http1_1:
+                hasher.combine(1)
+
+            case .http2:
+                hasher.combine(2)
+            }
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+HTTP2Configuration.swift
@@ -91,15 +91,6 @@ extension ServerConfiguration {
         enum Version: Sendable, Hashable {
             case http1_1
             case http2(config: HTTP2)
-
-            var http2Config: HTTP2? {
-                switch self {
-                case .http1_1:
-                    return nil
-                case .http2(let config):
-                    return config
-                }
-            }
         }
 
         var version: Version

--- a/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
+++ b/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
@@ -8,9 +8,13 @@ enum NIOHTTPServerAdapterError: Error {
     /// The underlying server reported that it was listening but exposed no addresses.
     case noListeningAddress
 
-    /// HTTP/2 was requested without TLS. HTTP/2 is only negotiated over TLS (via ALPN),
-    /// so a ``ServerConfiguration/tlsConfiguration`` is required to serve it.
+    /// HTTP/2 was requested without TLS. HTTP/2 is negotiated over TLS via ALPN, so a
+    /// ``ServerConfiguration/tlsConfiguration`` is required to serve it. Cleartext HTTP/2 (h2c) is not
+    /// supported by the underlying server yet; if that changes this check will be gated behind an opt-in.
     case http2RequiresTLS
+
+    /// No HTTP versions were configured. ``ServerConfiguration/httpVersions`` must contain at least one version.
+    case noHTTPVersionsSpecified
 }
 
 /// Adapts `NIOHTTPServer` to Vapor's `Server` protocol using structured concurrency.
@@ -84,6 +88,10 @@ final class NIOHTTPServerAdapter: Server, Sendable {
                     )
                 ))
             }
+        }
+
+        if self.application.serverConfiguration.httpVersions.isEmpty {
+            throw NIOHTTPServerAdapterError.noHTTPVersionsSpecified
         }
 
         // HTTP/2 is negotiated via ALPN, which requires TLS. Over plaintext, only HTTP/1.1 is allowed.

--- a/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
+++ b/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
@@ -90,15 +90,15 @@ final class NIOHTTPServerAdapter: Server, Sendable {
             }
         }
 
-        if self.application.serverConfiguration.httpVersions.isEmpty {
+        guard !self.application.serverConfiguration.httpVersions.isEmpty else {
             throw NIOHTTPServerAdapterError.noHTTPVersionsSpecified
         }
 
         // HTTP/2 is negotiated via ALPN, which requires TLS. Over plaintext, only HTTP/1.1 is allowed.
-        if !self.application.serverConfiguration.isTLSEnabled {
-            guard self.application.serverConfiguration.httpVersions == [.http1_1] else {
-                throw NIOHTTPServerAdapterError.http2RequiresTLS
-            }
+        guard self.application.serverConfiguration.isTLSEnabled
+            || self.application.serverConfiguration.httpVersions == [.http1_1]
+        else {
+            throw NIOHTTPServerAdapterError.http2RequiresTLS
         }
 
         let (hostname, port) = self.resolveBindAddress()

--- a/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
+++ b/Sources/Vapor/HTTPNewNew/NIOHTTPServerAdapter.swift
@@ -7,6 +7,10 @@ import Logging
 enum NIOHTTPServerAdapterError: Error {
     /// The underlying server reported that it was listening but exposed no addresses.
     case noListeningAddress
+
+    /// HTTP/2 was requested without TLS. HTTP/2 is only negotiated over TLS (via ALPN),
+    /// so a ``ServerConfiguration/tlsConfiguration`` is required to serve it.
+    case http2RequiresTLS
 }
 
 /// Adapts `NIOHTTPServer` to Vapor's `Server` protocol using structured concurrency.
@@ -63,11 +67,37 @@ final class NIOHTTPServerAdapter: Server, Sendable {
             transportSecurity = .plaintext
         }
 
+        var supportedHTTPVersions = Set<NIOHTTPServerConfiguration.HTTPVersion>()
+        for httpVersion in self.application.serverConfiguration.httpVersions {
+            switch httpVersion.version {
+            case .http1_1:
+                supportedHTTPVersions.insert(.http1_1)
+            case .http2(let config):
+                supportedHTTPVersions.insert(.http2(
+                    config: .init(
+                        maxFrameSize: config.maxFrameSize,
+                        targetWindowSize: config.targetWindowSize,
+                        maxConcurrentStreams: config.maxConcurrentStreams,
+                        gracefulShutdown: .init(
+                            maximumGracefulShutdownDuration: config.gracefulShutdown.maximumGracefulShutdownDuration
+                        )
+                    )
+                ))
+            }
+        }
+
+        // HTTP/2 is negotiated via ALPN, which requires TLS. Over plaintext, only HTTP/1.1 is allowed.
+        if !self.application.serverConfiguration.isTLSEnabled {
+            guard self.application.serverConfiguration.httpVersions == [.http1_1] else {
+                throw NIOHTTPServerAdapterError.http2RequiresTLS
+            }
+        }
+
         let (hostname, port) = self.resolveBindAddress()
 
         let configuration = try NIOHTTPServerConfiguration(
             bindTarget: .hostAndPort(host: hostname, port: port),
-            supportedHTTPVersions: [.http1_1],
+            supportedHTTPVersions: supportedHTTPVersions,
             transportSecurity: transportSecurity
         )
 

--- a/Sources/Vapor/Server/ServerConfiguration.swift
+++ b/Sources/Vapor/Server/ServerConfiguration.swift
@@ -4,12 +4,17 @@ public struct ServerConfiguration: Sendable {
     /// The TLS configuration for the server, or `nil` to serve over plaintext HTTP.
     public var tlsConfiguration: TLSConfiguration?
 
+    /// The HTTP versions the server accepts. Defaults to HTTP/1.1 only; adding HTTP/2 requires a ``tlsConfiguration``.
+    public var httpVersions: Set<HTTPVersion>
+
     public init(
         address: BindAddress = .hostname(),
-        tlsConfiguration: TLSConfiguration? = nil
+        tlsConfiguration: TLSConfiguration? = nil,
+        httpVersions: Set<HTTPVersion> = [.http1_1]
     ) {
         self.address = address
         self.tlsConfiguration = tlsConfiguration
+        self.httpVersions = httpVersions
     }
 
     /// Host name the server will bind to.

--- a/Tests/VaporTests/HTTPServerConfigurationTests.swift
+++ b/Tests/VaporTests/HTTPServerConfigurationTests.swift
@@ -90,5 +90,22 @@ struct HTTPServerConfigurationTests {
                 }
             }
         }
+
+        @Test("An empty httpVersions set throws")
+        func testEmptyHTTPVersionsFails() async throws {
+            try await withApp { app in
+                app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+                app.serverConfiguration.httpVersions = []
+
+                do {
+                    try await app.server.run()
+                    Issue.record("Expected run() to throw for an empty httpVersions set.")
+                } catch NIOHTTPServerAdapterError.noHTTPVersionsSpecified {
+                    // Expected.
+                } catch {
+                    Issue.record("Expected noHTTPVersionsSpecified but got \(error).")
+                }
+            }
+        }
     }
 }

--- a/Tests/VaporTests/HTTPServerConfigurationTests.swift
+++ b/Tests/VaporTests/HTTPServerConfigurationTests.swift
@@ -1,0 +1,94 @@
+@testable import Vapor
+import VaporTesting
+import ServiceLifecycle
+import Testing
+
+@Suite("HTTP Server Configuration Tests")
+struct HTTPServerConfigurationTests {
+
+    @Suite("HTTP/2 configuration")
+    struct HTTP2Tests {
+        @Test("Default values")
+        func testDefaultValues() {
+            let http2 = ServerConfiguration.HTTP2.defaults
+            #expect(http2.maxFrameSize == ServerConfiguration.HTTP2.defaultMaxFrameSize)
+            #expect(http2.targetWindowSize == ServerConfiguration.HTTP2.defaultTargetWindowSize)
+            #expect(http2.maxConcurrentStreams == ServerConfiguration.HTTP2.defaultMaxConcurrentStreams)
+            #expect(http2.gracefulShutdown.maximumGracefulShutdownDuration == nil)
+        }
+
+        @Test("Custom values")
+        func testCustomValues() {
+            let http2 = ServerConfiguration.HTTP2(
+                maxFrameSize: 1,
+                targetWindowSize: 2,
+                maxConcurrentStreams: 3,
+                gracefulShutdown: .init(maximumGracefulShutdownDuration: .seconds(4))
+            )
+            #expect(http2.maxFrameSize == 1)
+            #expect(http2.targetWindowSize == 2)
+            #expect(http2.maxConcurrentStreams == 3)
+            #expect(http2.gracefulShutdown.maximumGracefulShutdownDuration == .seconds(4))
+        }
+
+        @Test("Partial custom values fall back to defaults")
+        func testPartialCustomValues() {
+            let http2 = ServerConfiguration.HTTP2(maxFrameSize: 5)
+            #expect(http2.maxFrameSize == 5)
+            #expect(http2.targetWindowSize == ServerConfiguration.HTTP2.defaultTargetWindowSize)
+            #expect(http2.maxConcurrentStreams == ServerConfiguration.HTTP2.defaultMaxConcurrentStreams)
+            #expect(http2.gracefulShutdown.maximumGracefulShutdownDuration == nil)
+        }
+    }
+
+    @Suite("Supported HTTP versions")
+    struct SupportedHTTPVersionsTests {
+        @Test("Defaults to HTTP/1.1 only")
+        func testDefault() {
+            let config = ServerConfiguration(address: .hostname("localhost", port: 8080))
+            #expect(config.httpVersions == [.http1_1])
+        }
+
+        @Test("HTTP/1.1 and HTTP/2 are distinct versions")
+        func testDistinctVersions() {
+            let versions: Set<ServerConfiguration.HTTPVersion> = [.http1_1, .http2(config: .defaults)]
+            #expect(versions.count == 2)
+        }
+
+        @Test("HTTP/2 versions are equal regardless of configuration")
+        func testHTTP2EqualByVersionOnly() {
+            // Equality and hashing are by protocol version only, so two HTTP/2 entries with
+            // different configuration collapse to a single set member.
+            let a: ServerConfiguration.HTTPVersion = .http2(config: .defaults)
+            let b: ServerConfiguration.HTTPVersion = .http2(config: .init(maxFrameSize: 1))
+            #expect(a == b)
+            #expect(Set([a, b]).count == 1)
+        }
+    }
+
+    @Suite("Preflight validation")
+    struct PreflightValidationTests {
+        // HTTP/2 requires TLS, so any version set containing HTTP/2 must be rejected over
+        // plaintext — even when HTTP/1.1 is also present.
+        @Test("HTTP/2 requested over plaintext throws", arguments: [
+            [ServerConfiguration.HTTPVersion.http2(config: .defaults)],
+            [.http1_1, .http2(config: .defaults)],
+        ] as [Set<ServerConfiguration.HTTPVersion>])
+        func testHTTP2WithoutTLSFails(_ versions: Set<ServerConfiguration.HTTPVersion>) async throws {
+            try await withApp { app in
+                app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+                app.serverConfiguration.httpVersions = versions
+                // tlsConfiguration is intentionally left nil: HTTP/2 requires TLS.
+
+                do {
+                    try await app.server.run()
+                    Issue.record("Expected run() to throw for \(versions).")
+                } catch NIOHTTPServerAdapterError.http2RequiresTLS {
+                    // Expected.
+                } catch {
+                    Issue.record("Expected http2RequiresTLS but got \(error).")
+                }
+            }
+        }
+    }
+}

--- a/Tests/VaporTests/ServerTLSTests.swift
+++ b/Tests/VaporTests/ServerTLSTests.swift
@@ -233,6 +233,60 @@ struct ServerTLSTests {
             }
         }
     }
+
+    @Test("HTTP/1.1 client is served when the server also offers HTTP/2", .timeLimit(.minutes(1)))
+    func testHTTP1ClientAgainstHTTP2EnabledServer() async throws {
+        try await withApp { app in
+            let credentials = try TestCredentials.localhost()
+            app.serverConfiguration.tlsConfiguration = .inMemory(
+                certificateChain: [credentials.certificate],
+                privateKey: credentials.privateKey
+            )
+            app.serverConfiguration.httpVersions = [.http1_1, .http2(config: .defaults)]
+            app.get("hello") { _ in "world" }
+
+            try await withRunningApp(app: app, hostname: "127.0.0.1") { port in
+                // Force the client to HTTP/1.1: enabling HTTP/2 on the server must not break H1 clients.
+                try await withTLSClient(trustingOnly: credentials.nioCertificate, httpVersion: .http1Only) { client in
+                    let response = try await client.execute(
+                        HTTPClientRequest(url: "https://127.0.0.1:\(port)/hello"),
+                        timeout: .seconds(10)
+                    )
+                    #expect(response.status == .ok)
+                    #expect(response.version == .http1_1)
+                    #expect(try await response.body.collect(upTo: 1024).string == "world")
+                }
+            }
+        }
+    }
+
+    @Test("Server serves over HTTP/2 when negotiated", .timeLimit(.minutes(1)))
+    func testServesOverHTTP2() async throws {
+        try await withApp { app in
+            let credentials = try TestCredentials.localhost()
+            app.serverConfiguration.tlsConfiguration = .inMemory(
+                certificateChain: [credentials.certificate],
+                privateKey: credentials.privateKey
+            )
+            app.serverConfiguration.httpVersions = [.http1_1, .http2(config: .defaults)]
+            app.get("hello") { _ in "world" }
+
+            try await withRunningApp(app: app, hostname: "127.0.0.1") { port in
+                // The client defaults to `.automatic`, advertising both h2 and http/1.1 over ALPN.
+                // The server offers h2, so the negotiated response should come back over HTTP/2.
+                try await withTLSClient(trustingOnly: credentials.nioCertificate) { client in
+                    let response = try await client.execute(
+                        HTTPClientRequest(url: "https://127.0.0.1:\(port)/hello"),
+                        timeout: .seconds(10)
+                    )
+                    #expect(response.status == .ok)
+                    #expect(response.version == .http2)
+                    #expect(try await response.body.collect(upTo: 1024).string == "world")
+                }
+            }
+        }
+    }
+
 }
 
 // MARK: - Helpers
@@ -268,6 +322,7 @@ private struct TestCredentials {
 private func withTLSClient<T>(
     trustingOnly trustedCertificate: NIOSSLCertificate? = nil,
     verification: CertificateVerification = .fullVerification,
+    httpVersion: HTTPClient.Configuration.HTTPVersion = .automatic,
     _ body: (HTTPClient) async throws -> T
 ) async throws -> T {
     var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
@@ -278,6 +333,7 @@ private func withTLSClient<T>(
 
     var clientConfiguration = HTTPClient.Configuration()
     clientConfiguration.tlsConfiguration = tlsConfiguration
+    clientConfiguration.httpVersion = httpVersion
 
     let client = HTTPClient(
         eventLoopGroup: MultiThreadedEventLoopGroup.singleton,


### PR DESCRIPTION
Adds HTTP/2 support to the new server backend, keeping the underlying `swift-http-server` types out of Vapor's public API (fixes #3378).

Enable HTTP/2 (requires TLS — negotiated over ALPN):

    app.serverConfiguration.tlsConfiguration = .pemFile(certificateChainPath: "...", privateKeyPath: "...")
    app.serverConfiguration.httpVersions = [.http1_1, .http2(config: .defaults)]

- New Vapor-owned `ServerConfiguration.HTTP2` and `ServerConfiguration.HTTPVersion`; the adapter translates them to NIOHTTPServer types internally so no server types leak.
- New `httpVersions` on `ServerConfiguration`, defaulting to `[.http1_1]`.
- Requesting HTTP/2 without a `tlsConfiguration` throws a clear error instead of failing obscurely.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
