### PR TITLE
Remove NIO from Response's Public API

### DIFF
--- a/Performance/Sources/PerformanceServer/main.swift
+++ b/Performance/Sources/PerformanceServer/main.swift
@@ -34,7 +34,7 @@ app.get("bench", "json") { _ in json }
 app.get("bench", "stream") { _ -> Response in
     Response(body: .init(stream: { writer in
         for _ in 0..<16 {
-            try await writer.write(ByteBuffer(string: chunk))
+            try await writer.write(chunk)
         }
     }, count: 16 * 1024))
 }

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -2,7 +2,6 @@ import Foundation
 import Vapor
 import NIOCore
 import HTTPTypes
-import NIOConcurrencyHelpers
 import _NIOFileSystem
 import RoutingKit
 import Logging
@@ -101,15 +100,15 @@ func routes(_ app: Application) async throws {
     app.get("stream", "chunks") { _ -> Response in
         Response(body: .init(stream: { writer in
             for i in 1...5 {
-                try await writer.write(ByteBuffer(string: "chunk \(i)\n"))
+                try await writer.write("chunk \(i)\n")
             }
         }))
     }
 
     app.get("stream", "sequence") { _ -> Response in
-        let lines = AsyncStream<ByteBuffer> { continuation in
+        let lines = AsyncStream<String> { continuation in
             for i in 1...10 {
-                continuation.yield(ByteBuffer(string: "line \(i)\n"))
+                continuation.yield("line \(i)\n")
             }
             continuation.finish()
         }
@@ -122,7 +121,7 @@ func routes(_ app: Application) async throws {
 
     app.get("stream", "firehose") { _ -> Response in
         Response(body: .init(stream: { writer in
-            let chunk = ByteBuffer(repeating: 0x41, count: 16 * 1024)
+            let chunk = [UInt8](repeating: 0x41, count: 16 * 1024)
             for _ in 0..<10_000 {
                 try await writer.write(chunk)
             }
@@ -134,7 +133,7 @@ func routes(_ app: Application) async throws {
     app.get("stream", "slow") { _ -> Response in
         Response(body: .init(stream: { writer in
             for i in 1...10 {
-                try await writer.write(ByteBuffer(string: "chunk \(i)\n"))
+                try await writer.write("chunk \(i)\n")
                 try await Task.sleep(for: .milliseconds(500))
             }
         }))
@@ -147,7 +146,7 @@ func routes(_ app: Application) async throws {
             let handle = try await fileSystem.openFile(forReadingAt: FilePath(path), options: .init())
             defer { try? await handle.close() }
             for try await chunk in handle.readChunks(chunkLength: .bytes(64 * 1024)) {
-                try await writer.write(chunk)
+                try await writer.write(chunk.readableBytesSpan)
             }
         }))
     }

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -93,7 +93,7 @@ extension ClientResponse: ResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
         let body: Response.Body
         if let buffer = self.body {
-            body = .init(buffer: buffer, byteBufferAllocator: request.byteBufferAllocator)
+            body = .init(buffer: buffer)
         } else {
             body = .empty
         }

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -158,15 +158,6 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         self.inner = consume inner
     }
 
-    func write(_ buffer: ByteBuffer) async throws {
-        var out = UniqueArray<UInt8>(minimumCapacity: buffer.readableBytes)
-        out.append(copying: buffer.readableBytesView)
-        // `inner` is always present during writes (the body closure runs before `finish`, which
-        // takes it); the optional-chaining is just how we reach the move-only writer in place.
-        try await self.inner?.write(buffer: &out)
-        self.bytesWritten += buffer.readableBytes
-    }
-
     func write(_ bytes: RawSpan) async throws {
         // We need to copy here so the writer takes ownership of the data
         // TODO: This should be fixed in HTTP Server to avoid the copy

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -169,12 +169,7 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
 
     func write(_ bytes: some Sequence<UInt8>) async throws {
         var out = UniqueArray<UInt8>(minimumCapacity: bytes.underestimatedCount)
-        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
-            out.append(copying: buffer)
-        }
-        if borrowed == nil {
-            out.append(copying: bytes)
-        }
+        out.append(copying: bytes)
         // `write` drains `out`, so the count has to be taken first.
         let count = out.count
         try await self.inner?.write(buffer: &out)

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -114,8 +114,6 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 // move-only response writer), so it stays in this task; each `write` awaits the
                 // transport, so backpressure propagates to the closure. The server appends the
                 // final chunk via `finish` once the closure returns.
-                // Keep the concrete type so we can call `finish` (which is intentionally not part
-                // of the public `ResponseBodyWriter` protocol); the closure only sees `write`.
                 let writer = NIOResponseBodyWriter(inner: try await sender.send(httpResponse))
                 try await bodyStream.callback(writer)
                 guard bodyStream.count < 0 || writer.bytesWritten == bodyStream.count else {

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -163,6 +163,7 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         // TODO: This should be fixed in HTTP Server to avoid the copy
         var out = UniqueArray<UInt8>(minimumCapacity: bytes.byteCount)
         bytes.withUnsafeBytes { out.append(copying: $0) }
+        try await self.inner?.write(buffer: &out)
         self.bytesWritten += bytes.byteCount
     }
 

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -167,6 +167,14 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         self.bytesWritten += buffer.readableBytes
     }
 
+    func write(_ bytes: RawSpan) async throws {
+        // We need to copy here so the writer takes ownership of the data
+        // TODO: This should be fixed in HTTP Server to avoid the copy
+        var out = UniqueArray<UInt8>(minimumCapacity: bytes.byteCount)
+        bytes.withUnsafeBytes { out.append(copying: $0) }
+        self.bytesWritten += bytes.byteCount
+    }
+
     func finish(_ trailingHeaders: HTTPFields?) async throws {
         guard let writer = self.inner.take() else { return }
         var empty = UniqueArray<UInt8>()

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -167,6 +167,20 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         self.bytesWritten += bytes.byteCount
     }
 
+    func write(_ bytes: some Sequence<UInt8>) async throws {
+        var out = UniqueArray<UInt8>(minimumCapacity: bytes.underestimatedCount)
+        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
+            out.append(copying: buffer)
+        }
+        if borrowed == nil {
+            out.append(copying: bytes)
+        }
+        // `write` drains `out`, so the count has to be taken first.
+        let count = out.count
+        try await self.inner?.write(buffer: &out)
+        self.bytesWritten += count
+    }
+
     func finish(_ trailingHeaders: HTTPFields?) async throws {
         guard let writer = self.inner.take() else { return }
         var empty = UniqueArray<UInt8>()

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -128,10 +128,12 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 }
                 try await writer.finish(nil)
             default:
-                // Buffered body: single-shot write.
-                var responseBody = UniqueArray<UInt8>()
-                if let buffer = vaporResponse.body.buffer, buffer.readableBytes > 0 {
-                    responseBody.append(copying: buffer.readableBytesView)
+                // Buffered body: single-shot write. Borrowing the body's bytes copies them straight
+                // into the server's container - a `.string`/`.data`/`.staticString` body is no
+                // longer materialised into an intermediate `ByteBuffer` first.
+                var responseBody = UniqueArray<UInt8>(minimumCapacity: vaporResponse.body.count)
+                vaporResponse.body.withBytes { bytes in
+                    bytes.withUnsafeBytes { unsafe responseBody.append(copying: $0) }
                 }
                 try await sender.sendAndFinish(httpResponse, buffer: &responseBody)
             }

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -132,7 +132,7 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 // into the server's container - a `.string`/`.data`/`.staticString` body is no
                 // longer materialised into an intermediate `ByteBuffer` first.
                 var responseBody = UniqueArray<UInt8>(minimumCapacity: vaporResponse.body.count)
-                vaporResponse.body.withBytes { bytes in
+                try await vaporResponse.body.withStreamingBytes { bytes in
                     bytes.withUnsafeBytes { unsafe responseBody.append(copying: $0) }
                 }
                 try await sender.sendAndFinish(httpResponse, buffer: &responseBody)

--- a/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
+++ b/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
@@ -1,6 +1,3 @@
-#warning("Make this internal")
-public import NIOCore
-
 /// Protocol for writing HTTP response bodies.
 ///
 /// Implementations of this protocol are provided by the HTTP server layer and allow Vapor's
@@ -13,10 +10,6 @@ public import NIOCore
 /// is exposed: concluding the response is the server's responsibility, so a body-stream closure
 /// can never end the stream itself.
 public protocol ResponseBodyWriter: AnyObject {
-    /// Write a single ByteBuffer.
-    func write(_ buffer: ByteBuffer) async throws
-    /// Write a sequence of ByteBuffers.
-    func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
     /// Write a sindle chunk of bytes
     func write(_ bytes: RawSpan) async throws
 }
@@ -48,18 +41,6 @@ extension ResponseBodyWriter {
     public func write(contentsOf chunks: some Sequence<some Sequence<UInt8>>) async throws {
         for chunk in chunks {
             try await self.write(chunk)
-        }
-    }
-
-    // Internal helper to map to what NIOHTTPServer wants
-    func write(_ buffer: ByteBuffer) async throws {
-        try await self.write(buffer.readableBytesSpan)
-    }
-
-    #warning("Remove")
-    public func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
-        for buffer in buffers {
-            try await write(buffer)
         }
     }
 }

--- a/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
+++ b/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
@@ -10,8 +10,13 @@
 /// is exposed: concluding the response is the server's responsibility, so a body-stream closure
 /// can never end the stream itself.
 public protocol ResponseBodyWriter: AnyObject {
-    /// Write a sindle chunk of bytes
+    /// Write a single chunk of bytes
     func write(_ bytes: RawSpan) async throws
+
+    /// Write a sequence of bytes.
+    /// This is required on the protocol to ensure it gets used when ``ResponseBodyWriter`` is an existential.
+    /// This allows us to avoid a copy in certain scenarios
+    func write(_ bytes: some Sequence<UInt8>) async throws
 }
 
 extension ResponseBodyWriter {
@@ -27,8 +32,11 @@ extension ResponseBodyWriter {
         try await self.write(string.utf8Span.span.bytes)
     }
 
-    /// Write a sequence of bytes
-    /// This will copy the bytes into contiguous storage first. Use the `Span` APIs to avoid copies
+    /// Write a sequence of bytes.
+    ///
+    /// Copies into contiguous storage so the bytes can be handed over as a `RawSpan`.
+    /// `withContiguousStorageIfAvailable` is unusable here: its closure is synchronous, and
+    /// `write(_ bytes: RawSpan)` must be awaited. Writers that copy synchronously should override.
     @inlinable
     public func write(_ bytes: some Sequence<UInt8>) async throws {
         let contiguous = ContiguousArray(bytes)

--- a/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
+++ b/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
@@ -55,4 +55,11 @@ extension ResponseBodyWriter {
     func write(_ buffer: ByteBuffer) async throws {
         try await self.write(buffer.readableBytesSpan)
     }
+
+    #warning("Remove")
+    public func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
+        for buffer in buffers {
+            try await write(buffer)
+        }
+    }
 }

--- a/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
+++ b/Sources/Vapor/HTTP/Server/ResponseBodyWriter.swift
@@ -17,13 +17,42 @@ public protocol ResponseBodyWriter: AnyObject {
     func write(_ buffer: ByteBuffer) async throws
     /// Write a sequence of ByteBuffers.
     func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws
+    /// Write a sindle chunk of bytes
+    func write(_ bytes: RawSpan) async throws
 }
 
 extension ResponseBodyWriter {
+    /// Write a single chunk of bytes
     @inlinable
-    public func write(contentsOf buffers: some Sequence<ByteBuffer>) async throws {
-        for buffer in buffers {
-            try await self.write(buffer)
+    public func write(_ bytes: Span<UInt8>) async throws {
+        try await self.write(bytes.bytes)
+    }
+
+    /// Write the UTF-8 Representation of a `String`
+    @inlinable
+    public func write(_ string: String) async throws {
+        try await self.write(string.utf8Span.span.bytes)
+    }
+
+    /// Write a sequence of bytes
+    /// This will copy the bytes into contiguous storage first. Use the `Span` APIs to avoid copies
+    @inlinable
+    public func write(_ bytes: some Sequence<UInt8>) async throws {
+        let contiguous = ContiguousArray(bytes)
+        try await self.write(contiguous.span.bytes)
+    }
+
+    /// Write a sequence of byte chunks, in order
+    /// This will copy the bytes into contiguous storage first. Use the `Span` APIs to avoid copies
+    @inlinable
+    public func write(contentsOf chunks: some Sequence<some Sequence<UInt8>>) async throws {
+        for chunk in chunks {
+            try await self.write(chunk)
         }
+    }
+
+    // Internal helper to map to what NIOHTTPServer wants
+    func write(_ buffer: ByteBuffer) async throws {
+        try await self.write(buffer.readableBytesSpan)
     }
 }

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -63,10 +63,9 @@ public final class ErrorMiddleware: Middleware {
 
                 body = .init(
                     buffer: byteBuffer,
-                    byteBufferAllocator: req.byteBufferAllocator
                 )
             } catch {
-                body = .init(string: "Oops: \(String(describing: error))\nWhile encoding error: \(reason)", byteBufferAllocator: req.byteBufferAllocator)
+                body = .init(string: "Oops: \(String(describing: error))\nWhile encoding error: \(reason)")
                 headers.contentType = .plainText
             }
 

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -267,4 +267,15 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
     func write(_ bytes: RawSpan) async throws {
         bytes.withUnsafeBytes { self.data.append(contentsOf: $0) }
     }
+
+    /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying
+    /// it into a `ContiguousArray` first, as the protocol's default implementation must.
+    func write(_ bytes: some Sequence<UInt8>) async throws {
+        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
+            unsafe self.data.append(contentsOf: buffer)
+        }
+        if borrowed == nil {
+            self.data.append(contentsOf: bytes)
+        }
+    }
 }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -199,4 +199,7 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
         var buffer = buffer
         self.buffer.writeBuffer(&buffer)
     }
+
+    func write(_ bytes: RawSpan) async throws {
+    }
 }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -35,33 +35,38 @@ extension Response {
         /// An empty `Response.Body`.
         public static let empty: Body = .init()
 
-        /// Borrow the body's bytes without copying.
+        /// Read the body's bytes incrementally, without buffering the whole thing.
         ///
-        /// The span is only valid for the duration of `body`. `RawSpan` is non-escapable, so the
-        /// compiler enforces that: the closure cannot stash the span and read it later.
+        /// The closure is called once per chunk, in order, and is backpressured: a streaming body
+        /// only produces the next chunk once the closure returns. Each span is only valid for the
+        /// duration of that call - `RawSpan` is non-escapable, so the compiler enforces that: the
+        /// closure cannot stash a span and read it later.
         ///
-        /// Every buffered case borrows its existing storage, so nothing is copied on the way in -
-        /// including `.string` and `.staticString`, which are not materialised.
+        /// Works for every kind of body - a buffered one is handed over as a single chunk, and an
+        /// empty one calls the closure not at all - so callers do not need to branch on storage.
         ///
-        /// - Returns: The closure's result, or `nil` if the body is empty or still streaming.
-        ///            A streaming body has to be read with ``collect()`` instead.
-        public func withBytes<R>(_ body: (RawSpan) throws -> R) rethrows -> R? {
+        /// Note this *consumes* a streaming body: it runs the stream's callback,
+        /// so it has that closure's side effects and must not be called twice on the same body.
+        /// A streaming body can also throw part-way, after the closure has already seen chunks.
+        ///
+        /// Use ``collect()`` instead when the whole body is genuinely needed in memory.
+        public func withStreamingBytes(_ body: @escaping (RawSpan) async throws -> Void) async throws {
             switch self.storage {
+            case .stream(let stream):
+                try await stream.callback(ForwardingBodyWriter(body))
+            case .none:
+                return
+            // Buffered: the whole body is handed over as a single chunk.
             case .buffer(let buffer):
-                return try body(buffer.readableBytesSpan)
+                try await body(buffer.readableBytesSpan)
             case .data(let data):
-                return try body(data.span.bytes)
+                try await body(data.span.bytes)
             case .string(let string):
-                return try body(string.utf8Span.span.bytes)
+                try await body(string.utf8Span.span.bytes)
             case .staticString(let staticString):
-                // No public pointer-to-`RawSpan` initialiser exists yet, so the span over a
-                // `StaticString`'s UTF-8 has to be built with the underscored one. Safe here: a
-                // `StaticString`'s storage is immortal, so the span cannot outlive its bytes.
-                return try unsafe body(
+                try await unsafe body(
                     RawSpan(_unsafeStart: staticString.utf8Start, byteCount: staticString.utf8CodeUnitCount)
                 )
-            case .none, .stream:
-                return nil
             }
         }
 
@@ -185,6 +190,20 @@ extension Response {
         internal init(storage: Storage) {
             self.storage = storage
         }
+    }
+}
+
+/// A ``ResponseBodyWriter`` that forwards each chunk straight to a closure, used to drive a
+/// streaming body incrementally instead of collecting it.
+private final class ForwardingBodyWriter: ResponseBodyWriter {
+    let onChunk: (RawSpan) async throws -> Void
+
+    init(_ onChunk: @escaping (RawSpan) async throws -> Void) {
+        self.onChunk = onChunk
+    }
+
+    func write(_ bytes: RawSpan) async throws {
+        try await self.onChunk(bytes)
     }
 }
 

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -93,11 +93,11 @@ extension Response {
                 // Reserve the declared length up front when known (`count >= 0`) to avoid repeated
                 // grow-and-copy reallocations; `-1` means unknown/chunked, so start empty.
                 let initialCapacity = stream.count >= 0 ? stream.count : 0
-                let writer = CollectingBodyWriter(buffer: self.byteBufferAllocator.buffer(capacity: initialCapacity))
+                let writer = CollectingBodyWriter(capacity: initialCapacity)
                 try await stream.callback(writer)
-                return writer.buffer.readData(length: writer.buffer.readableBytes)
+                return writer.data
             default:
-                return self.buffer?.getData(at: 0, length: self.buffer?.readableBytes ?? 0)
+                return self.data
             }
         }
 
@@ -186,20 +186,20 @@ extension Response {
     }
 }
 
-/// A ``ResponseBodyWriter`` that accumulates everything written into a `ByteBuffer`, used to
+/// A ``ResponseBodyWriter`` that accumulates everything written into `Data`, used to
 /// eagerly collect a streaming body instead of forwarding it to the connection.
-private final class CollectingBodyWriter: ResponseBodyWriter {
-    var buffer: ByteBuffer
+private final class CollectingBodyWriter: ResponseBodyWriter {    
+    var data: Data
 
-    init(buffer: ByteBuffer) {
-        self.buffer = buffer
+    init(capacity: Int) {
+        self.data = Data(capacity: capacity)
     }
 
     func write(_ buffer: ByteBuffer) async throws {
-        var buffer = buffer
-        self.buffer.writeBuffer(&buffer)
+        try await self.write(buffer.readableBytesSpan)
     }
 
     func write(_ bytes: RawSpan) async throws {
+        bytes.withUnsafeBytes { self.data.append(contentsOf: $0) }
     }
 }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -74,14 +74,11 @@ extension Response {
             switch self.storage {
             case .buffer(let buffer): return buffer
             case .data(let data):
-                let buffer = ByteBufferAllocator().buffer(bytes: data)
-                return buffer
+                return ByteBuffer(data: data)
             case .staticString(let staticString):
-                let buffer = ByteBufferAllocator().buffer(staticString: staticString)
-                return buffer
+                return ByteBuffer(staticString: staticString)
             case .string(let string):
-                let buffer = ByteBufferAllocator().buffer(string: string)
-                return buffer
+                return ByteBuffer(string: string)
             case .none: return nil
             case .stream: return nil
             }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -271,13 +271,6 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
     /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying
     /// it into a `ContiguousArray` first, as the protocol's default implementation must.
     func write(_ bytes: some Sequence<UInt8>) async throws {
-        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
-            unsafe self.data.append(contentsOf: buffer)
-        }
-        if borrowed == nil {
-            self.data.append(contentsOf: bytes)
-        }
-    }
-    func write(_ bytes: some Sequence<UInt8>) async throws {
         self.data.append(contentsOf: bytes)
     }
+}

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -3,8 +3,8 @@ public import FoundationEssentials
 #else
 public import Foundation
 #endif
-#warning("Make this internal")
-public import NIOCore
+#warning("Remove")
+import NIOCore
 import NIOFoundationEssentialsCompat
 import HTTPTypes
 import NIOPosix
@@ -184,7 +184,7 @@ extension Response {
         }
 
         /// Create a new body from a Swift NIO `ByteBuffer`.
-        public init(buffer: ByteBuffer) {
+        init(buffer: ByteBuffer) {
             self.storage = .buffer(buffer)
         }
 
@@ -252,10 +252,6 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
 
     init(capacity: Int) {
         self.data = Data(capacity: capacity)
-    }
-
-    func write(_ buffer: ByteBuffer) async throws {
-        try await self.write(buffer.readableBytesSpan)
     }
 
     func write(_ bytes: RawSpan) async throws {

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -278,4 +278,6 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
             self.data.append(contentsOf: bytes)
         }
     }
-}
+    func write(_ bytes: some Sequence<UInt8>) async throws {
+        self.data.append(contentsOf: bytes)
+    }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -74,13 +74,13 @@ extension Response {
             switch self.storage {
             case .buffer(let buffer): return buffer
             case .data(let data):
-                let buffer = self.byteBufferAllocator.buffer(bytes: data)
+                let buffer = ByteBufferAllocator().buffer(bytes: data)
                 return buffer
             case .staticString(let staticString):
-                let buffer = self.byteBufferAllocator.buffer(staticString: staticString)
+                let buffer = ByteBufferAllocator().buffer(staticString: staticString)
                 return buffer
             case .string(let string):
-                let buffer = self.byteBufferAllocator.buffer(string: string)
+                let buffer = ByteBufferAllocator().buffer(string: string)
                 return buffer
             case .none: return nil
             case .stream: return nil
@@ -114,35 +114,29 @@ extension Response {
         }
 
         internal var storage: Storage
-        internal let byteBufferAllocator: ByteBufferAllocator
 
         /// Creates an empty body. Useful for `GET` requests where HTTP bodies are forbidden.
         public init() {
-            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .none
         }
 
         /// Create a new body wrapping `Data`.
         public init(data: Data) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             storage = .data(data)
         }
 
         /// Create a new body from the UTF8 representation of a `StaticString`.
         public init(staticString: StaticString) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             storage = .staticString(staticString)
         }
 
         /// Create a new body from the UTF8 representation of a `String`.
         public init(string: String) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .string(string)
         }
 
         /// Create a new body from a Swift NIO `ByteBuffer`.
         public init(buffer: ByteBuffer) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .buffer(buffer)
         }
 
@@ -156,13 +150,12 @@ extension Response {
         ///   - stream: The closure that writes the body chunks.
         ///   - count: The number of bytes that will be written. The `stream` **MUST** produce exactly `count` bytes.
         public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), count: Int) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .stream(.init(count: count, callback: stream))
         }
 
         /// Creates a chunked, streaming HTTP ``Response`` body of unknown length.
         ///
-        /// See ``init(stream:count:byteBufferAllocator:)`` for the streaming semantics.
+        /// See ``init(stream:count:)`` for the streaming semantics.
         ///
         /// - Parameters:
         ///   - stream: The closure that writes the body chunks.
@@ -172,13 +165,11 @@ extension Response {
 
         /// `ExpressibleByStringLiteral` conformance.
         public init(stringLiteral value: String) {
-            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .string(value)
         }
 
         /// Internal init.
-        internal init(storage: Storage, byteBufferAllocator: ByteBufferAllocator) {
-            self.byteBufferAllocator = byteBufferAllocator
+        internal init(storage: Storage) {
             self.storage = storage
         }
     }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -87,7 +87,7 @@ extension Response {
             }
         }
 
-        public func collect() async throws -> ByteBuffer? {
+        public func collect() async throws -> Data? {
             switch self.storage {
             case .stream(let stream):
                 // Reserve the declared length up front when known (`count >= 0`) to avoid repeated
@@ -95,9 +95,9 @@ extension Response {
                 let initialCapacity = stream.count >= 0 ? stream.count : 0
                 let writer = CollectingBodyWriter(buffer: self.byteBufferAllocator.buffer(capacity: initialCapacity))
                 try await stream.callback(writer)
-                return writer.buffer
+                return writer.buffer.readData(length: writer.buffer.readableBytes)
             default:
-                return self.buffer
+                return self.buffer?.getData(at: 0, length: self.buffer?.readableBytes ?? 0)
             }
         }
 

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -35,6 +35,36 @@ extension Response {
         /// An empty `Response.Body`.
         public static let empty: Body = .init()
 
+        /// Borrow the body's bytes without copying.
+        ///
+        /// The span is only valid for the duration of `body`. `RawSpan` is non-escapable, so the
+        /// compiler enforces that: the closure cannot stash the span and read it later.
+        ///
+        /// Every buffered case borrows its existing storage, so nothing is copied on the way in -
+        /// including `.string` and `.staticString`, which are not materialised.
+        ///
+        /// - Returns: The closure's result, or `nil` if the body is empty or still streaming.
+        ///            A streaming body has to be read with ``collect()`` instead.
+        public func withBytes<R>(_ body: (RawSpan) throws -> R) rethrows -> R? {
+            switch self.storage {
+            case .buffer(let buffer):
+                return try body(buffer.readableBytesSpan)
+            case .data(let data):
+                return try body(data.span.bytes)
+            case .string(let string):
+                return try body(string.utf8Span.span.bytes)
+            case .staticString(let staticString):
+                // No public pointer-to-`RawSpan` initialiser exists yet, so the span over a
+                // `StaticString`'s UTF-8 has to be built with the underscored one. Safe here: a
+                // `StaticString`'s storage is immortal, so the span cannot outlive its bytes.
+                return try unsafe body(
+                    RawSpan(_unsafeStart: staticString.utf8Start, byteCount: staticString.utf8CodeUnitCount)
+                )
+            case .none, .stream:
+                return nil
+            }
+        }
+
         public var string: String? {
             switch self.storage {
             case .buffer(var buffer): return buffer.readString(length: buffer.readableBytes)
@@ -65,20 +95,6 @@ extension Response {
             case .data(let data): return data
             case .staticString(let staticString): return unsafe Data(bytes: staticString.utf8Start, count: staticString.utf8CodeUnitCount)
             case .string(let string): return Data(string.utf8)
-            case .none: return nil
-            case .stream: return nil
-            }
-        }
-
-        public var buffer: ByteBuffer? {
-            switch self.storage {
-            case .buffer(let buffer): return buffer
-            case .data(let data):
-                return ByteBuffer(data: data)
-            case .staticString(let staticString):
-                return ByteBuffer(staticString: staticString)
-            case .string(let string):
-                return ByteBuffer(string: string)
             case .none: return nil
             case .stream: return nil
             }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -271,6 +271,7 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
     /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying
     /// it into a `ContiguousArray` first, as the protocol's default implementation must.
     func write(_ bytes: some Sequence<UInt8>) async throws {
+        // `Data.append(contentsOf:)` already takes the contiguous fast path internally
         self.data.append(contentsOf: bytes)
     }
 }

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -70,6 +70,36 @@ extension Response {
             }
         }
 
+        /// Fold the body's bytes into a value, one chunk at a time.
+        ///
+        /// The streaming counterpart to computing something over a whole body without ever holding
+        /// it in memory - hashing, counting, checksumming, incremental parsing. Chunk delivery and
+        /// backpressure are exactly ``withStreamingBytes(_:)``'s, so a streaming body is folded as
+        /// it arrives and a buffered one is folded in a single step.
+        ///
+        ///     let digest = try await body.reduceBytes(into: SHA256()) { hasher, span in
+        ///         span.withUnsafeBytes { hasher.update(bufferPointer: $0) }
+        ///     }.finalize()
+        ///
+        /// Like ``withStreamingBytes(_:)`` this consumes a streaming body.
+        ///
+        /// - Parameters:
+        ///   - initialResult: The value to start from.
+        ///   - updateAccumulatingResult: Folds each chunk into the accumulator.
+        /// - Returns: The accumulated value. An empty body returns `initialResult` untouched.
+        public func reduceBytes<R>(
+            into initialResult: R,
+            _ updateAccumulatingResult: @escaping (inout R, RawSpan) async throws -> Void
+        ) async throws -> R {
+            // `inout` can't cross into an escaping closure, so the accumulator is boxed for the
+            // duration. That is an implementation detail: callers still write plain `inout`.
+            let accumulator = ReduceBox(initialResult)
+            try await self.withStreamingBytes { span in
+                try await updateAccumulatingResult(&accumulator.value, span)
+            }
+            return accumulator.value
+        }
+
         public var string: String? {
             switch self.storage {
             case .buffer(var buffer): return buffer.readString(length: buffer.readableBytes)
@@ -191,6 +221,14 @@ extension Response {
             self.storage = storage
         }
     }
+}
+
+/// Holds a ``Response/Body/reduceBytes(into:_:)`` accumulator so it can be mutated from inside an
+/// escaping closure. Not locked: the chunk closure is driven serially by the body itself, never
+/// concurrently.
+private final class ReduceBox<R> {
+    var value: R
+    init(_ value: R) { self.value = value }
 }
 
 /// A ``ResponseBodyWriter`` that forwards each chunk straight to a closure, used to drive a

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -135,7 +135,16 @@ extension Response {
             }
         }
 
-        public func collect() async throws -> Data? {
+        /// Reads the whole body into memory, running a streaming body to completion.
+        ///
+        /// Collecting a streaming body **replaces** it with the bytes it produced as a mutating operation. A stream's
+        /// closure can only be relied on to run once - it may be reading a file handle, or draining
+        /// an `AsyncSequence` - so re-running it silently yields a short or empty body. Caching the
+        /// result means anything further down the chain, including the server that serialises the
+        /// response, sees an ordinary in-memory body instead.
+        ///
+        /// - Returns: The body's bytes, or `nil` if the body is empty.
+        public mutating func collect() async throws -> Data? {
             switch self.storage {
             case .stream(let stream):
                 // Reserve the declared length up front when known (`count >= 0`) to avoid repeated
@@ -143,6 +152,7 @@ extension Response {
                 let initialCapacity = stream.count >= 0 ? stream.count : 0
                 let writer = CollectingBodyWriter(capacity: initialCapacity)
                 try await stream.callback(writer)
+                self.storage = .data(writer.data)
                 return writer.data
             default:
                 return self.data

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -117,32 +117,32 @@ extension Response {
         internal let byteBufferAllocator: ByteBufferAllocator
 
         /// Creates an empty body. Useful for `GET` requests where HTTP bodies are forbidden.
-        public init(byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init() {
+            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .none
         }
 
         /// Create a new body wrapping `Data`.
-        public init(data: Data, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init(data: Data) {
+            self.byteBufferAllocator = ByteBufferAllocator()
             storage = .data(data)
         }
 
         /// Create a new body from the UTF8 representation of a `StaticString`.
-        public init(staticString: StaticString, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init(staticString: StaticString) {
+            self.byteBufferAllocator = ByteBufferAllocator()
             storage = .staticString(staticString)
         }
 
         /// Create a new body from the UTF8 representation of a `String`.
-        public init(string: String, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init(string: String) {
+            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .string(string)
         }
 
         /// Create a new body from a Swift NIO `ByteBuffer`.
-        public init(buffer: ByteBuffer, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init(buffer: ByteBuffer) {
+            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .buffer(buffer)
         }
 
@@ -155,9 +155,8 @@ extension Response {
         /// - Parameters:
         ///   - stream: The closure that writes the body chunks.
         ///   - count: The number of bytes that will be written. The `stream` **MUST** produce exactly `count` bytes.
-        ///   - byteBufferAllocator: The allocator that is preferred when writing data to SwiftNIO
-        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), count: Int, byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.byteBufferAllocator = byteBufferAllocator
+        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), count: Int) {
+            self.byteBufferAllocator = ByteBufferAllocator()
             self.storage = .stream(.init(count: count, callback: stream))
         }
 
@@ -167,9 +166,8 @@ extension Response {
         ///
         /// - Parameters:
         ///   - stream: The closure that writes the body chunks.
-        ///   - byteBufferAllocator: The allocator that is preferred when writing data to SwiftNIO
-        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator()) {
-            self.init(stream: stream, count: -1, byteBufferAllocator: byteBufferAllocator)
+        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> ()) {
+            self.init(stream: stream, count: -1)
         }
 
         /// `ExpressibleByStringLiteral` conformance.

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -73,7 +73,7 @@ public struct Response: CustomStringConvertible, Sendable {
         }
 
         mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E: Encodable {
-            var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
+            var body = ByteBufferAllocator().buffer(capacity: 0)
             try encoder.encode(encodable, to: &body, headers: &self.response.headers)
             self.response.body = .init(buffer: body)
         }
@@ -88,7 +88,7 @@ public struct Response: CustomStringConvertible, Sendable {
         mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C: Content {
             var content = content
             try content.beforeEncode()
-            var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
+            var body = ByteBufferAllocator().buffer(capacity: 0)
             try encoder.encode(content, to: &body, headers: &self.response.headers)
             self.response.body = .init(buffer: body)
         }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -79,10 +79,10 @@ public struct Response: CustomStringConvertible, Sendable {
         }
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D: Decodable {
-            guard let body = self.response.body.buffer else {
+            guard let body = self.response.body.data else {
                 throw Abort(.unprocessableContent)
             }
-            return try decoder.decode(D.self, from: body, headers: self.response.headers)
+            return try decoder.decode(D.self, from: ByteBuffer(data: body), headers: self.response.headers)
         }
 
         mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C: Content {
@@ -94,10 +94,10 @@ public struct Response: CustomStringConvertible, Sendable {
         }
 
         func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C: Content {
-            guard let body = self.response.body.buffer else {
+            guard let body = self.response.body.data else {
                 throw Abort(.unprocessableContent)
             }
-            var decoded = try decoder.decode(C.self, from: body, headers: self.response.headers)
+            var decoded = try decoder.decode(C.self, from: ByteBuffer(data: body), headers: self.response.headers)
             try decoded.afterDecode()
             return decoded
         }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -73,7 +73,7 @@ public struct Response: CustomStringConvertible, Sendable {
         }
 
         mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E: Encodable {
-            var body = ByteBufferAllocator().buffer(capacity: 0)
+            var body = ByteBuffer()
             try encoder.encode(encodable, to: &body, headers: &self.response.headers)
             self.response.body = .init(buffer: body)
         }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -75,7 +75,7 @@ public struct Response: CustomStringConvertible, Sendable {
         mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E: Encodable {
             var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
             try encoder.encode(encodable, to: &body, headers: &self.response.headers)
-            self.response.body = .init(buffer: body, byteBufferAllocator: self.response.body.byteBufferAllocator)
+            self.response.body = .init(buffer: body)
         }
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D: Decodable {
@@ -90,7 +90,7 @@ public struct Response: CustomStringConvertible, Sendable {
             try content.beforeEncode()
             var body = self.response.body.byteBufferAllocator.buffer(capacity: 0)
             try encoder.encode(content, to: &body, headers: &self.response.headers)
-            self.response.body = .init(buffer: body, byteBufferAllocator: self.response.body.byteBufferAllocator)
+            self.response.body = .init(buffer: body)
         }
 
         func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C: Content {

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -1,5 +1,4 @@
 public import HTTPTypes
-import NIOConcurrencyHelpers
 
 /// Can convert `self` to a `Response`.
 ///

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -304,7 +304,7 @@ public struct FileIO: Sendable {
                 throw error
             }
             try await onCompleted(.success(()))
-        }, count: byteCount, byteBufferAllocator: request.byteBufferAllocator)
+        }, count: byteCount)
 
         return response
     }

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -297,7 +297,7 @@ public struct FileIO: Sendable {
                     chunkLength: .bytes(chunkSize)
                 )
                 for try await chunk in chunks {
-                    try await writer.write(chunk)
+                    try await writer.write(chunk.readableBytesSpan)
                 }
             } catch {
                 try await onCompleted(.failure(error))

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -109,10 +109,15 @@ extension Application {
                 responder = DefaultResponder(routes: app.routes, middleware: app.middleware.resolve())
             }
             let res = try await responder.respond(to: request)
-            return try await TestingHTTPResponse(
+            let body = if let collectBody = try await res.body.collect() {
+                ByteBuffer(bytes: collectBody)
+            } else {
+                ByteBufferAllocator().buffer(capacity: 0)
+            }
+            return TestingHTTPResponse(
                 status: res.status,
                 headers: res.headers,
-                body: res.body.collect() ?? ByteBufferAllocator().buffer(capacity: 0),
+                body: body,
                 contentConfiguration: self.app.contentConfiguration
             )
         }

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -108,7 +108,7 @@ extension Application {
             case .default:
                 responder = DefaultResponder(routes: app.routes, middleware: app.middleware.resolve())
             }
-            let res = try await responder.respond(to: request)
+            var res = try await responder.respond(to: request)
             let body = if let collectBody = try await res.body.collect() {
                 ByteBuffer(bytes: collectBody)
             } else {

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -584,7 +584,13 @@ struct FileTests {
                 let response = try await request.fileio.streamFile(
                     at: filePath, advancedETagComparison: false)
 
-                let collecting = Task { try await response.body.collect() }
+                // `collect()` is mutating, so the Task works on its own copy of the body. That
+                // is fine here: this test is about descriptor cleanup on cancellation, not the
+                // collected value.
+                let collecting = Task { () -> Data? in
+                    var body = response.body
+                    return try await body.collect()
+                }
                 try await Task.sleep(for: .microseconds(200 * iteration))
                 collecting.cancel()
                 _ = try? await collecting.value

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -56,9 +56,9 @@ struct StreamingBodyTests {
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("stream") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
-                    try await writer.write(ByteBuffer(string: "Hello, "))
-                    try await writer.write(ByteBuffer(string: "streaming, "))
-                    try await writer.write(ByteBuffer(string: "world!"))
+                    try await writer.write("Hello, ")
+                    try await writer.write("streaming, ")
+                    try await writer.write("world!")
                 }))
             }
 
@@ -158,7 +158,7 @@ struct StreamingBodyTests {
             app.get("many") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
                     for _ in 0..<chunkCount {
-                        try await writer.write(ByteBuffer(string: "x"))
+                        try await writer.write("x")
                     }
                 }))
             }
@@ -195,7 +195,7 @@ struct StreamingBodyTests {
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("error-mid-stream") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
-                    try await writer.write(ByteBuffer(string: "partial"))
+                    try await writer.write("partial")
                     throw MidStreamError()
                 }))
             }
@@ -256,7 +256,7 @@ struct StreamingBodyTests {
             // errors on the truncated response or sees fewer bytes than advertised.
             app.get("abort") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
-                    try await writer.write(ByteBuffer(string: "AAAA"))
+                    try await writer.write("AAAA")
                     throw MidStreamError()
                 }, count: 8))
             }
@@ -306,7 +306,7 @@ struct StreamingBodyTests {
             app.get("firehose") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
                     for _ in 0..<100_000 {
-                        try await writer.write(ByteBuffer(string: "x"))
+                        try await writer.write("x")
                     }
                 }))
             }
@@ -355,7 +355,7 @@ struct StreamingBodyTests {
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("firehose") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
-                    let chunk = ByteBuffer(repeating: 0x41, count: chunkSize)
+                    let chunk = [UInt8](repeating: 0x41, count: chunkSize)
                     for _ in 0..<totalChunks {
                         try await writer.write(chunk)
                         produced.withLockedValue { $0 += 1 }
@@ -407,7 +407,7 @@ struct StreamingBodyTests {
             // Declares `Content-Length: 2` (via `count`) but only writes a single byte.
             app.get("bad-length") { _ -> Response in
                 Response(status: .ok, body: .init(stream: { writer in
-                    try await writer.write(ByteBuffer(string: "a"))
+                    try await writer.write("a")
                 }, count: 2))
             }
             app.get("ok") { _ in "ok" }
@@ -452,8 +452,8 @@ struct StreamingBodyTests {
     @Test("collect() gathers a streaming body into a single buffer")
     func testCollectStreamingBody() async throws {
         let body = Response.Body(stream: { writer in
-            try await writer.write(ByteBuffer(string: "Hello, "))
-            try await writer.write(ByteBuffer(string: "collected!"))
+            try await writer.write("Hello, ")
+            try await writer.write("collected!")
         })
         let collected = try await body.collect()
         #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "Hello, collected!")

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -456,7 +456,7 @@ struct StreamingBodyTests {
             try await writer.write(ByteBuffer(string: "collected!"))
         })
         let collected = try await body.collect()
-        #expect(collected.map { String(buffer: $0) } == "Hello, collected!")
+        #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "Hello, collected!")
     }
 
     @Test("Server does not write a body for a status that cannot carry one", .timeLimit(.minutes(1)),

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -459,6 +459,39 @@ struct StreamingBodyTests {
         #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "Hello, collected!")
     }
 
+    @Test("Every ResponseBodyWriter overload reaches the stream")
+    func testWriterOverloads() async throws {
+        let body = Response.Body(stream: { writer in
+            // String
+            try await writer.write("a")
+            // some Sequence<UInt8>
+            try await writer.write([UInt8]([0x62]))
+            // Data, via the same Sequence overload
+            try await writer.write(Data("c".utf8))
+            // Span<UInt8>
+            let d: [UInt8] = [0x64]
+            try await writer.write(d.span)
+            // RawSpan - the protocol requirement itself
+            let e: [UInt8] = [0x65]
+            try await writer.write(e.span.bytes)
+            // A sequence of chunks
+            try await writer.write(contentsOf: [[UInt8]([0x66]), [UInt8]([0x67])])
+        })
+        let collected = try await body.collect()
+        #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "abcdefg")
+    }
+
+    @Test("An empty write does not corrupt the stream")
+    func testEmptyWrite() async throws {
+        let body = Response.Body(stream: { writer in
+            try await writer.write("")
+            try await writer.write([UInt8]())
+            try await writer.write("done")
+        })
+        let collected = try await body.collect()
+        #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "done")
+    }
+
     @Test("Server does not write a body for a status that cannot carry one", .timeLimit(.minutes(1)),
           .bug("https://github.com/swift-server/swift-http-server/issues/118"))
     func testBodylessStatusDoesNotWriteBody() async throws {

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -452,7 +452,7 @@ struct StreamingBodyTests {
 
     @Test("collect() gathers a streaming body into a single buffer")
     func testCollectStreamingBody() async throws {
-        let body = Response.Body(stream: { writer in
+        var body = Response.Body(stream: { writer in
             try await writer.write("Hello, ")
             try await writer.write("collected!")
         })
@@ -462,7 +462,7 @@ struct StreamingBodyTests {
 
     @Test("Every ResponseBodyWriter overload reaches the stream")
     func testWriterOverloads() async throws {
-        let body = Response.Body(stream: { writer in
+        var body = Response.Body(stream: { writer in
             // String
             try await writer.write("a")
             // some Sequence<UInt8>
@@ -581,9 +581,45 @@ struct StreamingBodyTests {
         #expect(Array(streamed) == Array(expected))
     }
 
+    @Test("collect() caches, so the stream closure runs only once")
+    func testCollectCachesStream() async throws {
+        let runs = NIOLockedValueBox(0)
+        var body = Response.Body(stream: { writer in
+            runs.withLockedValue { $0 += 1 }
+            try await writer.write("payload")
+        })
+        let first = try await body.collect()
+        let second = try await body.collect()
+        #expect(first.map { String(decoding: $0, as: UTF8.self) } == "payload")
+        #expect(second.map { String(decoding: $0, as: UTF8.self) } == "payload")
+        #expect(runs.withLockedValue { $0 } == 1)
+    }
+
+    @Test("collect() replaces a stream with an in-memory body for anything downstream")
+    func testCollectReplacesStreamStorage() async throws {
+        // Exactly the middleware case: read the body, then hand the response on. A stream backed by
+        // a source that can only be drained once used to silently send nothing after this point.
+        let (chunks, continuation) = AsyncStream<String>.makeStream()
+        continuation.yield("alpha")
+        continuation.yield("beta")
+        continuation.finish()
+
+        var response = Response(status: .ok, body: .init(stream: { writer in
+            for await chunk in chunks { try await writer.write(chunk) }
+        }))
+        let collected = try await response.body.collect()
+        #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "alphabeta")
+
+        // The response now carries the bytes, not the drained stream, so a second reader sees them.
+        #expect(response.body.string == "alphabeta")
+        #expect(response.body.count == 9)
+        var again = response.body
+        #expect(try await again.collect().map { String(decoding: $0, as: UTF8.self) } == "alphabeta")
+    }
+
     @Test("An empty write does not corrupt the stream")
     func testEmptyWrite() async throws {
-        let body = Response.Body(stream: { writer in
+        var body = Response.Body(stream: { writer in
             try await writer.write("")
             try await writer.write([UInt8]())
             try await writer.write("done")

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -1,4 +1,5 @@
 import Vapor
+import Crypto
 import VaporTesting
 import AsyncHTTPClient
 import NIOCore
@@ -534,6 +535,50 @@ struct StreamingBodyTests {
         }
         // The closure saw the chunk that was written before the throw.
         #expect(seen.withLockedValue { $0 } == 1)
+    }
+
+    @Test("reduceBytes folds a streaming body chunk by chunk")
+    func testReduceBytesOnStream() async throws {
+        let body = Response.Body(stream: { writer in
+            try await writer.write("alpha")
+            try await writer.write("beta")
+            try await writer.write("gamma")
+        })
+        // Chunk sizes prove the fold sees each chunk separately rather than one blob.
+        let sizes = try await body.reduceBytes(into: [Int]()) { acc, span in
+            acc.append(span.byteCount)
+        }
+        #expect(sizes == [5, 4, 5])
+    }
+
+    @Test("reduceBytes folds a buffered body in a single step")
+    func testReduceBytesOnBuffered() async throws {
+        let total = try await Response.Body(string: "hello").reduceBytes(into: 0) { acc, span in
+            acc += span.byteCount
+        }
+        #expect(total == 5)
+    }
+
+    @Test("reduceBytes returns the initial value for an empty body")
+    func testReduceBytesOnEmpty() async throws {
+        let total = try await Response.Body().reduceBytes(into: 42) { acc, span in
+            acc += span.byteCount
+        }
+        #expect(total == 42)
+    }
+
+    @Test("reduceBytes hashes a streaming body without buffering it")
+    func testReduceBytesHashing() async throws {
+        let chunks = ["alpha", "beta", "gamma"]
+        let body = Response.Body(stream: { writer in
+            for chunk in chunks { try await writer.write(chunk) }
+        })
+        let streamed = try await body.reduceBytes(into: SHA256()) { hasher, span in
+            span.withUnsafeBytes { unsafe hasher.update(bufferPointer: $0) }
+        }.finalize()
+        // Same digest as hashing the whole thing at once.
+        let expected = SHA256.hash(data: Data(chunks.joined().utf8))
+        #expect(Array(streamed) == Array(expected))
     }
 
     @Test("An empty write does not corrupt the stream")

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -481,6 +481,61 @@ struct StreamingBodyTests {
         #expect(collected.map { String(decoding: $0, as: UTF8.self) } == "abcdefg")
     }
 
+    @Test("withStreamingBytes delivers a streaming body chunk by chunk")
+    func testWithStreamingBytesOnStream() async throws {
+        let chunks = NIOLockedValueBox([String]())
+        let body = Response.Body(stream: { writer in
+            try await writer.write("alpha")
+            try await writer.write("beta")
+            try await writer.write("gamma")
+        })
+        try await body.withStreamingBytes { span in
+            var bytes = [UInt8]()
+            for i in 0..<span.byteCount { bytes.append(unsafe span.unsafeLoad(fromByteOffset: i, as: UInt8.self)) }
+            chunks.withLockedValue { $0.append(String(decoding: bytes, as: UTF8.self)) }
+        }
+        // Delivered separately and in order - not collected into one blob.
+        #expect(chunks.withLockedValue { $0 } == ["alpha", "beta", "gamma"])
+    }
+
+    @Test("withStreamingBytes hands a buffered body over as a single chunk")
+    func testWithStreamingBytesOnBuffered() async throws {
+        for body in [Response.Body(string: "hello"), Response.Body(data: Data("hello".utf8))] {
+            let chunks = NIOLockedValueBox([String]())
+            try await body.withStreamingBytes { span in
+                var bytes = [UInt8]()
+                for i in 0..<span.byteCount { bytes.append(unsafe span.unsafeLoad(fromByteOffset: i, as: UInt8.self)) }
+                chunks.withLockedValue { $0.append(String(decoding: bytes, as: UTF8.self)) }
+            }
+            #expect(chunks.withLockedValue { $0 } == ["hello"])
+        }
+    }
+
+    @Test("withStreamingBytes does not call the closure for an empty body")
+    func testWithStreamingBytesOnEmpty() async throws {
+        let calls = NIOLockedValueBox(0)
+        try await Response.Body().withStreamingBytes { _ in
+            calls.withLockedValue { $0 += 1 }
+        }
+        #expect(calls.withLockedValue { $0 } == 0)
+    }
+
+    @Test("withStreamingBytes propagates an error thrown mid-stream")
+    func testWithStreamingBytesPropagatesError() async throws {
+        let seen = NIOLockedValueBox(0)
+        let body = Response.Body(stream: { writer in
+            try await writer.write("first")
+            throw MidStreamError()
+        })
+        await #expect(throws: MidStreamError.self) {
+            try await body.withStreamingBytes { _ in
+                seen.withLockedValue { $0 += 1 }
+            }
+        }
+        // The closure saw the chunk that was written before the throw.
+        #expect(seen.withLockedValue { $0 } == 1)
+    }
+
     @Test("An empty write does not corrupt the stream")
     func testEmptyWrite() async throws {
         let body = Response.Body(stream: { writer in


### PR DESCRIPTION
Removes NIO from the `Response.Body` public API 🎉

This removes the `ByteBuffer` usage in favour of Data/String where it makes sense and streaming as a first class citizen with easier APIs to use so we no longer need it. Also removes `ByteBufferAllocator` since we're not creating `ByteBuffer`s anymore.

We still have an internal reprensentation which we need for the `ContentContainer` but I'll migrate that next in a separate PR as it touches Request as well.

Also provide `Span` helpers for consuming the streaming response body
