### PR TITLE
Fix testing(method: .running).test second call

### DIFF
--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -77,6 +77,7 @@ public func withApp<T>(
 /// ```
 public func withRunningApp<T: Sendable>(app: Application, hostname: String = "localhost", portToUse: Int = 0, _ block: (Int) async throws -> T) async throws -> T {
     app.serverConfiguration.address = .hostname(hostname, port: portToUse)
+    defer { app.serverConfiguration.address = nil }
     try await app.boot()
 
     return try await withThrowingTaskGroup(of: T?.self) { group in


### PR DESCRIPTION
Fixes #3521

### Problem

`testing(method: .running).test(...)` failed on the second call:

```
We don't clear the address correctly and automatically fail the second `.run()`
```

`withRunningApp` set `app.serverConfiguration.address` but never cleared it, so the second `testing(.running)` left the previous address in place and the server's second `run()` failed.

### Change

Clear `app.serverConfiguration.address` after the server task completes:

```swift
app.serverConfiguration.address = .hostname(hostname, port: portToUse)
defer { app.serverConfiguration.address = nil }
try await app.boot()
```

The `defer` runs after the `withThrowingTaskGroup` that hosts the server, so the address is reset for the next test.

### Validation

- `swift test --filter VaporTesting` second-call repro now passes (previously failed)
- Change is isolated to `withApp.swift:79`; existing `TestingApplication` tests expected to be unaffected
