### PR TITLE
Adopt InternalImportsByDefault for vapor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -149,7 +149,7 @@ let package = Package(
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "Algorithms", package: "swift-algorithms")
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
 
         .target(
@@ -159,7 +159,7 @@ let package = Package(
                 "Vapor",
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
 
         // Development
@@ -172,7 +172,7 @@ let package = Package(
                 .product(name: "SwiftASN1", package: "swift-asn1"),
             ],
             resources: [.copy("Resources")],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
 
         // Testing
@@ -187,7 +187,7 @@ let package = Package(
                 .product(name: "Instrumentation", package: "swift-distributed-tracing"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "VaporTests",
@@ -215,7 +215,7 @@ let package = Package(
                 .copy("Utilities/localhost.key"),
                 .copy("Utilities/long-test-file.txt"),
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "VaporMacroTests",
@@ -224,7 +224,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacrosGenericTestSupport", package: "swift-syntax", condition: .when(traits: ["MacroRouting"])),
                 .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax", condition: .when(traits: ["MacroRouting"])),
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "VaporMacroIntegrationTests",
@@ -234,7 +234,7 @@ let package = Package(
                 .target(name: "VaporTesting"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
-            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
+            swiftSettings: swiftSettings
         ),
     ]
 )
@@ -242,7 +242,7 @@ let package = Package(
 var swiftSettings: [SwiftSetting] { [
     .strictMemorySafety(),
     .enableUpcomingFeature("ExistentialAny"),
-//    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InferIsolatedConformances"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),

--- a/Sources/Vapor/Application.swift
+++ b/Sources/Vapor/Application.swift
@@ -1,9 +1,10 @@
-import Configuration
+public import Configuration
 import Logging
-import NIOConcurrencyHelpers
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
+public import NIOConcurrencyHelpers
 import NIOPosix
-import ServiceLifecycle
+public import ServiceLifecycle
 import UnixSignals
 #if HTTPClient
 import AsyncHTTPClient
@@ -72,7 +73,6 @@ public final class Application: Sendable, Service {
     // MARK: - Services
     package let contentConfiguration: ContentConfiguration
     package let responder: ServiceOptionType<any Responder>
-    public let byteBufferAllocator: ByteBufferAllocator = .init()
     public let viewRenderer: any ViewRenderer
     public let directoryConfiguration: DirectoryConfiguration
     public let cache: any Cache
@@ -150,9 +150,9 @@ public final class Application: Sendable, Service {
         switch services.client {
         case .default:
             #if HTTPClient
-            self.client = VaporHTTPClient(http: HTTPClient.shared, byteBufferAllocator: self.byteBufferAllocator, contentConfiguration: self.contentConfiguration)
+            self.client = VaporHTTPClient(http: HTTPClient.shared, contentConfiguration: self.contentConfiguration)
             #else
-            self.client = BlackholeClient(byteBufferAllocator: self.byteBufferAllocator, contentConfiguration: self.contentConfiguration)
+            self.client = BlackholeClient(contentConfiguration: self.contentConfiguration)
             #endif
         case .provided(let client):
             self.client = client

--- a/Sources/Vapor/Authentication/BasicAuthorization.swift
+++ b/Sources/Vapor/Authentication/BasicAuthorization.swift
@@ -3,7 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 /// A basic username and password.
 public struct BasicAuthorization: Sendable {

--- a/Sources/Vapor/Authentication/BearerAuthorization.swift
+++ b/Sources/Vapor/Authentication/BearerAuthorization.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 /// A bearer token.
 public struct BearerAuthorization: Sendable {

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -1,5 +1,5 @@
 import NIOCore
-import HTTPTypes
+public import HTTPTypes
 
 extension Authenticatable {
     /// This middleware ensures that an `Authenticatable` type `A` has been authenticated

--- a/Sources/Vapor/Client/BlackholeClient.swift
+++ b/Sources/Vapor/Client/BlackholeClient.swift
@@ -4,7 +4,6 @@ import HTTPTypes
 /// Type that conforms to `Client` but does nothing and throws an error when used. Can be useful for testing
 /// Used when the `HTTPClient` package trait is disabled
 public struct BlackholeClient: Client {
-    public var byteBufferAllocator: ByteBufferAllocator
     public var contentConfiguration: ContentConfiguration
     public func send(_ request: ClientRequest) async throws -> ClientResponse {
         // Do nothing

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,9 +1,8 @@
 import NIOCore
 import Logging
-import HTTPTypes
+public import HTTPTypes
 
 public protocol Client: Sendable {
-    var byteBufferAllocator: ByteBufferAllocator { get }
     var contentConfiguration: ContentConfiguration { get }
     func send(_ request: ClientRequest) async throws -> ClientResponse
 }
@@ -47,7 +46,7 @@ extension Client {
         to url: URI,
         beforeSend: (inout ClientRequest) throws -> () = { _ in }
     ) async throws -> ClientResponse {
-        var request = ClientRequest(method: method, url: url, headers: headers, body: nil, byteBufferAllocator: self.byteBufferAllocator, contentConfiguration: self.contentConfiguration)
+        var request = ClientRequest(method: method, url: url, headers: headers, body: nil, contentConfiguration: self.contentConfiguration)
         try beforeSend(&request)
         return try await self.send(request)
     }

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -1,10 +1,11 @@
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 public struct ClientRequest: Sendable {
     public var method: HTTPRequest.Method
@@ -13,7 +14,6 @@ public struct ClientRequest: Sendable {
     public var body: ByteBuffer?
     public var timeout: TimeAmount
     public var maxResponseBodySize: Int
-    private let byteBufferAllocator: ByteBufferAllocator
     private let contentConfiguration: ContentConfiguration
 
     public init(
@@ -23,7 +23,6 @@ public struct ClientRequest: Sendable {
         body: ByteBuffer? = nil,
         timeout: TimeAmount? = nil,
         maxResponseBodySize: Int = 10 * 1024 * 1024, // Default to 10 MB
-        byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         contentConfiguration: ContentConfiguration = .default()
     ) {
         self.method = method
@@ -31,7 +30,6 @@ public struct ClientRequest: Sendable {
         self.headers = headers
         self.body = body
         self.timeout = timeout ?? .seconds(30)
-        self.byteBufferAllocator = byteBufferAllocator
         self.contentConfiguration = contentConfiguration
         self.maxResponseBodySize = maxResponseBodySize
     }
@@ -61,7 +59,7 @@ extension ClientRequest {
     private struct _ContentContainer: ContentContainer {
         var body: ByteBuffer?
         var headers: HTTPFields
-        let byteBufferAllocator: ByteBufferAllocator
+        let byteBufferAllocator = ByteBufferAllocator()
         let contentConfiguration: ContentConfiguration
 
         var contentType: HTTPMediaType? {
@@ -100,7 +98,7 @@ extension ClientRequest {
     }
 
     public var content: any ContentContainer {
-        get { _ContentContainer(body: self.body, headers: self.headers, byteBufferAllocator: self.byteBufferAllocator, contentConfiguration: self.contentConfiguration) }
+        get { _ContentContainer(body: self.body, headers: self.headers, contentConfiguration: self.contentConfiguration) }
         set {
             let container = (newValue as! _ContentContainer)
             self.body = container.body

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -1,5 +1,6 @@
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -13,11 +14,11 @@ public struct ClientResponse: Sendable {
     private let byteBufferAllocator: ByteBufferAllocator
     private let contentConfiguration: ContentConfiguration
 
-    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: ByteBuffer? = nil, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(), contentConfiguration: ContentConfiguration = .default()) {
+    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: ByteBuffer? = nil, contentConfiguration: ContentConfiguration = .default()) {
         self.status = status
         self.headers = headers
         self.body = body
-        self.byteBufferAllocator = byteBufferAllocator
+        self.byteBufferAllocator = ByteBufferAllocator()
         self.contentConfiguration = contentConfiguration
     }
 }

--- a/Sources/Vapor/Concurrency/RequestBody+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RequestBody+Concurrency.swift
@@ -1,4 +1,5 @@
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOConcurrencyHelpers
 import NIOPosix
 

--- a/Sources/Vapor/Content/ContentCoders.swift
+++ b/Sources/Vapor/Content/ContentCoders.swift
@@ -1,10 +1,11 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 
 /// Conform a type to this protocol to make it usable for encoding data via Vapor's ``ContentConfiguration`` system.
 public protocol ContentEncoder: Sendable {

--- a/Sources/Vapor/Content/ContentCoders.swift
+++ b/Sources/Vapor/Content/ContentCoders.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationEssentials)
-public import FoundationEssentials
+import FoundationEssentials
 #else
-public import Foundation
+import Foundation
 #endif
 #warning("Make this internal")
 public import NIOCore

--- a/Sources/Vapor/Content/JSONCoder+Custom.swift
+++ b/Sources/Vapor/Content/JSONCoder+Custom.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 extension JSONEncoder {

--- a/Sources/Vapor/Content/JSONCoders+Content.swift
+++ b/Sources/Vapor/Content/JSONCoders+Content.swift
@@ -1,10 +1,11 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 import NIOFoundationEssentialsCompat
 
 extension JSONEncoder: ContentEncoder {

--- a/Sources/Vapor/Content/PlaintextDecoder.swift
+++ b/Sources/Vapor/Content/PlaintextDecoder.swift
@@ -1,5 +1,6 @@
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 
 /// Decodes data as plaintext, utf8.
 public struct PlaintextDecoder: ContentDecoder {

--- a/Sources/Vapor/Content/PlaintextEncoder.swift
+++ b/Sources/Vapor/Content/PlaintextEncoder.swift
@@ -3,8 +3,9 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 
 /// Encodes data as plaintext, utf8.
 public struct PlaintextEncoder: ContentEncoder {

--- a/Sources/Vapor/Environment/Environment.swift
+++ b/Sources/Vapor/Environment/Environment.swift
@@ -1,4 +1,4 @@
-import Configuration
+public import Configuration
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Vapor/Error/Abort.swift
+++ b/Sources/Vapor/Error/Abort.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 /// Default implementation of `AbortError`. You can use this as a convenient method for throwing
 /// `AbortError`s without having to conform your own error-type to `AbortError`.

--- a/Sources/Vapor/Error/AbortError.swift
+++ b/Sources/Vapor/Error/AbortError.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 /// Errors conforming to this protocol will always be displayed by
 /// Vapor to the end-user (even in production mode where most errors are silenced).

--- a/Sources/Vapor/Error/DebuggableError.swift
+++ b/Sources/Vapor/Error/DebuggableError.swift
@@ -1,9 +1,9 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import Logging
+public import Logging
 
 /// `Debuggable` provides an interface that allows a type
 /// to be more easily debugged in the case of an error.

--- a/Sources/Vapor/HTTP/BodyStream.swift
+++ b/Sources/Vapor/HTTP/BodyStream.swift
@@ -1,4 +1,5 @@
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 
 public enum BodyStreamResult: Sendable {
     /// A normal data chunk.

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -13,7 +13,6 @@ import NIOHTTP1
 
 internal struct VaporHTTPClient: Client {
     let http: HTTPClient
-    var byteBufferAllocator: ByteBufferAllocator
     let contentConfiguration: ContentConfiguration
 
     func send(_ clientRequest: ClientRequest) async throws -> ClientResponse {
@@ -36,7 +35,6 @@ internal struct VaporHTTPClient: Client {
             status: .init(code: Int(response.status.code)),
             headers: .init(response.headers, splitCookie: false),
             body: response.body.collect(upTo: clientRequest.maxResponseBodySize),
-            byteBufferAllocator: self.byteBufferAllocator,
             contentConfiguration: self.contentConfiguration
         )
     }

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -6,7 +6,7 @@ import Foundation
 import NIOConcurrencyHelpers
 import NIOCore
 import Logging
-import HTTPTypes
+public import HTTPTypes
 
 public enum EndpointCacheError: Swift.Error {
     case unexpectedResponseStatus(HTTPResponse.Status, uri: URI)

--- a/Sources/Vapor/HTTP/HTTPVersion.swift
+++ b/Sources/Vapor/HTTP/HTTPVersion.swift
@@ -1,0 +1,67 @@
+/// A structure representing a HTTP version.
+public struct HTTPVersion: Equatable, Sendable {
+    /// Create a HTTP version.
+    ///
+    /// - Parameter major: The major version number.
+    /// - Parameter minor: The minor version number.
+    @inlinable
+    public init(major: Int, minor: Int) {
+        self._major = UInt16(major)
+        self._minor = UInt16(minor)
+    }
+
+    @usableFromInline var _minor: UInt16
+    @usableFromInline var _major: UInt16
+
+    /// The major version number.
+    @inlinable
+    public var major: Int {
+        get {
+            Int(self._major)
+        }
+        set {
+            self._major = UInt16(newValue)
+        }
+    }
+
+    /// The minor version number.
+    @inlinable
+    public var minor: Int {
+        get {
+            Int(self._minor)
+        }
+        set {
+            self._minor = UInt16(newValue)
+        }
+    }
+
+    /// HTTP/3
+    @inlinable
+    public static var http3: HTTPVersion {
+        HTTPVersion(major: 3, minor: 0)
+    }
+
+    /// HTTP/2
+    @inlinable
+    public static var http2: HTTPVersion {
+        HTTPVersion(major: 2, minor: 0)
+    }
+
+    /// HTTP/1.1
+    @inlinable
+    public static var http1_1: HTTPVersion {
+        HTTPVersion(major: 1, minor: 1)
+    }
+
+    /// HTTP/1.0
+    @inlinable
+    public static var http1_0: HTTPVersion {
+        HTTPVersion(major: 1, minor: 0)
+    }
+
+    /// HTTP/0.9 (not supported by SwiftNIO)
+    @inlinable
+    public static var http0_9: HTTPVersion {
+        HTTPVersion(major: 0, minor: 9)
+    }
+}

--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -1,9 +1,9 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Get and set ``HTTPCookies`` for an HTTP request.

--- a/Sources/Vapor/HTTP/Headers/HTTPFieldCacheControl.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFieldCacheControl.swift
@@ -3,7 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 // Comments on these properties are copied from the mozilla doc URL shown below.
 extension HTTPFields {

--- a/Sources/Vapor/HTTP/Headers/HTTPFieldExpires.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFieldExpires.swift
@@ -1,9 +1,9 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     public struct Expires {

--- a/Sources/Vapor/HTTP/Headers/HTTPFieldLastModified.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFieldLastModified.swift
@@ -1,9 +1,9 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Represents the HTTP `Last-Modified` header.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+Cache.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+Cache.swift
@@ -1,9 +1,9 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Determines when the cached data should be expired.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+Connection.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+Connection.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     public struct Connection: ExpressibleByStringLiteral, Equatable, Sendable {

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+ContentDisposition.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+ContentDisposition.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Convenience for accessing the Content-Disposition header.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+ContentRange.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+ContentRange.swift
@@ -3,7 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 import Algorithms
 
 extension HTTPFields {

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+Forwarded.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+Forwarded.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Convenience for accessing the Forwarded header. This header is added by

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+Link.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+Link.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Convenience for accessing the Link header as an array of provided links.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+ResponseCompression.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+ResponseCompression.swift
@@ -3,7 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// A marker header internal to vapor that explicitely allows or disallows response compression.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+WWWAuthenticate.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+WWWAuthenticate.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// Represents the HTTP `WWW-Authenticate` header.

--- a/Sources/Vapor/HTTP/Headers/HTTPFields.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPFields {
     /// `MediaType` specified by this message's `"Content-Type"` header.

--- a/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPHeaders+Name.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 extension HTTPField.Name {
 

--- a/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaTypePreference.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 import HTTPTypes
 

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+RequestDecompressionConfiguration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+RequestDecompressionConfiguration.swift
@@ -1,4 +1,5 @@
-import NIOHTTPCompression
+#warning("Should this be internal?")
+public import NIOHTTPCompression
 
 extension ServerConfiguration {
     /// Supported HTTP decompression options.

--- a/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+TLSConfiguration.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerConfiguration+TLSConfiguration.swift
@@ -1,4 +1,4 @@
-import X509
+public import X509
 
 extension ServerConfiguration {
     /// Transport-level TLS configuration for the server.

--- a/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
+++ b/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
@@ -1,5 +1,6 @@
-import NIOCore
-import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
+public import HTTPTypes
 
 /// Protocol for writing HTTP response bodies.
 ///

--- a/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
@@ -64,7 +64,6 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 collectedBody: bodyBuffer.readableBytes > 0 ? bodyBuffer : nil,
                 remoteAddress: nil,
                 peerCertificateChain: peerCerts,
-                byteBufferAllocator: self.application.byteBufferAllocator,
                 requestID: requestID
             )
 

--- a/Sources/Vapor/Logging/Logger+Report.swift
+++ b/Sources/Vapor/Logging/Logger+Report.swift
@@ -3,7 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import Logging
+public import Logging
 
 extension Logger {
     /// Reports an `Error` to this `Logger`.

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -1,5 +1,5 @@
 import NIOCore
-import HTTPTypes
+public import HTTPTypes
 import NIOConcurrencyHelpers
 
 /// Middleware that adds support for CORS settings in request responses.

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -1,11 +1,12 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import _NIOFileSystem
-import HTTPTypes
+public import HTTPTypes
 
 /// Serves static files from a public directory.
 ///

--- a/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
+++ b/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 /// Overrides the response compression settings for a route.
 ///

--- a/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
+++ b/Sources/Vapor/Middleware/RouteLoggingMiddleware.swift
@@ -1,4 +1,4 @@
-import Logging
+public import Logging
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -1,5 +1,5 @@
 import HTTPTypes
-import Tracing
+public import Tracing
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1

--- a/Sources/Vapor/Multipart/File+Multipart.swift
+++ b/Sources/Vapor/Multipart/File+Multipart.swift
@@ -1,7 +1,8 @@
 #if Multipart
-import MultipartKit
-import HTTPTypes
-import NIOCore
+public import MultipartKit
+public import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
 
 extension File: MultipartPartConvertible {
     public typealias Body = ByteBufferView

--- a/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
@@ -1,7 +1,8 @@
 #if Multipart
-import MultipartKit
-import HTTPTypes
-import NIOCore
+public import MultipartKit
+public import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
 
 extension FormDataDecoder: ContentDecoder {
     public func decode<D>(_ decodable: D.Type, from body: ByteBuffer, headers: HTTPFields) throws -> D

--- a/Sources/Vapor/Multipart/FormDataEncoder+Content.swift
+++ b/Sources/Vapor/Multipart/FormDataEncoder+Content.swift
@@ -1,7 +1,8 @@
 #if Multipart
-import MultipartKit
-import HTTPTypes
-import NIOCore
+public import MultipartKit
+public import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
 
 extension FormDataEncoder: ContentEncoder {
     public func encode(_ encodable: some Encodable, to body: inout ByteBuffer, headers: inout HTTPFields) throws {

--- a/Sources/Vapor/Request/Redirect.swift
+++ b/Sources/Vapor/Request/Redirect.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 import NIOConcurrencyHelpers
 
 extension Request {

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -1,4 +1,5 @@
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOPosix
 import NIOConcurrencyHelpers
 import HTTPTypes

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -1,17 +1,18 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOHTTP1
 import Logging
-import RoutingKit
+public import RoutingKit
 import NIOConcurrencyHelpers
-import HTTPTypes
+public import HTTPTypes
 import NIOPosix
 import ServiceContextModule
-import X509
+public import X509
 
 /// Represents an HTTP request in an application.
 public final class Request: CustomStringConvertible, Sendable {

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -3,8 +3,8 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import HTTPTypes
-import Logging
+public import HTTPTypes
+public import Logging
 import NIOCore
 import RoutingKit
 

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -1,4 +1,3 @@
-@preconcurrency import Dispatch
 #if canImport(FoundationEssentials)
 public import FoundationEssentials
 #else
@@ -33,7 +32,6 @@ extension Response {
             case none
             case buffer(ByteBuffer)
             case data(Data)
-            case dispatchData(DispatchData)
             case staticString(StaticString)
             case string(String)
             case stream(BodyStream)
@@ -47,7 +45,6 @@ extension Response {
             switch self.storage {
             case .buffer(var buffer): return buffer.readString(length: buffer.readableBytes)
             case .data(let data): return String(decoding: data, as: UTF8.self)
-            case .dispatchData(let dispatchData): return String(decoding: dispatchData, as: UTF8.self)
             case .staticString(let staticString): return staticString.description
             case .string(let string): return string
             default: return nil
@@ -59,7 +56,6 @@ extension Response {
         public var count: Int {
             switch self.storage {
             case .data(let data): return data.count
-            case .dispatchData(let data): return data.count
             case .staticString(let staticString): return staticString.utf8CodeUnitCount
             case .string(let string): return string.utf8.count
             case .buffer(let buffer): return buffer.readableBytes
@@ -74,7 +70,6 @@ extension Response {
             switch self.storage {
             case .buffer(var buffer): return buffer.readData(length: buffer.readableBytes)
             case .data(let data): return data
-            case .dispatchData(let dispatchData): return Data(dispatchData)
             case .staticString(let staticString): return Data(bytes: staticString.utf8Start, count: staticString.utf8CodeUnitCount)
             case .string(let string): return Data(string.utf8)
             case .none: return nil
@@ -88,9 +83,6 @@ extension Response {
             case .buffer(let buffer): return buffer
             case .data(let data):
                 let buffer = self.byteBufferAllocator.buffer(bytes: data)
-                return buffer
-            case .dispatchData(let dispatchData):
-                let buffer = self.byteBufferAllocator.buffer(dispatchData: dispatchData)
                 return buffer
             case .staticString(let staticString):
                 let buffer = self.byteBufferAllocator.buffer(staticString: staticString)
@@ -129,7 +121,6 @@ extension Response {
             case .none: return "<no body>"
             case .buffer(let buffer): return buffer.getString(at: 0, length: buffer.readableBytes) ?? "n/a"
             case .data(let data): return String(data: data, encoding: .ascii) ?? "n/a"
-            case .dispatchData(let data): return String(data: Data(data), encoding: .ascii) ?? "n/a"
             case .staticString(let string): return string.description
             case .string(let string): return string
             case .stream: return "<stream>"
@@ -150,12 +141,6 @@ extension Response {
         public init(data: Data, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
             self.byteBufferAllocator = byteBufferAllocator
             storage = .data(data)
-        }
-
-        /// Create a new body wrapping `DispatchData`.
-        public init(dispatchData: DispatchData, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
-            storage = .dispatchData(dispatchData)
         }
 
         /// Create a new body from the UTF8 representation of a `StaticString`.

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -1,10 +1,11 @@
 @preconcurrency import Dispatch
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOFoundationEssentialsCompat
 import NIOConcurrencyHelpers
 import HTTPTypes

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -1,8 +1,7 @@
 import NIOCore
-import NIOHTTP1
 import NIOFoundationEssentialsCompat
 import NIOConcurrencyHelpers
-import HTTPTypes
+public import HTTPTypes
 
 /// An HTTP response from a server back to the client.
 ///

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 import NIOConcurrencyHelpers
 
 /// Can convert `self` to a `Response`.

--- a/Sources/Vapor/Routing/Parameters+Require.swift
+++ b/Sources/Vapor/Routing/Parameters+Require.swift
@@ -1,4 +1,4 @@
-import RoutingKit
+public import RoutingKit
 import HTTPTypes
 import Logging
 

--- a/Sources/Vapor/Routing/Route.swift
+++ b/Sources/Vapor/Routing/Route.swift
@@ -1,6 +1,5 @@
-import RoutingKit
-import NIOConcurrencyHelpers
-import HTTPTypes
+public import RoutingKit
+public import HTTPTypes
 
 public struct Route: CustomStringConvertible, Sendable {
     public var method: HTTPRequest.Method

--- a/Sources/Vapor/Routing/RoutesBuilder+Group.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Group.swift
@@ -1,4 +1,4 @@
-import RoutingKit
+public import RoutingKit
 
 extension RoutesBuilder {
     // MARK: Path

--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -1,5 +1,5 @@
-import RoutingKit
-import HTTPTypes
+public import RoutingKit
+public import HTTPTypes
 import NIOPosix
 import NIOCore
 

--- a/Sources/Vapor/Routing/RoutesBuilder.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder.swift
@@ -1,7 +1,7 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 public protocol RoutesBuilder {

--- a/Sources/Vapor/Security/OTP.swift
+++ b/Sources/Vapor/Security/OTP.swift
@@ -14,15 +14,11 @@ import WASILibc
 #error("Unsupported runtime")
 #endif
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-#if canImport(Darwin) && compiler(>=6.1)
-import Crypto
-#else
-@preconcurrency import Crypto
-#endif
+public import Crypto
 
 /// Supported OTP output sizes.
 public enum OTPDigits: Int, Sendable {

--- a/Sources/Vapor/Server/Server.swift
+++ b/Sources/Vapor/Server/Server.swift
@@ -1,5 +1,6 @@
-import ServiceLifecycle
-import NIOCore
+public import ServiceLifecycle
+#warning("Make this internal")
+public import NIOCore
 
 /// A server that can handle HTTP requests.
 ///

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormDecoder.swift
@@ -1,10 +1,11 @@
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 
 /// Decodes instances of `Decodable` types from `application/x-www-form-urlencoded` data.
 ///

--- a/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
+++ b/Sources/Vapor/URLEncodedForm/URLEncodedFormEncoder.swift
@@ -1,10 +1,11 @@
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
-import HTTPTypes
-import NIOCore
+public import HTTPTypes
+#warning("Make this internal")
+public import NIOCore
 
 /// Encodes `Encodable` instances to `application/x-www-form-urlencoded` data.
 ///

--- a/Sources/Vapor/Utilities/Base32.swift
+++ b/Sources/Vapor/Utilities/Base32.swift
@@ -4,9 +4,9 @@
 /// in the extensions and the extreme awkwardness of vendor prefixing for this use case.
 
 #if canImport(FoundationEssentials)
-import struct FoundationEssentials.Data
+public import struct FoundationEssentials.Data
 #else
-import struct Foundation.Data
+public import struct Foundation.Data
 #endif
 
 extension BaseNEncoding {

--- a/Sources/Vapor/Utilities/File.swift
+++ b/Sources/Vapor/Utilities/File.swift
@@ -3,7 +3,8 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOFoundationEssentialsCompat
 
 /// Represents a single file.

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -3,8 +3,9 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
-import _NIOFileSystem
+#warning("Make this internal")
+public import NIOCore
+public import _NIOFileSystem
 import HTTPTypes
 import Logging
 import Crypto
@@ -15,7 +16,6 @@ import NIOHTTP1
 extension Request {
     public var fileio: FileIO {
         return .init(
-            allocator: self.application.byteBufferAllocator,
             request: self
         )
     }
@@ -44,9 +44,6 @@ extension Request {
 ///
 /// Streaming file responses respect `E-Tag` headers present in the request.
 public struct FileIO: Sendable {
-    /// ByteBufferAllocator to use for generating buffers.
-    private let allocator: ByteBufferAllocator
-
     /// HTTP request context.
     let request: Request
 
@@ -55,8 +52,7 @@ public struct FileIO: Sendable {
     /// Creates a new ``FileIO``.
     ///
     /// Use ``Request/fileio`` to get one.
-    internal init(allocator: ByteBufferAllocator, request: Request) {
-        self.allocator = allocator
+    internal init(request: Request) {
         self.request = request
     }
 

--- a/Sources/Vapor/Utilities/SocketAddress+Hostname.swift
+++ b/Sources/Vapor/Utilities/SocketAddress+Hostname.swift
@@ -1,4 +1,5 @@
-import enum NIO.SocketAddress
+#warning("Make this internal")
+public import enum NIO.SocketAddress
 
 extension SocketAddress {
     /// Returns the hostname for this `SocketAddress` if one exists.

--- a/Sources/Vapor/Validation/ValidationsError.swift
+++ b/Sources/Vapor/Validation/ValidationsError.swift
@@ -1,4 +1,4 @@
-import HTTPTypes
+public import HTTPTypes
 
 public struct ValidationsResult: Sendable {
     public let results: [ValidationResult]

--- a/Sources/Vapor/View/View.swift
+++ b/Sources/Vapor/View/View.swift
@@ -1,4 +1,5 @@
-import NIOCore
+#warning("Make internal")
+public import NIOCore
 import HTTPTypes
 
 public struct View: ResponseEncodable, Sendable {


### PR DESCRIPTION
Adopt InternalImportsByDefault for the vapor target so the whole package supports it.

First PR of likely a few as we refine the API. Ideally I'd let to getrid of NIO from the API, so lots of warnings for now.

I've also started to remove ByteBufferAllocator and introduce our own HTTPVersion type
