### PR TITLE
`Response` overhaul

### DIFF
--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -32,7 +32,7 @@ extension RequestAuthenticator {
     ) async throws -> Response {
         do {
             try await self.authenticate(request: request)
-            let response = try await next.respond(to: request)
+            var response = try await next.respond(to: request)
             if response.status == .unauthorized, response.headers[.wwwAuthenticate] == nil {
                 response.headers.wwwAuthenticate = challenge
             }

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -70,7 +70,7 @@ extension Content {
     }
     
     public func encodeResponse(for request: Request) async throws -> Response {
-        let response = Response(contentConfiguration: request.application.contentConfiguration)
+        var response = Response(contentConfiguration: request.application.contentConfiguration)
         try response.content.encode(self)
         return response
     }

--- a/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
@@ -79,6 +79,19 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 Logger.current.critical("Invalid server state - no response sender")
                 throw Abort(.internalServerError)
             }
+            // If this is a HEAD request we don't need a body, so write an empty body out and don't
+            // waste time going through the response body. `204` and `304` are defined as bodyless
+            // too: writing one anyway breaks framing, and the client reads it as the start of the
+            // next response.
+            let bodyIsForbidden = request.method == .head
+                || vaporResponse.status == .noContent
+                || vaporResponse.status == .notModified
+            guard !bodyIsForbidden else {
+                var empty = UniqueArray<UInt8>()
+                try await sender.sendAndFinish(httpResponse, buffer: &empty)
+                return
+            }
+
             switch vaporResponse.body.storage {
             case .stream(let bodyStream):
                 // Streaming body: send the head, then let the body closure write chunks straight

--- a/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
@@ -79,6 +79,17 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 Logger.current.critical("Invalid server state - no response sender")
                 throw Abort(.internalServerError)
             }
+            // Vapor currently doesn't have an API for informational responses, trying to return one would
+            // result in a crash, so bypass that here
+            guard vaporResponse.status.kind != .informational else {
+                Logger.current.error(
+                    "Handler returned an informational status, which cannot be sent as a final response",
+                    metadata: ["status": "\(vaporResponse.status.code)"])
+                var empty = UniqueArray<UInt8>()
+                try await sender.sendAndFinish(HTTPResponse(status: .internalServerError), buffer: &empty)
+                return
+            }
+
             // If this is a HEAD request we don't need a body, so write an empty body out and don't
             // waste time going through the response body. `204` and `304` are defined as bodyless
             // too: writing one anyway breaks framing, and the client reads it as the start of the

--- a/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTPNewNew/HTTPServerHandler.swift
@@ -90,6 +90,16 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 // of the public `ResponseBodyWriter` protocol); the closure only sees `write`.
                 let writer = NIOResponseBodyWriter(inner: try await sender.send(httpResponse))
                 try await bodyStream.callback(writer)
+                guard bodyStream.count < 0 || writer.bytesWritten == bodyStream.count else {
+                    // Stream lenght is different to what was expecting, this is an error state to close the connection
+                    Logger.current.debug(
+                        "Response body stream wrote a different number of bytes than it declared, closing the connection",
+                        metadata: [
+                            "written": "\(writer.bytesWritten)",
+                            "declared": "\(bodyStream.count)",
+                        ])
+                    return
+                }
                 try await writer.finish(nil)
             default:
                 // Buffered body: single-shot write.
@@ -113,6 +123,9 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
 final class NIOResponseBodyWriter: ResponseBodyWriter {
     private var inner: NIOHTTPServer.ResponseSender.Writer?
 
+    /// The number of body bytes written so far, used to check a stream against its declared length.
+    private(set) var bytesWritten = 0
+
     init(inner: consuming NIOHTTPServer.ResponseSender.Writer) {
         self.inner = consume inner
     }
@@ -123,6 +136,7 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         // `inner` is always present during writes (the body closure runs before `finish`, which
         // takes it); the optional-chaining is just how we reach the move-only writer in place.
         try await self.inner?.write(buffer: &out)
+        self.bytesWritten += buffer.readableBytes
     }
 
     func finish(_ trailingHeaders: HTTPFields?) async throws {

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -138,34 +138,33 @@ public final class CORSMiddleware: Middleware {
 
         // Determine if the request is pre-flight.
         // If it is, create empty response otherwise get response from the responder chain.
-        let response = request.isPreflight ? Response() : try await next.respond(to: request)
+        var response = request.isPreflight ? Response() : try await next.respond(to: request)
 
         // Modify response headers based on CORS settings
         let accessControlAllowOriginHeader = self.configuration.allowedOrigin.header(forRequest: request)
-        response.responseBox.withLockedValue { box in
-            if !accessControlAllowOriginHeader.isEmpty {
-                box.headers[.accessControlAllowOrigin] = accessControlAllowOriginHeader
-            }
-
-            box.headers[.accessControlAllowMethods] = self.configuration.allowedMethods
-            box.headers[.accessControlAllowHeaders] = self.configuration.allowedHeaders
-
-            if let exposedHeaders = self.configuration.exposedHeaders {
-                box.headers[.accessControlExposeHeaders] = exposedHeaders
-            }
-
-            if let cacheExpiration = self.configuration.cacheExpiration {
-                box.headers[.accessControlMaxAge] = String(cacheExpiration)
-            }
-
-            if self.configuration.allowCredentials {
-                box.headers[.accessControlAllowCredentials] = "true"
-            }
-
-            if self.configuration.allowedOrigin.variesByRequestOrigin, !accessControlAllowOriginHeader.isEmpty {
-                box.headers[.vary] = "origin"
-            }
+        if !accessControlAllowOriginHeader.isEmpty {
+            response.headers[.accessControlAllowOrigin] = accessControlAllowOriginHeader
         }
+
+        response.headers[.accessControlAllowMethods] = self.configuration.allowedMethods
+        response.headers[.accessControlAllowHeaders] = self.configuration.allowedHeaders
+
+        if let exposedHeaders = self.configuration.exposedHeaders {
+            response.headers[.accessControlExposeHeaders] = exposedHeaders
+        }
+
+        if let cacheExpiration = self.configuration.cacheExpiration {
+            response.headers[.accessControlMaxAge] = String(cacheExpiration)
+        }
+
+        if self.configuration.allowCredentials {
+            response.headers[.accessControlAllowCredentials] = "true"
+        }
+
+        if self.configuration.allowedOrigin.variesByRequestOrigin, !accessControlAllowOriginHeader.isEmpty {
+            response.headers[.vary] = "origin"
+        }
+
         return response
     }
 }

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -95,10 +95,10 @@ public final class FileMiddleware: Middleware {
 
                         if try await FileSystem.shared.info(forFileAt: .init(absPath)) != nil {
                             // If the default file exists, stream it
-                            return try await request
+                            var response = try await request
                                 .fileio
                                 .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
-                                .cachePolicy(cachePolicy)
+                            return response.cachePolicy(cachePolicy)
                         }
                     }
                 } else {
@@ -110,10 +110,10 @@ public final class FileMiddleware: Middleware {
                 }
             } else {
                 // file exists, stream it
-                return try await request
+                var response = try await request
                     .fileio
                     .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
-                    .cachePolicy(cachePolicy)
+                return response.cachePolicy(cachePolicy)
             }
         }
 
@@ -241,7 +241,7 @@ extension Response {
     /// - Parameter policy: The cache policy to use.
     /// - Returns: The same response as the receiver.
     @discardableResult
-    func cachePolicy(_ policy: FileMiddleware.CachePolicy) -> Response {
+    mutating func cachePolicy(_ policy: FileMiddleware.CachePolicy) -> Response {
         self.headers.cacheControl = policy.cacheControlHeader
         if let age = policy.ageHeader {
             self.headers[.age] = "\(age)"

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -64,6 +64,13 @@ public final class FileMiddleware: Middleware {
     }
 
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
+        // Only GET and HEAD retrieve a representation of a file. Anything else — writes, OPTIONS,
+        // and so on — isn't ours to answer just because the path happens to match a file on disk,
+        // so hand it down the chain where a route (or the 404) can deal with it.
+        guard request.method == .get || request.method == .head else {
+            return try await next.respond(to: request)
+        }
+
         // make a copy of the percent-decoded path
         guard var path = request.url.path.removingPercentEncoding else {
             throw Abort(.badRequest)

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -31,12 +31,12 @@ public final class FileMiddleware: Middleware {
         public static let publicDirectoryIsNotAFolder: Self = .init(description: "Cannot find any actual folder for the given Public Directory")
     }
 
-    struct ETagHashes: StorageKey {
-        public typealias Value = [String: FileHash]
+    package struct ETagHashes: StorageKey {
+        package typealias Value = [String: FileHash]
 
-        public struct FileHash {
-            let lastModified: Date
-            let digestHex: String
+        package struct FileHash {
+            package let lastModified: Date
+            package let digestHex: String
         }
     }
 

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -95,10 +95,10 @@ public final class FileMiddleware: Middleware {
 
                         if try await FileSystem.shared.info(forFileAt: .init(absPath)) != nil {
                             // If the default file exists, stream it
-                            var response = try await request
+                            return try await request
                                 .fileio
                                 .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
-                            return response.cachePolicy(cachePolicy)
+                                .applyingCachePolicy(cachePolicy)
                         }
                     }
                 } else {
@@ -110,10 +110,10 @@ public final class FileMiddleware: Middleware {
                 }
             } else {
                 // file exists, stream it
-                var response = try await request
+                return try await request
                     .fileio
                     .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
-                return response.cachePolicy(cachePolicy)
+                    .applyingCachePolicy(cachePolicy)
             }
         }
 
@@ -237,17 +237,14 @@ extension FileMiddleware {
 }
 
 extension Response {
-    /// Update the response with a cache policy.
+    /// Returns a copy of the response carrying the given cache policy.
     /// - Parameter policy: The cache policy to use.
-    /// - Returns: The same response as the receiver.
-    @discardableResult
-    mutating func cachePolicy(_ policy: FileMiddleware.CachePolicy) -> Response {
-        self.headers.cacheControl = policy.cacheControlHeader
-        if let age = policy.ageHeader {
-            self.headers[.age] = "\(age)"
-        } else {
-            self.headers[.age] = nil
-        }
-        return self
+    /// - Returns: A copy of the receiver with the policy's `Cache-Control` and `Age` headers set.
+    ///            A policy that doesn't specify a header clears any header already there.
+    func applyingCachePolicy(_ policy: FileMiddleware.CachePolicy) -> Response {
+        var response = self
+        response.headers.cacheControl = policy.cacheControlHeader
+        response.headers[.age] = policy.ageHeader.map { "\($0)" }
+        return response
     }
 }

--- a/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
+++ b/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
@@ -4,7 +4,7 @@ public import HTTPTypes
 ///
 /// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
 ///
-/// When the ``HTTPServerOld/Configuration-swift.struct/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPFields/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPFields/ResponseCompression/disable`` can be set to explicitly disable compression.
+/// When the ``ServerConfiguration/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPFields/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPFields/ResponseCompression/disable`` can be set to explicitly disable compression.
 ///
 /// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPFields/ResponseCompression/useDefault``.
 ///
@@ -12,7 +12,7 @@ public import HTTPTypes
 public struct ResponseCompressionMiddleware: Middleware {
     /// The response compression override to use over the base configuration.
     ///
-    /// Overrides are only used when the server's ``HTTPServerOld/Configuration-swift.struct/ResponseCompressionConfiguration/allowRequestOverrides`` property is enabled, otherwise they are ignored.
+    /// Overrides are only used when the server's ``ServerConfiguration/ResponseCompressionConfiguration/allowRequestOverrides`` property is enabled, otherwise they are ignored.
     ///
     /// To clear an override set previously in the chain (ie. closer to the root route than to the original response), set ``HTTPFields/ResponseCompression/useDefault``.
     ///
@@ -49,7 +49,7 @@ extension RoutesBuilder {
     /// 
     /// This is useful when a set of static routes does not need compression, or a set of dynamic routes does.
     /// 
-    /// When the ``HTTPServerOld/Configuration-swift.struct/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPFields/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPFields/ResponseCompression/disable`` can be set to explicitly disable compression.
+    /// When the ``ServerConfiguration/ResponseCompressionConfiguration`` is set to be disabled by default, ``HTTPFields/ResponseCompression/enable`` can be set to explicitly enable compression. Likewise, when the configuration is set to be enabled by default, ``HTTPFields/ResponseCompression/disable`` can be set to explicitly disable compression.
     ///
     /// To ignore a preference a downstream middleware (ie. closer to the root route than to the original response) may propose in favor of the server defaults, use ``HTTPFields/ResponseCompression/useDefault``.
     ///

--- a/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
+++ b/Sources/Vapor/Middleware/ResponseCompressionMiddleware.swift
@@ -35,7 +35,7 @@ public struct ResponseCompressionMiddleware: Middleware {
     }
     
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
-        let response = try await next.respond(to: request)
+        var response = try await next.respond(to: request)
         /// Only set the header if it is unset, and prefer the next responder's header over our own override, as _it_ is overriding ours.
         if response.headers.responseCompression == .unset || shouldForce {
             response.headers.responseCompression = responseCompressionOverride

--- a/Sources/Vapor/Request/Redirect.swift
+++ b/Sources/Vapor/Request/Redirect.swift
@@ -16,10 +16,8 @@ extension Request {
     ///   - redirectType: The type of redirect to perform
     /// - Returns: A response that redirects the client to the specified location
     public func redirect(to location: String, redirectType: Redirect = .normal) -> Response {
-        let response = Response(status: redirectType.status)
-        response.responseBox.withLockedValue { box in
-            box.headers[.location] = location
-        }
+        var response = Response(status: redirectType.status)
+        response.headers[.location] = location
         return response
     }
 }

--- a/Sources/Vapor/Request/Redirect.swift
+++ b/Sources/Vapor/Request/Redirect.swift
@@ -16,9 +16,8 @@ extension Request {
     ///   - redirectType: The type of redirect to perform
     /// - Returns: A response that redirects the client to the specified location
     public func redirect(to location: String, redirectType: Redirect = .normal) -> Response {
-        let response = Response()
+        let response = Response(status: redirectType.status)
         response.responseBox.withLockedValue { box in
-            box.status = redirectType.status
             box.headers[.location] = location
         }
         return response

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -63,7 +63,7 @@ extension Response {
             switch self.storage {
             case .buffer(var buffer): return buffer.readData(length: buffer.readableBytes)
             case .data(let data): return data
-            case .staticString(let staticString): return Data(bytes: staticString.utf8Start, count: staticString.utf8CodeUnitCount)
+            case .staticString(let staticString): return unsafe Data(bytes: staticString.utf8Start, count: staticString.utf8CodeUnitCount)
             case .string(let string): return Data(string.utf8)
             case .none: return nil
             case .stream: return nil

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -1,6 +1,5 @@
 import NIOCore
 import NIOFoundationEssentialsCompat
-import NIOConcurrencyHelpers
 public import HTTPTypes
 
 /// An HTTP response from a server back to the client.

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -115,9 +115,6 @@ public struct Response: CustomStringConvertible, Sendable {
         }
     }
 
-    /// If `true`, don't serialize the body.
-    var forHeadRequest: Bool = false
-
     private let contentConfiguration: ContentConfiguration
 
     // MARK: Init

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -16,9 +16,8 @@ public struct Response: CustomStringConvertible, Sendable {
     public let version: HTTPVersion
     
     /// The HTTP response status.
-    #warning("This probably should be mutable when a struct")
-    public let status: HTTPResponse.Status
-    
+    public var status: HTTPResponse.Status
+
     /// The header fields for this HTTP response.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -8,7 +8,7 @@ public import HTTPTypes
 ///     let res = Response(status: .ok)
 ///
 /// See `HTTPClient`.
-public final class Response: CustomStringConvertible, Sendable {
+public struct Response: CustomStringConvertible, Sendable {
     /// Maximum streaming body size to use for `debugPrint(_:)`.
     private let maxDebugStreamingBodySize: Int = 1_000_000
 
@@ -175,7 +175,7 @@ public final class Response: CustomStringConvertible, Sendable {
     ///                The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically.
     ///     - body: `Body` for this response, defaults to an empty body.
     ///             See `Response.Body` for more information.
-    public convenience init(
+    public init(
         status: HTTPResponse.Status = .ok,
         version: HTTPVersion = .init(major: 1, minor: 1),
         headers: HTTPFields = .init(),

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -8,9 +8,6 @@ public import HTTPTypes
 ///
 /// See `HTTPClient`.
 public struct Response: CustomStringConvertible, Sendable {
-    /// The HTTP version that corresponds to this response.
-    public let version: HTTPVersion
-    
     /// The HTTP response status.
     public var status: HTTPResponse.Status
 
@@ -56,7 +53,7 @@ public struct Response: CustomStringConvertible, Sendable {
     // See `CustomStringConvertible.description`.
     public var description: String {
         var desc: [String] = []
-        desc.append("HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)")
+        desc.append("\(status.code) \(status.reasonPhrase)")
         desc.append(self.headers.debugDescription)
         desc.append(self.body.description)
         return desc.joined(separator: "\n")
@@ -131,7 +128,6 @@ public struct Response: CustomStringConvertible, Sendable {
     ///
     /// - parameters:
     ///     - status: `HTTPResponse.Status` to use. This defaults to `HTTPResponse.Status.ok`
-    ///     - version: `HTTPVersion` of this response, should usually be (and defaults to) 1.1.
     ///     - headers: `HTTPFields` to include with this response.
     ///                Defaults to empty headers.
     ///                The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically.
@@ -139,14 +135,12 @@ public struct Response: CustomStringConvertible, Sendable {
     ///             See `Response.Body` for more information.
     public init(
         status: HTTPResponse.Status = .ok,
-        version: HTTPVersion = .init(major: 1, minor: 1),
         headers: HTTPFields = .init(),
         body: Body = .empty,
         contentConfiguration: ContentConfiguration = .default()
     ) {
         self.init(
             status: status,
-            version: version,
             headersNoUpdate: headers,
             body: body,
             contentConfiguration: contentConfiguration
@@ -157,7 +151,6 @@ public struct Response: CustomStringConvertible, Sendable {
     /// Internal init that creates a new `Response` without sanitizing headers.
     package init(
         status: HTTPResponse.Status,
-        version: HTTPVersion,
         headersNoUpdate headers: HTTPFields,
         body: Body,
         contentConfiguration: ContentConfiguration = .default()
@@ -165,7 +158,6 @@ public struct Response: CustomStringConvertible, Sendable {
         self.headers = headers
         self.body = body
         self.contentConfiguration = contentConfiguration
-        self.version = version
         self.status = status
     }
 }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -21,14 +21,7 @@ public struct Response: CustomStringConvertible, Sendable {
     /// The header fields for this HTTP response.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.
-    public var headers: HTTPFields {
-        get {
-            self.responseBox.withLockedValue { $0.headers }
-        }
-        set {
-            self.responseBox.withLockedValue { $0.headers = newValue }
-        }
-    }
+    public var headers: HTTPFields
     
     /// The `Body`. Updating this property will also update the associated transport headers.
     ///
@@ -37,13 +30,8 @@ public struct Response: CustomStringConvertible, Sendable {
     /// Also be sure to set this message's `contentType` property to a `MediaType` that correctly
     /// represents the `Body`.
     public var body: Body {
-        get {
-            responseBox.withLockedValue { $0.body }
-        }
-        set {
-            responseBox.withLockedValue { box in
-                box.body = newValue
-            }
+        didSet {
+            self.headers.updateContentLength(body.count)
         }
     }
 
@@ -62,75 +50,61 @@ public struct Response: CustomStringConvertible, Sendable {
     /// This accesses the `"Set-Cookie"` header.
     public var cookies: HTTPCookies {
         get {
-            return self.responseBox.withLockedValue { box in
-                box.headers.setCookie ?? .init()
-            }
+            self.headers.setCookie ?? .init()
         }
         set {
-            self.responseBox.withLockedValue { box in
-                box.headers.setCookie = newValue
-            }
+            self.headers.setCookie = newValue
         }
     }
     
     // See `CustomStringConvertible.description`.
     public var description: String {
         var desc: [String] = []
-        self.responseBox.withLockedValue { box in
-            desc.append("HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)")
-            desc.append(box.headers.debugDescription)
-            desc.append(box.body.description)
-        }
+        desc.append("HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)")
+        desc.append(self.headers.debugDescription)
+        desc.append(self.body.description)
         return desc.joined(separator: "\n")
     }
 
     // MARK: Content
 
     private struct _ContentContainer: ContentContainer {
-        let response: Response
+        var response: Response
 
         var contentConfiguration: ContentConfiguration {
             self.response.contentConfiguration
         }
 
         var contentType: HTTPMediaType? {
-            return self.response.headers.contentType
+            self.response.headers.contentType
         }
 
-        func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E : Encodable {
-            try self.response.responseBox.withLockedValue { box in
-                var body = box.body.byteBufferAllocator.buffer(capacity: 0)
-                try encoder.encode(encodable, to: &body, headers: &box.headers)
-                box.body = .init(buffer: body, byteBufferAllocator: box.body.byteBufferAllocator)
+        mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E: Encodable {
+            var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
+            try encoder.encode(encodable, to: &body, headers: &self.response.headers)
+            self.response.body = .init(buffer: body, byteBufferAllocator: self.response.body.byteBufferAllocator)
+        }
+
+        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D: Decodable {
+            guard let body = self.response.body.buffer else {
+                throw Abort(.unprocessableContent)
             }
+            return try decoder.decode(D.self, from: body, headers: self.response.headers)
         }
 
-        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D : Decodable {
-            try self.response.responseBox.withLockedValue { box in
-                guard let body = box.body.buffer else {
-                    throw Abort(.unprocessableContent)
-                }
-                return try decoder.decode(D.self, from: body, headers: box.headers)
-            }
-        }
-
-        func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C : Content {
+        mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C: Content {
             var content = content
             try content.beforeEncode()
-            try self.response.responseBox.withLockedValue { box in
-                var body = box.body.byteBufferAllocator.buffer(capacity: 0)
-                try encoder.encode(content, to: &body, headers: &box.headers)
-                box.body = .init(buffer: body, byteBufferAllocator: box.body.byteBufferAllocator)
-            }
+            var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
+            try encoder.encode(content, to: &body, headers: &self.response.headers)
+            self.response.body = .init(buffer: body, byteBufferAllocator: self.response.body.byteBufferAllocator)
         }
 
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            var decoded = try self.response.responseBox.withLockedValue { box in
-                guard let body = box.body.buffer else {
-                    throw Abort(.unprocessableContent)
-                }
-                return try decoder.decode(C.self, from: body, headers: box.headers)
+        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C: Content {
+            guard let body = self.response.body.buffer else {
+                throw Abort(.unprocessableContent)
             }
+            var decoded = try decoder.decode(C.self, from: body, headers: self.response.headers)
             try decoded.afterDecode()
             return decoded
         }
@@ -138,26 +112,19 @@ public struct Response: CustomStringConvertible, Sendable {
 
     public var content: any ContentContainer {
         get {
-            return _ContentContainer(response: self)
+            _ContentContainer(response: self)
         }
         set {
-            // ignore since Request is a reference type
-        }
-    }
-    
-    struct ResponseBox: Sendable {
-        var headers: HTTPFields
-        var body: Body {
-            didSet {
-                self.headers.updateContentLength(body.count)
+            // Write back whatever the container mutated to allow content to be set
+            if let container = newValue as? _ContentContainer {
+                self = container.response
             }
         }
-        // If `true`, don't serialize the body.
-        var forHeadRequest: Bool
-
     }
-    
-    let responseBox: NIOLockedValueBox<ResponseBox>
+
+    /// If `true`, don't serialize the body.
+    var forHeadRequest: Bool = false
+
     private let contentConfiguration: ContentConfiguration
 
     // MARK: Init
@@ -199,7 +166,8 @@ public struct Response: CustomStringConvertible, Sendable {
         body: Body,
         contentConfiguration: ContentConfiguration = .default()
     ) {
-        self.responseBox = .init(.init(headers: headers, body: body, forHeadRequest: false))
+        self.headers = headers
+        self.body = body
         self.contentConfiguration = contentConfiguration
         self.version = version
         self.status = status

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -8,9 +8,6 @@ public import HTTPTypes
 ///
 /// See `HTTPClient`.
 public struct Response: CustomStringConvertible, Sendable {
-    /// Maximum streaming body size to use for `debugPrint(_:)`.
-    private let maxDebugStreamingBodySize: Int = 1_000_000
-
     /// The HTTP version that corresponds to this response.
     public let version: HTTPVersion
     

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -16,14 +16,8 @@ public final class Response: CustomStringConvertible, Sendable {
     public let version: HTTPVersion
     
     /// The HTTP response status.
-    public var status: HTTPResponse.Status {
-        get {
-            self.responseBox.withLockedValue { $0.status }
-        }
-        set {
-            self.responseBox.withLockedValue { $0.status = newValue }
-        }
-    }
+    #warning("This probably should be mutable when a struct")
+    public let status: HTTPResponse.Status
     
     /// The header fields for this HTTP response.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
@@ -84,7 +78,7 @@ public final class Response: CustomStringConvertible, Sendable {
     public var description: String {
         var desc: [String] = []
         self.responseBox.withLockedValue { box in
-            desc.append("HTTP/\(version.major).\(version.minor) \(box.status.code) \(box.status.reasonPhrase)")
+            desc.append("HTTP/\(version.major).\(version.minor) \(status.code) \(status.reasonPhrase)")
             desc.append(box.headers.debugDescription)
             desc.append(box.body.description)
         }
@@ -153,7 +147,6 @@ public final class Response: CustomStringConvertible, Sendable {
     }
     
     struct ResponseBox: Sendable {
-        var status: HTTPResponse.Status
         var headers: HTTPFields
         var body: Body {
             didSet {
@@ -207,9 +200,10 @@ public final class Response: CustomStringConvertible, Sendable {
         body: Body,
         contentConfiguration: ContentConfiguration = .default()
     ) {
-        self.responseBox = .init(.init(status: status, headers: headers, body: body, forHeadRequest: false))
+        self.responseBox = .init(.init(headers: headers, body: body, forHeadRequest: false))
         self.contentConfiguration = contentConfiguration
         self.version = version
+        self.status = status
     }
 }
 

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -108,10 +108,10 @@ public struct Response: CustomStringConvertible, Sendable {
             _ContentContainer(response: self)
         }
         set {
-            // Write back whatever the container mutated to allow content to be set
-            if let container = newValue as? _ContentContainer {
-                self = container.response
-            }
+            // Just need to copy the parts of a response that can be changed
+            guard let container = newValue as? _ContentContainer else { return }
+            self.headers = container.response.headers
+            self.body = container.response.body
         }
     }
 

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -7,20 +7,13 @@ public import HTTPTypes
 ///
 ///     let res = Response(status: .ok)
 ///
-/// See `HTTPClient` and `HTTPServerOld`.
+/// See `HTTPClient`.
 public final class Response: CustomStringConvertible, Sendable {
     /// Maximum streaming body size to use for `debugPrint(_:)`.
     private let maxDebugStreamingBodySize: Int = 1_000_000
 
     /// The HTTP version that corresponds to this response.
-    public var version: HTTPVersion {
-        get {
-            self.responseBox.withLockedValue { $0.version }
-        }
-        set {
-            self.responseBox.withLockedValue { $0.version = newValue }
-        }
-    }
+    public let version: HTTPVersion
     
     /// The HTTP response status.
     public var status: HTTPResponse.Status {
@@ -100,7 +93,7 @@ public final class Response: CustomStringConvertible, Sendable {
     public var description: String {
         var desc: [String] = []
         self.responseBox.withLockedValue { box in
-            desc.append("HTTP/\(box.version.major).\(box.version.minor) \(box.status.code) \(box.status.reasonPhrase)")
+            desc.append("HTTP/\(version.major).\(version.minor) \(box.status.code) \(box.status.reasonPhrase)")
             desc.append(box.headers.debugDescription)
             desc.append(box.body.description)
         }
@@ -169,7 +162,6 @@ public final class Response: CustomStringConvertible, Sendable {
     }
     
     struct ResponseBox: Sendable {
-        var version: HTTPVersion
         var status: HTTPResponse.Status
         var headers: HTTPFields
         var body: Body {
@@ -226,8 +218,9 @@ public final class Response: CustomStringConvertible, Sendable {
         contentConfiguration: ContentConfiguration = .default()
     ) {
         self._storage = .init(.init())
-        self.responseBox = .init(.init(version: version, status: status, headers: headers, body: body, forHeadRequest: false))
+        self.responseBox = .init(.init(status: status, headers: headers, body: body, forHeadRequest: false))
         self.contentConfiguration = contentConfiguration
+        self.version = version
     }
 }
 

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -64,15 +64,6 @@ public final class Response: CustomStringConvertible, Sendable {
 //            self.responseBox.withLockedValue { $0.upgrader = newValue }
 //        }
 //    }
-
-    public var storage: Storage {
-        get {
-            self._storage.withLockedValue { $0 }
-        }
-        set {
-            self._storage.withLockedValue { $0 = newValue }
-        }
-    }
     
     /// Get and set `HTTPCookies` for this `Response`.
     /// This accesses the `"Set-Cookie"` header.
@@ -175,7 +166,6 @@ public final class Response: CustomStringConvertible, Sendable {
     }
     
     let responseBox: NIOLockedValueBox<ResponseBox>
-    private let _storage: NIOLockedValueBox<Storage>
     private let contentConfiguration: ContentConfiguration
 
     // MARK: Init
@@ -217,7 +207,6 @@ public final class Response: CustomStringConvertible, Sendable {
         body: Body,
         contentConfiguration: ContentConfiguration = .default()
     ) {
-        self._storage = .init(.init())
         self.responseBox = .init(.init(status: status, headers: headers, body: body, forHeadRequest: false))
         self.contentConfiguration = contentConfiguration
         self.version = version

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -49,10 +49,8 @@ extension ResponseEncodable {
     /// - returns: Newly encoded `Response`.
     public func encodeResponse(status: HTTPResponse.Status, headers: HTTPFields = [:], for request: Request) async throws -> Response {
         var response = try await encodeResponse(for: request)
-        response.responseBox.withLockedValue { box in
-            for header in headers {
-                box.headers.append(header)
-            }
+        for header in headers {
+            response.headers.append(header)
         }
         response.status = status
         return response

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -48,15 +48,14 @@ extension ResponseEncodable {
     ///     - headers: `HTTPFields` to merge into the `Response`'s headers.
     /// - returns: Newly encoded `Response`.
     public func encodeResponse(status: HTTPResponse.Status, headers: HTTPFields = [:], for request: Request) async throws -> Response {
-        let response = try await encodeResponse(for: request)
+        var response = try await encodeResponse(for: request)
         response.responseBox.withLockedValue { box in
             for header in headers {
                 box.headers.append(header)
             }
         }
-        #warning("We should be able to mutate this is response is a struct")
-        let responseWithStatus = Response(status: status, version: response.version, headers: response.headers, body: response.body)
-        return responseWithStatus
+        response.status = status
+        return response
     }
 }
 

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -53,9 +53,10 @@ extension ResponseEncodable {
             for header in headers {
                 box.headers.append(header)
             }
-            box.status = status
         }
-        return response
+        #warning("We should be able to mutate this is response is a struct")
+        let responseWithStatus = Response(status: status, version: response.version, headers: response.headers, body: response.body)
+        return responseWithStatus
     }
 }
 

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -56,6 +56,7 @@ public final class SessionsMiddleware: Middleware {
 
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) async throws -> Response {
+        var response = response
         if let session = request._sessionCache.session.withLockedValue({ $0 }), session.isValid.withLockedValue({ $0 }) {
             // A session exists or has been created. we must
             // set a cookie value on the response

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -71,6 +71,11 @@ public struct FileIO: Sendable {
     ///   - path: The file's path.
     ///   - lastModified: When the file was last modified.
     /// - Returns: A `String` which holds the ETag.
+    // TODO: Rework this caching in a follow-up PR. The `Application.storage`-based cache is a
+    // candidate for removal, and the edge cases need working through: the cache is unbounded (one
+    // entry per file ever served, never evicted), concurrent misses each read and hash the file
+    // rather than sharing one computation, and the read-modify-write below can lose an entry
+    // because reading and writing `Application.storage` take the lock separately.
     private func generateETagHash(path: String, lastModified: Date) async throws -> String {
         if let hash = request.application.storage[FileMiddleware.ETagHashes.self]?[path], hash.lastModified == lastModified {
             return hash.digestHex

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -270,10 +270,11 @@ public struct FileIO: Sendable {
         let fileSystem = self.fileSystem
         var response = Response(status: responseStatus, headers: headers)
         response.body = .init(stream: { writer in
-            // Open the handle directly (rather than the scoped `readFile`/`withFileHandle` API):
-            // that API's chunk closure is `@Sendable`, but `writer` is a non-Sendable
-            // `ResponseBodyWriter`, so it can't be captured there. We open here, write each chunk
-            // straight to `writer` with `await` (the transport backpressures us), and always close.
+            // The scoped `withFileHandle` API would close the handle for us, but its `execute`
+            // parameter is `@concurrent` from here (Vapor builds with `NonisolatedNonsendingByDefault`,
+            // NIO doesn't), so the closure would have to be sent — and it captures the non-Sendable
+            // `writer`. So we open by hand, and write each chunk with `await` so the transport
+            // backpressures the read.
             let handle: ReadFileHandle
             do {
                 handle = try await fileSystem.openFile(forReadingAt: FilePath(path), options: .init())
@@ -281,9 +282,14 @@ public struct FileIO: Sendable {
                 try await onCompleted(.failure(error))
                 throw error
             }
-            // Close on the way out (success or throw), exactly once. The handle is being discarded,
-            // so a close failure isn't actionable, hence `try?`.
-            defer { try? await handle.close() }
+            // Close on the way out (success or throw), exactly once — and shielded from
+            // cancellation. `close()` hops to a thread pool via `runIfActive`, which resumes with
+            // `CancellationError` *without running the close* if the current task is already
+            // cancelled: the descriptor stays open, and dropping the handle then trips its `deinit`
+            // precondition and traps the process. An unstructured task doesn't inherit
+            // cancellation, and awaiting its value keeps the close ordered before we return. This
+            // is what NIOFileSystem's own `withUncancellableTearDown` does.
+            defer { await Task { try? await handle.close() }.value }
 
             do {
                 let chunks = handle.readChunks(

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -268,7 +268,7 @@ public struct FileIO: Sendable {
         }
 
         let fileSystem = self.fileSystem
-        let response = Response(status: responseStatus, headers: headers)
+        var response = Response(status: responseStatus, headers: headers)
         response.body = .init(stream: { writer in
             // Open the handle directly (rather than the scoped `readFile`/`withFileHandle` API):
             // that API's chunk closure is `@Sendable`, but `writer` is a non-Sendable

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -74,17 +74,23 @@ public struct FileIO: Sendable {
     private func generateETagHash(path: String, lastModified: Date) async throws -> String {
         if let hash = request.application.storage[FileMiddleware.ETagHashes.self]?[path], hash.lastModified == lastModified {
             return hash.digestHex
-        } else {
-            return try await FileSystem.shared.withFileHandle(forReadingAt: .init(path)) { handle in
-                let buffer = try await handle.readToEnd(maximumSizeAllowed: .bytes(.max))
-                let digest = SHA256.hash(data: buffer.readableBytesView)
-
-                // update hash in dictionary
-                request.application.storage[FileMiddleware.ETagHashes.self]?[path] = FileMiddleware.ETagHashes.FileHash(lastModified: lastModified, digestHex: digest.hex)
-
-                return digest.hex
-            }
         }
+
+        let digestHex = try await FileSystem.shared.withFileHandle(forReadingAt: .init(path)) { handle in
+            // Hashing in chunks is constant memory and has no size ceiling.
+            var hasher = SHA256()
+            for try await chunk in handle.readChunks(chunkLength: .bytes(128 * 1024)) {
+                hasher.update(data: chunk.readableBytesView)
+            }
+            return hasher.finalize().hex
+        }
+
+        // Cache the digest so later requests don't re-read the file
+        var hashes = request.application.storage[FileMiddleware.ETagHashes.self] ?? [:]
+        hashes[path] = FileMiddleware.ETagHashes.FileHash(lastModified: lastModified, digestHex: digestHex)
+        request.application.storage[FileMiddleware.ETagHashes.self] = hashes
+
+        return digestHex
     }
 
     // MARK: - Concurrency

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -231,7 +231,7 @@ public struct FileIO: Sendable {
             // and here: https://www.rfc-editor.org/rfc/rfc9110.html#name-content-encoding
             // A 304 response MUST include the ETag header and a Content-Length header matching what the original resource's content length would have been were this a 200 response.
             headers[.contentLength] = fileInfo.size.description
-            return Response(status: .notModified, version: .http1_1, headersNoUpdate: headers, body: .empty)
+            return Response(status: .notModified, headersNoUpdate: headers, body: .empty)
         }
 
         // Create the HTTP response.

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -235,16 +235,16 @@ public struct FileIO: Sendable {
         }
 
         // Create the HTTP response.
-        let response = Response(status: .ok, headers: headers)
+        let responseStatus: HTTPResponse.Status
         let offset: Int64
         let byteCount: Int
         if let contentRange = contentRange {
-            response.status = .partialContent
-            response.headers[.accept] = contentRange.unit.serialize()
+            responseStatus = .partialContent
+            headers[.accept] = contentRange.unit.serialize()
             if let firstRange = contentRange.ranges.first {
                 do {
                     let range = try firstRange.asResponseContentRange(limit: Int(fileInfo.size))
-                    response.headers.contentRange = HTTPFields.ContentRange(unit: contentRange.unit, range: range)
+                    headers.contentRange = HTTPFields.ContentRange(unit: contentRange.unit, range: range)
                     (offset, byteCount) = try firstRange.asByteBufferBounds(withMaxSize: Int(fileInfo.size))
                 } catch {
                     throw Abort(.badRequest)
@@ -254,6 +254,7 @@ public struct FileIO: Sendable {
                 byteCount = Int(fileInfo.size)
             }
         } else {
+            responseStatus = .ok
             offset = 0
             byteCount = Int(fileInfo.size)
         }
@@ -263,10 +264,11 @@ public struct FileIO: Sendable {
             let fileExtension = path.components(separatedBy: ".").last,
             let type = mediaType ?? HTTPMediaType.fileExtension(fileExtension)
         {
-            response.headers.contentType = type
+            headers.contentType = type
         }
 
         let fileSystem = self.fileSystem
+        let response = Response(status: responseStatus, headers: headers)
         response.body = .init(stream: { writer in
             // Open the handle directly (rather than the scoped `readFile`/`withFileHandle` API):
             // that API's chunk closure is `@Sendable`, but `writer` is a non-Sendable

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -282,13 +282,9 @@ public struct FileIO: Sendable {
                 try await onCompleted(.failure(error))
                 throw error
             }
-            // Close on the way out (success or throw), exactly once — and shielded from
-            // cancellation. `close()` hops to a thread pool via `runIfActive`, which resumes with
-            // `CancellationError` *without running the close* if the current task is already
-            // cancelled: the descriptor stays open, and dropping the handle then trips its `deinit`
-            // precondition and traps the process. An unstructured task doesn't inherit
-            // cancellation, and awaiting its value keeps the close ordered before we return. This
-            // is what NIOFileSystem's own `withUncancellableTearDown` does.
+            // Wrap the close handle in a task to avoid inheriting cancellation. We always want to close the
+            // handle, but without it we can hit a subtle issue where the defer would be cancelled before
+            // close had triggered, leading to a crash
             defer { await Task { try? await handle.close() }.value }
 
             do {

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -118,7 +118,7 @@ struct AuthenticationTests {
                 Response(status: .unauthorized)
             }
             app.routes.grouped(TestAuthenticator()).get("existing") { _ -> Response in
-                let response = Response(status: .unauthorized)
+                var response = Response(status: .unauthorized)
                 response.headers[.wwwAuthenticate] = #"Basic realm="Existing""#
                 return response
             }
@@ -155,7 +155,7 @@ struct AuthenticationTests {
                 Response(status: .unauthorized)
             }
             app.routes.grouped(CustomRealmAuthenticator()).get("existing") { _ -> Response in
-                let response = Response(status: .unauthorized)
+                var response = Response(status: .unauthorized)
                 response.headers[.wwwAuthenticate] = #"Bearer realm="Existing""#
                 return response
             }

--- a/Tests/VaporTests/CacheTests.swift
+++ b/Tests/VaporTests/CacheTests.swift
@@ -19,7 +19,7 @@ struct CacheTests {
 
             let value3: String? = try await app.cache.get("foo2")
             #expect(value3 == "bar2")
-            try await Task.sleep(for: .seconds(1))
+            try await Task.sleep(for: .milliseconds(1200))
             let value4 = try await app.cache.get("foo2", as: String.self)
             #expect(value4 == nil)
 

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -101,7 +101,7 @@ struct ContentTests {
 
         try await withApp { app in
             app.routes.get("encode") { _ -> Response in
-                let res = Response()
+                var res = Response()
                 try res.content.encode(FooContent())
                 try res.content.encode(FooContent(), as: .json)
                 try res.content.encode(FooEncodable(), as: .json)
@@ -490,7 +490,7 @@ struct ContentTests {
         let content = SampleContent()
         #expect(content.name == "old name")
 
-        let response = Response(status: .ok)
+        var response = Response(status: .ok)
         try response.content.encode(content)
 
         let body = try #require(response.body.string)
@@ -685,13 +685,13 @@ struct ContentTests {
         try await withApp { app in
             let data = "255"
             app.routes.get("plaintext") { _ -> Response in
-                let res = Response()
+                var res = Response()
                 try res.content.encode(data, as: .plainText)
                 return res
             }
 
             app.routes.get("empty-plaintext") { _ -> Response in
-                let res = Response()
+                var res = Response()
                 try res.content.encode("", as: .plainText)
                 return res
             }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -485,6 +485,27 @@ struct ContentTests {
         }
     }
 
+    @Test("Assigning content from another response copies only the content")
+    func testContentAssignmentCopiesOnlyContent() throws {
+        struct FooContent: Content {
+            var message: String = "hi"
+        }
+
+        var source = Response(status: .ok)
+        try source.content.encode(FooContent())
+
+        var destination = Response(status: .created)
+        destination.headers[.xRequestId] = "abc123"
+        destination.content = source.content
+
+        // The content — body and the headers that describe it — comes across...
+        #expect(destination.body.string == source.body.string)
+        #expect(destination.headers.contentType == source.headers.contentType)
+        #expect(destination.headers[.contentLength] == source.headers[.contentLength])
+        // ...but the rest of the response is left alone.
+        #expect(destination.status == .created)
+    }
+
     @Test("Test Before Encode Content")
     func testBeforeEncodeContent() throws {
         let content = SampleContent()

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -60,7 +60,7 @@ struct EndpointCacheTests {
             }
 
             app.get("number") { req -> Response in
-                let res = Response()
+                var res = Response()
                 let current = await currentActor.getCurrent()
                 try res.content.encode(Test(number: current))
                 res.headers.cacheControl = .init(maxAge: 1)
@@ -103,7 +103,7 @@ struct EndpointCacheTests {
             }
 
             app.get("number") { req -> Response in
-                let res = Response()
+                var res = Response()
                 let current = await currentActor.getCurrent()
                 try res.content.encode(Test(number: current))
                 res.headers.cacheControl = .init(maxAge: 10)

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -594,14 +594,10 @@ struct FileTests {
                 #expect(res.body.readableBytes == 0)
             }
 
-            // A HEAD response carries no body, so opening and reading the file is wasted work:
-            // the transport discards every byte before it reaches the client. Vapor 4 skipped body
-            // serialisation entirely via `Response.forHeadRequest`; the new server doesn't, so the
-            // whole file is still read off disk.
-            #warning("Vapor: HEAD still produces the response body — wire up `Response.forHeadRequest` in the server handler, then drop this `withKnownIssue`")
-            withKnownIssue("HEAD still runs the body stream and reads the file") {
-                #expect(fileWasRead.withLockedValue { $0 } == false)
-            }
+            // A HEAD response carries no body, so opening and reading the file would be wasted
+            // work: the transport discards every byte before it reaches the client. The server
+            // handler concludes HEAD responses without running the body stream at all.
+            #expect(fileWasRead.withLockedValue { $0 } == false)
         }
     }
 

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -605,33 +605,6 @@ struct FileTests {
         }
     }
 
-    @Test("OPTIONS request does not read the file")
-    func testOptionsRequestDoesNotReadFile() async throws {
-        try await withApp { app in
-            let fileWasRead = NIOLockedValueBox(false)
-            app.on(.options, "file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: false) { _ in
-                    fileWasRead.withLockedValue { $0 = true }
-                }
-            }
-
-            try await app.test(method: .running) { runner in
-                let res = try await runner.sendRequest(.options, "/file-stream")
-                // Unlike HEAD, nothing downstream strips the body for OPTIONS, so the whole file
-                // goes out on the wire.
-                #warning("Vapor: OPTIONS responses still carry the body — drop this `withKnownIssue` once bodyless methods skip body production")
-                withKnownIssue("OPTIONS returns the file body") {
-                    #expect(res.body.readableBytes == 0)
-                }
-            }
-
-            #warning("Vapor: OPTIONS still reads the file off disk — drop this `withKnownIssue` once bodyless methods skip body production")
-            withKnownIssue("OPTIONS reads the file") {
-                #expect(fileWasRead.withLockedValue { $0 } == false)
-            }
-        }
-    }
-
     @Test("FileMiddleware does not send a file body for HEAD and OPTIONS")
     func testFileMiddlewareBodylessMethods() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -544,6 +544,36 @@ struct FileTests {
 //        }
 //    }
 
+    @Test("Cancelling a file stream still closes the file handle")
+    func testCancelledFileStreamClosesHandle() async throws {
+        // Large enough that a read is still in flight when the cancellation lands: the whole point
+        // is to cancel between opening the handle and closing it.
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("vapor-cancel-\(UUID().uuidString).bin")
+        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        try await withApp { app in
+            let request = Request(application: app)
+
+            // `close()` is dispatched through a thread pool that refuses cancelled work, so a
+            // handle closed naively from a cancelled task stays open and trips NIOFileSystem's
+            // `deinit` precondition — which traps the process rather than throwing. Cancelling
+            // repeatedly at slightly different points covers the window between open and close.
+            for iteration in 1...10 {
+                let response = try await request.fileio.streamFile(
+                    at: fileURL.path, advancedETagComparison: false)
+
+                let collecting = Task { try await response.body.collect() }
+                try await Task.sleep(for: .microseconds(200 * iteration))
+                collecting.cancel()
+                _ = try? await collecting.value
+            }
+        }
+
+        // Getting here at all is the assertion: a leaked descriptor would have killed the process.
+    }
+
     // MARK: Bodyless methods
 
     @Test("HEAD request does not read the file")

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -571,10 +571,7 @@ struct FileTests {
     func testCancelledFileStreamClosesHandle() async throws {
         // Large enough that a read is still in flight when the cancellation lands: the whole point
         // is to cancel between opening the handle and closing it.
-        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("vapor-cancel-\(UUID().uuidString).bin")
-        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
-        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let filePath = try await makeTemporaryFile(size: 8 << 20)
 
         try await withApp { app in
             let request = Request(application: app)
@@ -585,7 +582,7 @@ struct FileTests {
             // repeatedly at slightly different points covers the window between open and close.
             for iteration in 1...10 {
                 let response = try await request.fileio.streamFile(
-                    at: fileURL.path, advancedETagComparison: false)
+                    at: filePath, advancedETagComparison: false)
 
                 let collecting = Task { try await response.body.collect() }
                 try await Task.sleep(for: .microseconds(200 * iteration))

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -1,5 +1,6 @@
 import Vapor
 import NIOCore
+import NIOConcurrencyHelpers
 import HTTPTypes
 import _NIOFileSystem
 import Crypto
@@ -542,4 +543,80 @@ struct FileTests {
 //            throw error
 //        }
 //    }
+
+    // MARK: Bodyless methods
+
+    @Test("HEAD request does not read the file")
+    func testHeadRequestDoesNotReadFile() async throws {
+        try await withApp { app in
+            let fileWasRead = NIOLockedValueBox(false)
+            app.get("file-stream") { req -> Response in
+                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: false) { _ in
+                    fileWasRead.withLockedValue { $0 = true }
+                }
+            }
+
+            try await app.test(method: .running) { runner in
+                let res = try await runner.sendRequest(.head, "/file-stream")
+                #expect(res.status == .ok)
+                // The length is advertised even though no body follows it.
+                #expect(res.headers[.contentLength] != nil)
+                #expect(res.body.readableBytes == 0)
+            }
+
+            // A HEAD response carries no body, so opening and reading the file is wasted work:
+            // the transport discards every byte before it reaches the client. Vapor 4 skipped body
+            // serialisation entirely via `Response.forHeadRequest`; the new server doesn't, so the
+            // whole file is still read off disk.
+            withKnownIssue("HEAD still runs the body stream and reads the file") {
+                #expect(fileWasRead.withLockedValue { $0 } == false)
+            }
+        }
+    }
+
+    @Test("OPTIONS request does not read the file")
+    func testOptionsRequestDoesNotReadFile() async throws {
+        try await withApp { app in
+            let fileWasRead = NIOLockedValueBox(false)
+            app.on(.options, "file-stream") { req -> Response in
+                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: false) { _ in
+                    fileWasRead.withLockedValue { $0 = true }
+                }
+            }
+
+            try await app.test(method: .running) { runner in
+                let res = try await runner.sendRequest(.options, "/file-stream")
+                // Unlike HEAD, nothing downstream strips the body for OPTIONS, so the whole file
+                // goes out on the wire.
+                withKnownIssue("OPTIONS returns the file body") {
+                    #expect(res.body.readableBytes == 0)
+                }
+            }
+
+            withKnownIssue("OPTIONS reads the file") {
+                #expect(fileWasRead.withLockedValue { $0 } == false)
+            }
+        }
+    }
+
+    @Test("FileMiddleware does not send a file body for HEAD and OPTIONS")
+    func testFileMiddlewareBodylessMethods() async throws {
+        try await withApp { app in
+            let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
+
+            try await app.test(method: .running) { runner in
+                let head = try await runner.sendRequest(.head, "/Utilities/foo.txt")
+                #expect(head.status == .ok)
+                #expect(head.body.readableBytes == 0)
+
+                // `FileMiddleware` doesn't look at the method at all: any method whose path matches
+                // a file is served the file.
+                let options = try await runner.sendRequest(.options, "/Utilities/foo.txt")
+                withKnownIssue("FileMiddleware serves the file body for OPTIONS") {
+                    #expect(options.body.readableBytes == 0)
+                }
+            }
+        }
+    }
 }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -102,6 +102,29 @@ struct FileTests {
         }
     }
 
+    @Test("Advanced ETag hashes are cached across requests")
+    func testAdvancedETagHashIsCached() async throws {
+        try await withApp { app in
+            app.get("file-stream") { req -> Response in
+                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true)
+            }
+
+            #expect(app.storage[FileMiddleware.ETagHashes.self] == nil)
+
+            try await app.test(method: .running) { runner in
+                let first = try await runner.sendRequest(.get, "/file-stream")
+                let firstETag = try #require(first.headers[.eTag])
+
+                // Without a populated cache every request re-reads and re-hashes the whole file.
+                let cached = try #require(app.storage[FileMiddleware.ETagHashes.self]?[#filePath])
+                #expect(cached.digestHex == firstETag)
+
+                let second = try await runner.sendRequest(.get, "/file-stream")
+                #expect(second.headers[.eTag] == firstETag)
+            }
+        }
+    }
+
     @Test("Test Simple ETag Headers")
     func testSimpleETagHeaders() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -624,23 +624,28 @@ struct FileTests {
         }
     }
 
-    @Test("FileMiddleware does not send a file body for HEAD and OPTIONS")
-    func testFileMiddlewareBodylessMethods() async throws {
+    @Test("FileMiddleware only serves GET and HEAD")
+    func testFileMiddlewareOnlyServesGetAndHead() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
             app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
             try await app.test(method: .running) { runner in
+                let get = try await runner.sendRequest(.get, "/Utilities/foo.txt")
+                #expect(get.status == .ok)
+                #expect(get.body.readableBytes > 0)
+
+                // HEAD gets the headers a GET would have returned, with no body.
                 let head = try await runner.sendRequest(.head, "/Utilities/foo.txt")
                 #expect(head.status == .ok)
+                #expect(head.headers[.contentLength] == get.headers[.contentLength])
                 #expect(head.body.readableBytes == 0)
 
-                // `FileMiddleware` doesn't look at the method at all: any method whose path matches
-                // a file is served the file.
-                let options = try await runner.sendRequest(.options, "/Utilities/foo.txt")
-                #warning("Vapor: FileMiddleware ignores the request method and serves files for any of them — drop this `withKnownIssue` once it only answers GET and HEAD")
-                withKnownIssue("FileMiddleware serves the file body for OPTIONS") {
-                    #expect(options.body.readableBytes == 0)
+                // Everything else falls through the middleware; nothing else is registered here,
+                // so it 404s rather than being answered with the file.
+                for method in [HTTPRequest.Method.options, .post, .delete] {
+                    let res = try await runner.sendRequest(method, "/Utilities/foo.txt")
+                    #expect(res.status == .notFound, "\(method) was served by FileMiddleware")
                 }
             }
         }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -598,6 +598,7 @@ struct FileTests {
             // the transport discards every byte before it reaches the client. Vapor 4 skipped body
             // serialisation entirely via `Response.forHeadRequest`; the new server doesn't, so the
             // whole file is still read off disk.
+            #warning("Vapor: HEAD still produces the response body — wire up `Response.forHeadRequest` in the server handler, then drop this `withKnownIssue`")
             withKnownIssue("HEAD still runs the body stream and reads the file") {
                 #expect(fileWasRead.withLockedValue { $0 } == false)
             }
@@ -618,11 +619,13 @@ struct FileTests {
                 let res = try await runner.sendRequest(.options, "/file-stream")
                 // Unlike HEAD, nothing downstream strips the body for OPTIONS, so the whole file
                 // goes out on the wire.
+                #warning("Vapor: OPTIONS responses still carry the body — drop this `withKnownIssue` once bodyless methods skip body production")
                 withKnownIssue("OPTIONS returns the file body") {
                     #expect(res.body.readableBytes == 0)
                 }
             }
 
+            #warning("Vapor: OPTIONS still reads the file off disk — drop this `withKnownIssue` once bodyless methods skip body production")
             withKnownIssue("OPTIONS reads the file") {
                 #expect(fileWasRead.withLockedValue { $0 } == false)
             }
@@ -643,6 +646,7 @@ struct FileTests {
                 // `FileMiddleware` doesn't look at the method at all: any method whose path matches
                 // a file is served the file.
                 let options = try await runner.sendRequest(.options, "/Utilities/foo.txt")
+                #warning("Vapor: FileMiddleware ignores the request method and serves files for any of them — drop this `withKnownIssue` once it only answers GET and HEAD")
                 withKnownIssue("FileMiddleware serves the file body for OPTIONS") {
                     #expect(options.body.readableBytes == 0)
                 }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -75,6 +75,30 @@ struct MiddlewareTests {
         }
     }
 
+    @Test("Test CORS Middleware Preflight Returns No Body")
+    func testCORSMiddlewarePreflightReturnsNoBody() async throws {
+        try await withApp { app in
+            // Registered globally rather than on a route group: a preflight is an OPTIONS request
+            // that matches no route, so middleware attached to the group never runs for it.
+            app.middleware.use(
+                CORSMiddleware(configuration: .init(allowedOrigin: .any(["foo"]), allowedMethods: [.get], allowedHeaders: [.origin]))
+            )
+            app.get("order") { req -> String in
+                return "done"
+            }
+
+            // A preflight is answered by the middleware itself rather than the route, so it carries
+            // the CORS headers and no body — the route's "done" must not leak into the response.
+            let headers: HTTPFields = [.origin: "foo", .accessControlRequestMethod: "GET"]
+            try await app.testing().test(.options, "/order", headers: headers) { res in
+                #expect(res.status == .ok)
+                #expect(res.body.readableBytes == 0)
+                #expect(res.headers[values: .accessControlAllowOrigin] == ["foo"])
+                #expect(res.headers[values: .accessControlAllowMethods] == ["GET"])
+            }
+        }
+    }
+
     @Test("Test CORS Middleware Varied By Request Origin")
     func testCORSMiddlewareVariedByRequestOrigin() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -194,7 +194,7 @@ struct QueryTests {
     func testCustomEncode() async throws {
         try await withApp { app throws in
             app.get("custom-encode") { req -> Response in
-                let res = Response(status: .ok)
+                var res = Response(status: .ok)
                 let jsonEncoder = JSONEncoder()
                 jsonEncoder.outputFormatting = .prettyPrinted
                 try res.content.encode(["hello": "world"], using: jsonEncoder)

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -531,17 +531,11 @@ struct StreamingBodyTests {
 
                 let noContent = try await rawExchange(port: port, path: "/no-content").bytes
                 #expect(noContent.hasPrefix("HTTP/1.1 204 No Content"))
-                #warning("swift-http-server#118: 204 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
-                withKnownIssue("204 response carries the handler's body") {
-                    #expect(!noContent.contains("Hello, world!"), "\(noContent.debugDescription)")
-                }
+                #expect(!noContent.contains("Hello, world!"), "\(noContent.debugDescription)")
 
                 let notModified = try await rawExchange(port: port, path: "/not-modified").bytes
                 #expect(notModified.hasPrefix("HTTP/1.1 304 Not Modified"))
-                #warning("swift-http-server#118: 304 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
-                withKnownIssue("304 response carries the handler's body") {
-                    #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
-                }
+                #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -10,6 +10,11 @@ import ServiceLifecycle
 import Logging
 import Testing
 import RoutingKit
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 @Suite("Streaming Body Tests")
 struct StreamingBodyTests {
@@ -462,6 +467,7 @@ struct StreamingBodyTests {
     private func rawExchange(
         port: Int,
         path: String,
+        extraHeaders: String = "",
         grace: Duration = .milliseconds(250)
     ) async throws -> (bytes: String, serverClosed: Bool) {
         let channel = try await ClientBootstrap(group: MultiThreadedEventLoopGroup.singleton)
@@ -472,7 +478,7 @@ struct StreamingBodyTests {
             }
         return try await channel.executeThenClose { inbound, outbound in
             try await outbound.write(ByteBuffer(
-                string: "GET \(path) HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+                string: "GET \(path) HTTP/1.1\r\nHost: localhost\r\n\(extraHeaders)\r\n"))
             let received = NIOLockedValueBox("")
             let reachedEnd = NIOLockedValueBox(false)
             await withTaskGroup(of: Void.self) { group in
@@ -532,6 +538,95 @@ struct StreamingBodyTests {
                 withKnownIssue("304 response carries the handler's body") {
                     #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
                 }
+
+                await group.triggerGracefulShutdown()
+                try await tg.waitForAll()
+            }
+        }
+    }
+
+    @Test("Server closes the connection when the client asks for Connection: close", .timeLimit(.minutes(1)))
+    func testConnectionCloseIsHonoured() async throws {
+        try await withApp { app in
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            app.get("hello") { _ in "hi" }
+
+            try await app.boot()
+            let group = ServiceGroup(configuration: .init(
+                services: [.init(service: app.server, successTerminationBehavior: .gracefullyShutdownGroup)],
+                logger: Logger.current))
+            try await withThrowingTaskGroup(of: Void.self) { tg in
+                tg.addTask {
+                    try await group.run()
+                }
+                let address = try await app.server.listeningAddress
+                let port = try #require(address.port)
+
+                let exchange = try await rawExchange(
+                    port: port,
+                    path: "/hello",
+                    extraHeaders: "Connection: close\r\n",
+                    grace: .seconds(1))
+                #expect(exchange.bytes.contains("hi"))
+
+                // RFC 9112 § 9.6: a server that receives `Connection: close` must close the
+                // connection once the response is sent, and should echo the header back. Today the
+                // connection is left open until the 30s read-header timeout reaps it.
+                withKnownIssue("the connection is left open after the response") {
+                    #expect(exchange.serverClosed)
+                    #expect(exchange.bytes.lowercased().contains("connection: close"))
+                }
+
+                await group.triggerGracefulShutdown()
+                try await tg.waitForAll()
+            }
+        }
+    }
+
+    @Test("Server survives a client aborting mid-file-stream")
+    func testClientAbortMidFileStreamDoesNotBreakServer() async throws {
+        // Big enough that the server is still reading when the client gives up: the transport
+        // can't have buffered the whole thing, so the body closure is mid-read when it's cancelled.
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("vapor-abort-\(UUID().uuidString).bin")
+        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        try await withApp { app in
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            app.get("file") { req -> Response in
+                try await req.fileio.streamFile(at: fileURL.path, advancedETagComparison: false)
+            }
+            app.get("ok") { _ in "ok" }
+
+            try await app.boot()
+            let group = ServiceGroup(configuration: .init(
+                services: [.init(service: app.server, successTerminationBehavior: .gracefullyShutdownGroup)],
+                logger: Logger.current))
+            try await withThrowingTaskGroup(of: Void.self) { tg in
+                tg.addTask {
+                    try await group.run()
+                }
+                let address = try await app.server.listeningAddress
+                let port = try #require(address.port)
+
+                // Abort mid-stream: collect with a tiny limit so the client drops the connection
+                // while the file is still being read. The writes then fail with an I/O error rather
+                // than cancelling the task, so this covers the error path out of the body closure;
+                // the cancellation path is covered by `testCancelledFileStreamClosesHandle`.
+                await #expect(throws: (any Error).self) {
+                    let resp = try await HTTPClient.shared.execute(
+                        HTTPClientRequest(url: "http://127.0.0.1:\(port)/file"), timeout: .seconds(10)
+                    )
+                    _ = try await resp.body.collect(upTo: 16)
+                }
+
+                // The server must still be alive and serving.
+                let ok = try await HTTPClient.shared.execute(
+                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
+                )
+                #expect(ok.status == .ok)
+                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -398,7 +398,8 @@ struct StreamingBodyTests {
         }
     }
 
-    @Test("Server survives a stream that writes fewer bytes than its declared length")
+    @Test("Server survives a stream that writes fewer bytes than its declared length",
+          .bug("https://github.com/swift-server/swift-http-server/issues/116"))
     func testBadStreamLengthDoesNotBreakServer() async throws {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
@@ -504,7 +505,8 @@ struct StreamingBodyTests {
         }
     }
 
-    @Test("Server does not write a body for a status that cannot carry one", .timeLimit(.minutes(1)))
+    @Test("Server does not write a body for a status that cannot carry one", .timeLimit(.minutes(1)),
+          .bug("https://github.com/swift-server/swift-http-server/issues/118"))
     func testBodylessStatusDoesNotWriteBody() async throws {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
@@ -529,14 +531,14 @@ struct StreamingBodyTests {
 
                 let noContent = try await rawExchange(port: port, path: "/no-content").bytes
                 #expect(noContent.hasPrefix("HTTP/1.1 204 No Content"))
-                #warning("swift-http-server: 204 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
+                #warning("swift-http-server#118: 204 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("204 response carries the handler's body") {
                     #expect(!noContent.contains("Hello, world!"), "\(noContent.debugDescription)")
                 }
 
                 let notModified = try await rawExchange(port: port, path: "/not-modified").bytes
                 #expect(notModified.hasPrefix("HTTP/1.1 304 Not Modified"))
-                #warning("swift-http-server: 304 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
+                #warning("swift-http-server#118: 304 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("304 response carries the handler's body") {
                     #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
                 }
@@ -547,7 +549,8 @@ struct StreamingBodyTests {
         }
     }
 
-    @Test("Server closes the connection when the client asks for Connection: close", .timeLimit(.minutes(1)))
+    @Test("Server closes the connection when the client asks for Connection: close", .timeLimit(.minutes(1)),
+          .bug("https://github.com/swift-server/swift-http-server/issues/119"))
     func testConnectionCloseIsHonoured() async throws {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
@@ -574,7 +577,7 @@ struct StreamingBodyTests {
                 // RFC 9112 § 9.6: a server that receives `Connection: close` must close the
                 // connection once the response is sent, and should echo the header back. Today the
                 // connection is left open until the 30s read-header timeout reaps it.
-                #warning("swift-http-server: the request's `Connection` header is never read, so `Connection: close` is ignored — drop this `withKnownIssue` when the upstream fix lands")
+                #warning("swift-http-server#119: the request's `Connection` header is never read, so `Connection: close` is ignored — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("the connection is left open after the response") {
                     #expect(exchange.serverClosed)
                     #expect(exchange.bytes.lowercased().contains("connection: close"))
@@ -586,7 +589,8 @@ struct StreamingBodyTests {
         }
     }
 
-    @Test("Server survives a client aborting mid-file-stream")
+    @Test("Server survives a client aborting mid-file-stream",
+          .bug("https://github.com/swift-server/swift-http-server/issues/53"))
     func testClientAbortMidFileStreamDoesNotBreakServer() async throws {
         // Big enough that the server is still reading when the client gives up: the transport
         // can't have buffered the whole thing, so the body closure is mid-read when it's cancelled.

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -634,4 +634,38 @@ struct StreamingBodyTests {
             }
         }
     }
+
+    @Test("Server does not crash when a handler returns an informational status")
+    func testInformationalStatusDoesNotCrashServer() async throws {
+        try await withApp { app in
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            // A 1xx can only precede a final response. The server trapped on one before Vapor
+            // started rejecting it, so this is really a "the process is still alive" test.
+            app.get("informational") { _ in Response(status: .continue) }
+            app.get("ok") { _ in "ok" }
+
+            try await app.boot()
+            let group = ServiceGroup(configuration: .init(
+                services: [.init(service: app.server, successTerminationBehavior: .gracefullyShutdownGroup)],
+                logger: Logger.current))
+            try await withThrowingTaskGroup(of: Void.self) { tg in
+                tg.addTask {
+                    try await group.run()
+                }
+                let address = try await app.server.listeningAddress
+                let port = try #require(address.port)
+
+                let resp = try await HTTPClient.shared.execute(
+                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/informational"), timeout: .seconds(5))
+                #expect(resp.status == .internalServerError)
+
+                let ok = try await HTTPClient.shared.execute(
+                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(5))
+                #expect(ok.status == .ok)
+
+                await group.triggerGracefulShutdown()
+                try await tg.waitForAll()
+            }
+        }
+    }
 }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -529,12 +529,14 @@ struct StreamingBodyTests {
 
                 let noContent = try await rawExchange(port: port, path: "/no-content").bytes
                 #expect(noContent.hasPrefix("HTTP/1.1 204 No Content"))
+                #warning("swift-http-server: 204 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("204 response carries the handler's body") {
                     #expect(!noContent.contains("Hello, world!"), "\(noContent.debugDescription)")
                 }
 
                 let notModified = try await rawExchange(port: port, path: "/not-modified").bytes
                 #expect(notModified.hasPrefix("HTTP/1.1 304 Not Modified"))
+                #warning("swift-http-server: 304 responses still write the body — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("304 response carries the handler's body") {
                     #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
                 }
@@ -572,6 +574,7 @@ struct StreamingBodyTests {
                 // RFC 9112 § 9.6: a server that receives `Connection: close` must close the
                 // connection once the response is sent, and should echo the header back. Today the
                 // connection is left open until the 30s read-header timeout reaps it.
+                #warning("swift-http-server: the request's `Connection` header is never read, so `Connection: close` is ignored — drop this `withKnownIssue` when the upstream fix lands")
                 withKnownIssue("the connection is left open after the response") {
                     #expect(exchange.serverClosed)
                     #expect(exchange.bytes.lowercased().contains("connection: close"))

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -668,4 +668,59 @@ struct StreamingBodyTests {
             }
         }
     }
+
+    @Test("Response body stream completion runs once when the client disconnects",
+          .bug("https://github.com/vapor/vapor/issues/3002"))
+    func testStreamCompletionRunsOnceOnClientDisconnect() async throws {
+        // The Vapor 4 shape of this bug: the body-stream closure wrote `.end`/`.error` itself while
+        // the server concluded the same response, so a connection failure ran the completion twice.
+        // `ResponseBodyWriter` can only write buffers now — concluding is the server's job — so the
+        // race has nowhere to happen, and this pins that down.
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("vapor-once-\(UUID().uuidString).bin")
+        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let completions = NIOLockedValueBox(0)
+
+        try await withApp { app in
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            app.get("file") { req -> Response in
+                try await req.fileio.streamFile(at: fileURL.path, advancedETagComparison: false) { _ in
+                    completions.withLockedValue { $0 += 1 }
+                }
+            }
+
+            try await app.boot()
+            let group = ServiceGroup(configuration: .init(
+                services: [.init(service: app.server, successTerminationBehavior: .gracefullyShutdownGroup)],
+                logger: Logger.current))
+            try await withThrowingTaskGroup(of: Void.self) { tg in
+                tg.addTask {
+                    try await group.run()
+                }
+                let address = try await app.server.listeningAddress
+                let port = try #require(address.port)
+
+                await #expect(throws: (any Error).self) {
+                    let resp = try await HTTPClient.shared.execute(
+                        HTTPClientRequest(url: "http://127.0.0.1:\(port)/file"), timeout: .seconds(10)
+                    )
+                    _ = try await resp.body.collect(upTo: 16)
+                }
+
+                // The server unwinds the aborted response on its own schedule, so wait for the
+                // completion rather than assuming it has already run...
+                for _ in 0..<200 where completions.withLockedValue({ $0 }) == 0 {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                // ...then give a second call a chance to land before declaring there wasn't one.
+                try await Task.sleep(for: .milliseconds(200))
+                #expect(completions.withLockedValue { $0 } == 1)
+
+                await group.triggerGracefulShutdown()
+                try await tg.waitForAll()
+            }
+        }
+    }
 }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -428,7 +428,7 @@ struct StreamingBodyTests {
                 // Either is acceptable — we only require the server not to crash.
                 do {
                     let resp = try await HTTPClient.shared.execute(
-                        HTTPClientRequest(url: "http://127.0.0.1:\(port)/bad-length"), timeout: .seconds(5)
+                        HTTPClientRequest(url: "http://127.0.0.1:\(port)/bad-length"), timeout: .seconds(15)
                     )
                     let body = try await resp.body.collect(upTo: 1 << 20)
                     #expect(body.readableBytes < 2)
@@ -470,7 +470,8 @@ struct StreamingBodyTests {
         port: Int,
         path: String,
         extraHeaders: String = "",
-        grace: Duration = .milliseconds(250)
+        quiet: Duration = .milliseconds(250),
+        deadline: Duration = .seconds(10)
     ) async throws -> (bytes: String, serverClosed: Bool) {
         let channel = try await ClientBootstrap(group: MultiThreadedEventLoopGroup.singleton)
             .connect(host: "127.0.0.1", port: port) { channel in
@@ -482,23 +483,35 @@ struct StreamingBodyTests {
             try await outbound.write(ByteBuffer(
                 string: "GET \(path) HTTP/1.1\r\nHost: localhost\r\n\(extraHeaders)\r\n"))
             let received = NIOLockedValueBox("")
+            let lastActivity = NIOLockedValueBox(ContinuousClock.now)
             let reachedEnd = NIOLockedValueBox(false)
             await withTaskGroup(of: Void.self) { group in
                 group.addTask {
                     do {
                         for try await buffer in inbound {
                             received.withLockedValue { $0 += String(buffer: buffer) }
+                            lastActivity.withLockedValue { $0 = ContinuousClock.now }
                         }
                         reachedEnd.withLockedValue { $0 = true }
                     } catch {
-                        // Cancelled by the deadline below, or the connection failed. Either way
-                        // whatever arrived is what we assert on.
+                        // Cancelled below, or the connection failed. Either way whatever arrived is
+                        // what we assert on.
                     }
                 }
                 group.addTask {
-                    try? await Task.sleep(for: grace)
+                    // Wait for the response to go quiet rather than for a fixed slice of time: a
+                    // loaded machine can take a while to answer at all, and a fixed grace period
+                    // then reads nothing and fails the test for the wrong reason. `deadline` only
+                    // runs out if the response never arrives.
+                    let start = ContinuousClock.now
+                    while true {
+                        try? await Task.sleep(for: .milliseconds(25))
+                        if reachedEnd.withLockedValue({ $0 }) { return }
+                        let idle = ContinuousClock.now - lastActivity.withLockedValue { $0 }
+                        if !received.withLockedValue({ $0.isEmpty }), idle >= quiet { return }
+                        if ContinuousClock.now - start >= deadline { return }
+                    }
                 }
-                // Whichever finishes first — EOF or the deadline — ends the exchange.
                 await group.next()
                 group.cancelAll()
             }
@@ -565,8 +578,7 @@ struct StreamingBodyTests {
                 let exchange = try await rawExchange(
                     port: port,
                     path: "/hello",
-                    extraHeaders: "Connection: close\r\n",
-                    grace: .seconds(1))
+                    extraHeaders: "Connection: close\r\n")
                 #expect(exchange.bytes.contains("hi"))
 
                 // RFC 9112 § 9.6: a server that receives `Connection: close` must close the
@@ -654,11 +666,11 @@ struct StreamingBodyTests {
                 let port = try #require(address.port)
 
                 let resp = try await HTTPClient.shared.execute(
-                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/informational"), timeout: .seconds(5))
+                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/informational"), timeout: .seconds(15))
                 #expect(resp.status == .internalServerError)
 
                 let ok = try await HTTPClient.shared.execute(
-                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(5))
+                    HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(15))
                 #expect(ok.status == .ok)
 
                 await group.triggerGracefulShutdown()

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -451,4 +451,91 @@ struct StreamingBodyTests {
         let collected = try await body.collect()
         #expect(collected.map { String(buffer: $0) } == "Hello, collected!")
     }
+
+    /// Sends a raw request over a plain TCP socket and returns every byte the server sends back
+    /// within `grace`, along with whether the server closed the connection.
+    ///
+    /// A real HTTP client hides framing violations — it parses the response according to the rules
+    /// the server is supposed to be following — so checking "is there a body on the wire" needs a
+    /// socket, not a client. The deadline is client-side: waiting for the server to close would
+    /// otherwise park the test on the server's read-header timeout.
+    private func rawExchange(
+        port: Int,
+        path: String,
+        grace: Duration = .milliseconds(250)
+    ) async throws -> (bytes: String, serverClosed: Bool) {
+        let channel = try await ClientBootstrap(group: MultiThreadedEventLoopGroup.singleton)
+            .connect(host: "127.0.0.1", port: port) { channel in
+                channel.eventLoop.makeCompletedFuture {
+                    try NIOAsyncChannel<ByteBuffer, ByteBuffer>(wrappingChannelSynchronously: channel)
+                }
+            }
+        return try await channel.executeThenClose { inbound, outbound in
+            try await outbound.write(ByteBuffer(
+                string: "GET \(path) HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+            let received = NIOLockedValueBox("")
+            let reachedEnd = NIOLockedValueBox(false)
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    do {
+                        for try await buffer in inbound {
+                            received.withLockedValue { $0 += String(buffer: buffer) }
+                        }
+                        reachedEnd.withLockedValue { $0 = true }
+                    } catch {
+                        // Cancelled by the deadline below, or the connection failed. Either way
+                        // whatever arrived is what we assert on.
+                    }
+                }
+                group.addTask {
+                    try? await Task.sleep(for: grace)
+                }
+                // Whichever finishes first — EOF or the deadline — ends the exchange.
+                await group.next()
+                group.cancelAll()
+            }
+            return (received.withLockedValue { $0 }, reachedEnd.withLockedValue { $0 })
+        }
+    }
+
+    @Test("Server does not write a body for a status that cannot carry one", .timeLimit(.minutes(1)))
+    func testBodylessStatusDoesNotWriteBody() async throws {
+        try await withApp { app in
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            // Both statuses are defined to have no body, whatever the handler attaches.
+            app.get("no-content") { _ in
+                Response(status: .noContent, body: .init(string: "Hello, world!"))
+            }
+            app.get("not-modified") { _ in
+                Response(status: .notModified, body: .init(string: "Hello, world!"))
+            }
+
+            try await app.boot()
+            let group = ServiceGroup(configuration: .init(
+                services: [.init(service: app.server, successTerminationBehavior: .gracefullyShutdownGroup)],
+                logger: Logger.current))
+            try await withThrowingTaskGroup(of: Void.self) { tg in
+                tg.addTask {
+                    try await group.run()
+                }
+                let address = try await app.server.listeningAddress
+                let port = try #require(address.port)
+
+                let noContent = try await rawExchange(port: port, path: "/no-content").bytes
+                #expect(noContent.hasPrefix("HTTP/1.1 204 No Content"))
+                withKnownIssue("204 response carries the handler's body") {
+                    #expect(!noContent.contains("Hello, world!"), "\(noContent.debugDescription)")
+                }
+
+                let notModified = try await rawExchange(port: port, path: "/not-modified").bytes
+                #expect(notModified.hasPrefix("HTTP/1.1 304 Not Modified"))
+                withKnownIssue("304 response carries the handler's body") {
+                    #expect(!notModified.contains("Hello, world!"), "\(notModified.debugDescription)")
+                }
+
+                await group.triggerGracefulShutdown()
+                try await tg.waitForAll()
+            }
+        }
+    }
 }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -16,6 +16,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
+
 @Suite("Streaming Body Tests")
 struct StreamingBodyTests {
 
@@ -588,15 +589,12 @@ struct StreamingBodyTests {
     func testClientAbortMidFileStreamDoesNotBreakServer() async throws {
         // Big enough that the server is still reading when the client gives up: the transport
         // can't have buffered the whole thing, so the body closure is mid-read when it's cancelled.
-        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("vapor-abort-\(UUID().uuidString).bin")
-        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
-        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let filePath = try await makeTemporaryFile(size: 8 << 20)
 
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio.streamFile(at: fileURL.path, advancedETagComparison: false)
+                try await req.fileio.streamFile(at: filePath, advancedETagComparison: false)
             }
             app.get("ok") { _ in "ok" }
 
@@ -676,17 +674,14 @@ struct StreamingBodyTests {
         // the server concluded the same response, so a connection failure ran the completion twice.
         // `ResponseBodyWriter` can only write buffers now — concluding is the server's job — so the
         // race has nowhere to happen, and this pins that down.
-        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("vapor-once-\(UUID().uuidString).bin")
-        try Data(repeating: 0x41, count: 8 << 20).write(to: fileURL)
-        defer { try? FileManager.default.removeItem(at: fileURL) }
+        let filePath = try await makeTemporaryFile(size: 8 << 20)
 
         let completions = NIOLockedValueBox(0)
 
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio.streamFile(at: fileURL.path, advancedETagComparison: false) { _ in
+                try await req.fileio.streamFile(at: filePath, advancedETagComparison: false) { _ in
                     completions.withLockedValue { $0 += 1 }
                 }
             }

--- a/Tests/VaporTests/Utilities/TemporaryFile.swift
+++ b/Tests/VaporTests/Utilities/TemporaryFile.swift
@@ -1,0 +1,19 @@
+import NIOCore
+import _NIOFileSystem
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Writes a temporary file of `size` bytes and returns its path.
+func makeTemporaryFile(size: Int) async throws -> String {
+    let directory = try await FileSystem.shared.temporaryDirectory
+    let path = directory.appending("vapor-test-\(UUID().uuidString).bin")
+    try await FileSystem.shared.withFileHandle(
+        forWritingAt: path, options: .newFile(replaceExisting: true)
+    ) { handle in
+        _ = try await handle.write(contentsOf: ByteBuffer(repeating: 0x41, count: size), toAbsoluteOffset: 0)
+    }
+    return path.string
+}

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -757,7 +757,7 @@ struct ValidationTests {
                                 return "\(failure.key) \(reason)"
                             }
                             // Create the 400 response and encode the custom error content.
-                            let response = Response(status: .badRequest)
+                            var response = Response(status: .badRequest)
                             try response.content.encode(ErrorResponse(errors: errorMessages))
                             return response
                         } else {


### PR DESCRIPTION
Overhaul and tidy up `Response`:
* migrates `Response` to a struct
* Fix a bug where the incorrect stream length wasn't closing the connection
* Fix a crash in FileIO when stream file was cancelled and the async defer wasn't firing
* tidy up `Response`, removing all locks, storage and version as they don't make sense
* fixes a number of edge cases around responses with connection closes, empty responses and throwing errors

Resolves #3525