### PR TITLE
Small Optimisation

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -173,7 +173,14 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
 
     func write(_ bytes: some Sequence<UInt8>) async throws {
         var out = UniqueArray<UInt8>(minimumCapacity: bytes.underestimatedCount)
-        out.append(copying: bytes)
+        // Staging is synchronous, so the sequence's own storage can be borrowed rather than copied
+        // element by element; only the transport write is awaited, after the borrow has ended.
+        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
+            out.append(copying: buffer)
+        }
+        if borrowed == nil {
+            out.append(copying: bytes)
+        }
         // `write` drains `out`, so the count has to be taken first.
         let count = out.count
         try await self.inner?.write(buffer: &out)

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -368,7 +368,15 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
     /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying
     /// it into a `ContiguousArray` first, as the protocol's default implementation must.
     func write(_ bytes: some Sequence<UInt8>) async throws {
-        self.data.append(contentsOf: bytes)
+        // `Data.append(contentsOf:)` cannot reach a contiguous fast path here: the generic context
+        // has erased the concrete type, so it appends element by element. Recovering the buffer
+        // explicitly is what makes this cheaper than the protocol's default implementation.
+        let borrowed: Void? = bytes.withContiguousStorageIfAvailable { buffer in
+            unsafe self.data.append(contentsOf: buffer)
+        }
+        if borrowed == nil {
+            self.data.append(contentsOf: bytes)
+        }
         try self.checkLimit(adding: 0)
     }
 


### PR DESCRIPTION
We shouldn't need this but the compiler isn't picking the fast path (as shown by benchmarks). Potentially a Swift bug?
