### PR TITLE
One Responsy Body to rule them all

### DIFF
--- a/Performance/Sources/PerformanceServer/main.swift
+++ b/Performance/Sources/PerformanceServer/main.swift
@@ -32,7 +32,7 @@ app.get("bench", "large") { _ in large }
 app.get("bench", "json") { _ in json }
 
 app.get("bench", "stream") { _ -> Response in
-    Response(body: .init(stream: { writer in
+    Response(body: try .init(stream: { writer in
         for _ in 0..<16 {
             try await writer.write(chunk)
         }

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -1,5 +1,4 @@
 import Vapor
-import NIOConcurrencyHelpers
 import X509
 import Logging
 import SwiftASN1

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -256,18 +256,18 @@ func routes(_ app: Application) async throws {
     let asyncRoutes = app.grouped("async").grouped(TestMiddleware(number: 1))
     asyncRoutes.get("client") { req async throws -> String in
         let response = try await req.application.client.get("https://www.google.com")
-        guard let body = response.body else {
+        guard let bodyString = response.body.string else {
             throw Abort(.internalServerError)
         }
-        return String(buffer: body)
+        return bodyString
     }
 
     asyncRoutes.get("client2") { req -> String in
         let response = try await req.application.client.get("https://www.google.com")
-        guard let body = response.body else {
+        guard let bodyString = response.body.string else {
             throw Abort(.internalServerError)
         }
-        return String(buffer: body)
+        return bodyString
     }
 
     asyncRoutes.get("content") { req in

--- a/Sources/Vapor/Authentication/GuardMiddleware.swift
+++ b/Sources/Vapor/Authentication/GuardMiddleware.swift
@@ -1,4 +1,3 @@
-import NIOCore
 public import HTTPTypes
 
 extension Authenticatable {

--- a/Sources/Vapor/Authentication/RedirectMiddleware.swift
+++ b/Sources/Vapor/Authentication/RedirectMiddleware.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 extension Authenticatable {
     /// Basic middleware to redirect unauthenticated requests to the supplied path
     ///

--- a/Sources/Vapor/Authentication/SessionAuthenticatable.swift
+++ b/Sources/Vapor/Authentication/SessionAuthenticatable.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// Helper for creating authentication middleware in conjunction with `SessionsMiddleware`.
 public protocol SessionAuthenticator: RequestAuthenticator {
     associatedtype User: SessionAuthenticatable

--- a/Sources/Vapor/Cache/Cache.swift
+++ b/Sources/Vapor/Cache/Cache.swift
@@ -1,4 +1,3 @@
-import NIOCore
 /// Codable key-value pair cache.
 public protocol Cache: Sendable {
     /// Gets a decodable value from the cache. Returns `nil` if not found.

--- a/Sources/Vapor/Cache/MemoryCache.swift
+++ b/Sources/Vapor/Cache/MemoryCache.swift
@@ -3,7 +3,6 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
 import NIOConcurrencyHelpers
 
 private actor MemoryCacheStorage: Sendable {

--- a/Sources/Vapor/Client/BlackholeClient.swift
+++ b/Sources/Vapor/Client/BlackholeClient.swift
@@ -1,4 +1,3 @@
-import NIOCore
 import HTTPTypes
 
 /// Type that conforms to `Client` but does nothing and throws an error when used. Can be useful for testing

--- a/Sources/Vapor/Client/Client.swift
+++ b/Sources/Vapor/Client/Client.swift
@@ -1,4 +1,3 @@
-import NIOCore
 import Logging
 public import HTTPTypes
 

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -86,15 +86,6 @@ extension ClientRequest {
             try encoder.encode(content, to: &body, headers: &self.headers, userInfo: [:])
             self.body = body
         }
-
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            guard let body = self.body else {
-                throw Abort(.lengthRequired)
-            }
-            var decoded = try decoder.decode(C.self, from: body, headers: self.headers, userInfo: [:])
-            try decoded.afterDecode()
-            return decoded
-        }
     }
 
     public var content: any ContentContainer {

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -1,6 +1,3 @@
-#warning("Make this internal")
-public import NIOCore
-import NIOFoundationEssentialsCompat
 public import HTTPTypes
 #if canImport(FoundationEssentials)
 import FoundationEssentials
@@ -11,24 +8,25 @@ import Foundation
 public struct ClientResponse: Sendable {
     public var status: HTTPResponse.Status
     public var headers: HTTPFields
-    public var body: ByteBuffer?
-    private let byteBufferAllocator: ByteBufferAllocator
+    public var body: Response.Body {
+        didSet {
+            self.headers.updateContentLength(body.count)
+        }
+    }
     private let contentConfiguration: ContentConfiguration
 
-    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: ByteBuffer? = nil, contentConfiguration: ContentConfiguration = .default()) {
+    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: Response.Body, contentConfiguration: ContentConfiguration = .default()) {
         self.status = status
         self.headers = headers
         self.body = body
-        self.byteBufferAllocator = ByteBufferAllocator()
         self.contentConfiguration = contentConfiguration
     }
 }
 
 extension ClientResponse {
     private struct _ContentContainer: ContentContainer {
-        var body: Data?
+        var body: Response.Body
         var headers: HTTPFields
-        let allocator: ByteBufferAllocator
         let contentConfiguration: ContentConfiguration
 
         var contentType: HTTPMediaType? {
@@ -36,13 +34,13 @@ extension ClientResponse {
         }
 
         mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E : Encodable {
-            var body = Data()
-            try encoder.encode(encodable, to: &body, headers: &self.headers, userInfo: [:])
-            self.body = body
+            var data = Data()
+            try encoder.encode(encodable, to: &data, headers: &self.headers, userInfo: [:])
+            self.body = .init(data: data)
         }
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D : Decodable {
-            guard let body = self.body else {
+            guard let body = self.body.data else {
                 throw Abort(.lengthRequired)
             }
             return try decoder.decode(D.self, from: body, headers: self.headers, userInfo: [:])
@@ -53,11 +51,11 @@ extension ClientResponse {
             var content = content
             try content.beforeEncode()
             try encoder.encode(content, to: &body, headers: &self.headers, userInfo: [:])
-            self.body = body
+            self.body = .init(data: body)
         }
 
         func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            guard let body = self.body else {
+            guard let body = self.body.data else {
                 throw Abort(.lengthRequired)
             }
             var decoded = try decoder.decode(C.self, from: body, headers: self.headers, userInfo: [:])
@@ -68,11 +66,11 @@ extension ClientResponse {
 
     public var content: any ContentContainer {
         get {
-            _ContentContainer(body: body?.getData(at: 0, length: body?.readableBytes ?? 0), headers: self.headers, allocator: self.byteBufferAllocator, contentConfiguration: self.contentConfiguration)
+            _ContentContainer(body: self.body, headers: self.headers, contentConfiguration: self.contentConfiguration)
         }
         set {
             let container = (newValue as! _ContentContainer)
-            self.body = ByteBuffer(data: container.body ?? Data())
+            self.body = container.body
             self.headers = container.headers
         }
     }
@@ -82,9 +80,8 @@ extension ClientResponse: CustomStringConvertible {
     public var description: String {
         var desc = ["HTTP/1.1 \(status.code) \(status.reasonPhrase)"]
         desc += self.headers.map { "\($0.name): \($0.value)" }
-        if var body = self.body {
-            let string = body.readString(length: body.readableBytes) ?? ""
-            desc += ["", string]
+        if let body = self.body.string {
+            desc += ["", body]
         }
         return desc.joined(separator: "\n")
     }

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -54,15 +54,6 @@ extension ClientResponse {
             try encoder.encode(content, to: &body, headers: &self.headers, userInfo: [:])
             self.body = .init(data: body)
         }
-
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            guard let body = self.body.data else {
-                throw Abort(.lengthRequired)
-            }
-            var decoded = try decoder.decode(C.self, from: body, headers: self.headers, userInfo: [:])
-            try decoded.afterDecode()
-            return decoded
-        }
     }
 
     public var content: any ContentContainer {

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -14,11 +14,24 @@ public struct ClientResponse: Sendable {
         }
     }
     private let contentConfiguration: ContentConfiguration
+    /// The most bytes ``content`` will buffer when decoding a streaming body.
+    ///
+    /// A response arriving from somewhere else is not bounded by anything this process controls, so
+    /// collecting one has to have a ceiling. Streaming it with ``Response/Body/withStreamingBytes(_:)``
+    /// is not limited by this - only holding the whole thing in memory is.
+    public let maxBodySize: Int
 
-    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: Response.Body = .empty, contentConfiguration: ContentConfiguration = .default()) {
+    public init(
+        status: HTTPResponse.Status = .ok,
+        headers: HTTPFields = [:],
+        body: Response.Body = .empty,
+        maxBodySize: Int = 10 * 1024 * 1024, // Default to 10 MB, matching `ClientRequest`
+        contentConfiguration: ContentConfiguration = .default()
+    ) {
         self.status = status
         self.headers = headers
         self.body = body
+        self.maxBodySize = maxBodySize
         self.contentConfiguration = contentConfiguration
     }
 }
@@ -27,6 +40,7 @@ extension ClientResponse {
     private struct _ContentContainer: ContentContainer {
         var body: Response.Body
         var headers: HTTPFields
+        let maxBodySize: Int
         let contentConfiguration: ContentConfiguration
 
         var contentType: HTTPMediaType? {
@@ -41,7 +55,7 @@ extension ClientResponse {
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) async throws -> D where D : Decodable {
             var body = self.body
-            guard let data = try await body.collect() else {
+            guard let data = try await body.collect(max: self.maxBodySize) else {
                 throw Abort(.lengthRequired)
             }
             return try decoder.decode(D.self, from: data, headers: self.headers, userInfo: [:])
@@ -58,7 +72,7 @@ extension ClientResponse {
 
     public var content: any ContentContainer {
         get {
-            _ContentContainer(body: self.body, headers: self.headers, contentConfiguration: self.contentConfiguration)
+            _ContentContainer(body: self.body, headers: self.headers, maxBodySize: self.maxBodySize, contentConfiguration: self.contentConfiguration)
         }
         set {
             let container = (newValue as! _ContentContainer)
@@ -81,10 +95,16 @@ extension ClientResponse: CustomStringConvertible {
 
 extension ClientResponse: ResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
-        Response(
+        // Returning a client response from a handler is proxying, so the origin's connection-specific
+        // fields have to go: its `Connection: close` would close *our* client's connection, and its
+        // framing headers describe a hop this response is not travelling over. `Response.init` then
+        // sets the framing to match the body actually being sent.
+        var headers = self.headers
+        headers.removeHopByHopFields()
+        return Response(
             status: self.status,
-            headers: self.headers,
-            body: .empty,
+            headers: headers,
+            body: self.body,
             contentConfiguration: request.application.contentConfiguration
         )
     }

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -39,11 +39,12 @@ extension ClientResponse {
             self.body = .init(data: data)
         }
 
-        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D : Decodable {
-            guard let body = self.body.data else {
+        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) async throws -> D where D : Decodable {
+            var body = self.body
+            guard let data = try await body.collect() else {
                 throw Abort(.lengthRequired)
             }
-            return try decoder.decode(D.self, from: body, headers: self.headers, userInfo: [:])
+            return try decoder.decode(D.self, from: data, headers: self.headers, userInfo: [:])
         }
 
         mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C : Content {

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -97,9 +97,3 @@ extension ClientResponse: ResponseEncodable {
         )
     }
 }
-
-extension ClientResponse: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.status == rhs.status && lhs.headers == rhs.headers && lhs.body == rhs.body
-    }
-}

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -15,7 +15,7 @@ public struct ClientResponse: Sendable {
     }
     private let contentConfiguration: ContentConfiguration
 
-    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: Response.Body, contentConfiguration: ContentConfiguration = .default()) {
+    public init(status: HTTPResponse.Status = .ok, headers: HTTPFields = [:], body: Response.Body = .empty, contentConfiguration: ContentConfiguration = .default()) {
         self.status = status
         self.headers = headers
         self.body = body

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// Convertible to / from content in an HTTP message.
 ///
 /// Conformance to this protocol consists of:

--- a/Sources/Vapor/Content/ContentCoders.swift
+++ b/Sources/Vapor/Content/ContentCoders.swift
@@ -3,7 +3,6 @@ public import FoundationEssentials
 #else
 public import Foundation
 #endif
-import NIOCore
 public import HTTPTypes
 
 /// Conform a type to this protocol to make it usable for encoding data via Vapor's ``ContentConfiguration`` system.

--- a/Sources/Vapor/Content/ContentConfiguration.swift
+++ b/Sources/Vapor/Content/ContentConfiguration.swift
@@ -6,7 +6,6 @@ import Foundation
 #if Multipart
 import MultipartKit
 #endif
-import NIOConcurrencyHelpers
 import HTTPTypes
 
 /// Configures which ``Encoder``s and ``Decoder``s to use when interacting with data in HTTP messages.

--- a/Sources/Vapor/Content/ContentContainer.swift
+++ b/Sources/Vapor/Content/ContentContainer.swift
@@ -47,6 +47,20 @@ extension ContentContainer {
         try await self.decode(D.self, using: self.configuredDecoder(for: contentType))
     }
 
+    /// Use the default configured decoder for the ``contentType`` parameter to read a value
+    /// of type `C` from the container.
+    ///
+    /// This overload exists so that passing an explicit content type still runs
+    /// ``Content/afterDecode()``. Without it a ``Content`` type binds to the `Decodable` overload
+    /// above, which cannot know to call the hook, and the type is silently returned unprocessed.
+    ///
+    /// - Note: The ``Content/defaultContentType-9sljl`` of `C` is ignored.
+    public func decode<C: Content>(_: C.Type, as contentType: HTTPMediaType) async throws -> C {
+        var content = try await self.decode(C.self, using: self.configuredDecoder(for: contentType))
+        try content.afterDecode()
+        return content
+    }
+
     // MARK: - Encoding helpers
 
     /// Serialize a ``Content`` object to the container as its default content type.

--- a/Sources/Vapor/Content/JSONCoders+Content.swift
+++ b/Sources/Vapor/Content/JSONCoders+Content.swift
@@ -4,7 +4,6 @@ public import FoundationEssentials
 public import Foundation
 #endif
 public import HTTPTypes
-import NIOFoundationEssentialsCompat
 
 extension JSONEncoder: ContentEncoder {
     public func encode(_ encodable: some Encodable, to body: inout Data, headers: inout HTTPFields, userInfo: [CodingUserInfoKey : any Sendable]) throws {

--- a/Sources/Vapor/Content/URLQueryContainer.swift
+++ b/Sources/Vapor/Content/URLQueryContainer.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// Helper for encoding and decoding data from an HTTP request query string.
 ///
 /// See ``Request/query`` for more information.

--- a/Sources/Vapor/HTTP/BasicResponder.swift
+++ b/Sources/Vapor/HTTP/BasicResponder.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// A basic, async closure-based `Responder`.
 public struct BasicResponder: Responder {
     /// The stored responder closure.

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -31,14 +31,29 @@ internal struct VaporHTTPClient: Client {
             request,
             deadline: .now() + clientRequest.timeout,
             logger: Logger.current)
+        // Wrapping AHC's body ourselves means losing its `collect(upTo:)` size check, so the declared
+        // length is rejected here instead - before a byte is read, as AHC did.
+        let declaredLength = response.headers.first(name: "content-length").flatMap(Int.init)
+        if let declaredLength, declaredLength > clientRequest.maxResponseBodySize {
+            Logger.current.debug(
+                "Response body is larger than the configured maximum",
+                metadata: [
+                    "declared": "\(declaredLength)",
+                    "maximum": "\(clientRequest.maxResponseBodySize)",
+                ])
+            throw Abort(.contentTooLarge)
+        }
         return ClientResponse(
             status: .init(code: Int(response.status.code)),
             headers: .init(response.headers, splitCookie: false),
-            body: .init(stream: { writer in
+            // Declaring the length lets a proxied response keep its `Content-Length` instead of
+            // being re-framed as chunked. `nil` when the origin did not say.
+            body: try .init(stream: { writer in
                 for try await chunk in response.body {
                     try await writer.write(chunk.readableBytesSpan)
                 }
-            }),
+            }, count: declaredLength),
+            maxBodySize: clientRequest.maxResponseBodySize,
             contentConfiguration: self.contentConfiguration
         )
     }

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -31,10 +31,14 @@ internal struct VaporHTTPClient: Client {
             request,
             deadline: .now() + clientRequest.timeout,
             logger: Logger.current)
-        return try await ClientResponse(
+        return ClientResponse(
             status: .init(code: Int(response.status.code)),
             headers: .init(response.headers, splitCookie: false),
-            body: response.body.collect(upTo: clientRequest.maxResponseBodySize),
+            body: .init(stream: { writer in
+                for try await chunk in response.body {
+                    try await writer.write(chunk.readableBytesSpan)
+                }
+            }),
             contentConfiguration: self.contentConfiguration
         )
     }

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -3,8 +3,6 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOConcurrencyHelpers
-import NIOCore
 import Logging
 public import HTTPTypes
 

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+Connection.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+Connection.swift
@@ -29,3 +29,45 @@ extension HTTPFields {
         }
     }
 }
+
+extension HTTPFields {
+    /// The connection-specific fields an intermediary must not forward.
+    ///
+    /// RFC 9110 §7.6.1. These describe the single hop they arrived on, not the message, so passing
+    /// them along makes an origin server's framing and connection decisions look like our own.
+    private static let hopByHopFieldNames: [HTTPField.Name] = [
+        .connection,
+        .transferEncoding,
+        .trailer,
+        .upgrade,
+        .proxyAuthenticate,
+        .proxyAuthorization,
+        // Not among the `HTTPField.Name` constants, but valid tokens, so these never fail.
+        HTTPField.Name("Keep-Alive")!,
+        HTTPField.Name("TE")!,
+    ]
+
+    /// Removes the fields that belong to a single connection rather than to the message.
+    ///
+    /// Call this before forwarding a response received from somewhere else - proxying a
+    /// ``ClientResponse``, say. Without it an origin server's `Connection: close` would close *our*
+    /// client's connection, and its `Upgrade` would advertise a protocol switch this server never
+    /// agreed to.
+    ///
+    /// `Connection` itself names further fields that are hop-by-hop for that hop, so those are
+    /// removed too.
+    public mutating func removeHopByHopFields() {
+        // Read before `Connection` is itself removed below.
+        if let connection = self[.connection] {
+            for name in connection.split(separator: ",") {
+                let trimmed = name.drop(while: \.isWhitespace).reversed().drop(while: \.isWhitespace).reversed()
+                if let field = HTTPField.Name(String(trimmed)) {
+                    self[field] = nil
+                }
+            }
+        }
+        for name in Self.hopByHopFieldNames {
+            self[name] = nil
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
+++ b/Sources/Vapor/HTTP/Server/Application+HTTP+Server.swift
@@ -1,5 +1,3 @@
-import NIOCore
-import NIOConcurrencyHelpers
 import Logging
 
 extension Application.Servers.Provider {

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -108,7 +108,10 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
             }
 
             switch vaporResponse.body.storage {
-            case .stream(let bodyStream):
+            // A stream some copy of this body already collected is spent: its bytes live in the
+            // body's shared cache, so it is serialised down the buffered path below instead of by
+            // re-running a callback that would now write nothing.
+            case .stream(let bodyStream) where bodyStream.state.collected == nil:
                 // Streaming body: send the head, then let the body closure write chunks straight
                 // into the server's writer. The writer is non-Sendable (it wraps the server's
                 // move-only response writer), so it stays in this task; each `write` awaits the

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -119,13 +119,13 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 // final chunk via `finish` once the closure returns.
                 let writer = NIOResponseBodyWriter(inner: try await sender.send(httpResponse))
                 try await bodyStream.callback(writer)
-                guard bodyStream.count < 0 || writer.bytesWritten == bodyStream.count else {
-                    // Stream lenght is different to what was expecting, this is an error state to close the connection
+                guard bodyStream.count == nil || writer.bytesWritten == bodyStream.count else {
+                    // Stream length differs from what was declared: an error state, so close the connection
                     Logger.current.debug(
                         "Response body stream wrote a different number of bytes than it declared, closing the connection",
                         metadata: [
                             "written": "\(writer.bytesWritten)",
-                            "declared": "\(bodyStream.count)",
+                            "declared": "\(bodyStream.count.map(String.init) ?? "unknown")",
                         ])
                     return
                 }
@@ -134,7 +134,7 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 // Buffered body: single-shot write. Borrowing the body's bytes copies them straight
                 // into the server's container - a `.string`/`.data`/`.staticString` body is no
                 // longer materialised into an intermediate `ByteBuffer` first.
-                var responseBody = UniqueArray<UInt8>(minimumCapacity: vaporResponse.body.count)
+                var responseBody = UniqueArray<UInt8>(minimumCapacity: vaporResponse.body.count ?? 0)
                 try await vaporResponse.body.withStreamingBytes { bytes in
                     bytes.withUnsafeBytes { unsafe responseBody.append(copying: $0) }
                 }

--- a/Sources/Vapor/Middleware/CORSMiddleware.swift
+++ b/Sources/Vapor/Middleware/CORSMiddleware.swift
@@ -1,6 +1,4 @@
-import NIOCore
 public import HTTPTypes
-import NIOConcurrencyHelpers
 
 /// Middleware that adds support for CORS settings in request responses.
 /// For configuration of this middleware please use the `CORSMiddleware.Configuration` object.

--- a/Sources/Vapor/Middleware/MetricsMiddleware.swift
+++ b/Sources/Vapor/Middleware/MetricsMiddleware.swift
@@ -107,23 +107,29 @@ public final class MetricsMiddleware: Middleware {
             
             // http.server.response.body.size
             // https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverresponsebodysize
-            Recorder(
-                label: "http.server.response.body.size",
-                dimensions: [
-                    // Required
-                    ("http.request.method", httpRequestMethod),
-                    ("url.scheme", urlScheme),
+            //
+            // Only recorded when the size is actually known. A streaming body of undeclared length
+            // has no size until something reads it, and this middleware must not read it - recording
+            // a placeholder would put a bogus sample in the histogram.
+            if let bodySize = response.body.count {
+                Recorder(
+                    label: "http.server.response.body.size",
+                    dimensions: [
+                        // Required
+                        ("http.request.method", httpRequestMethod),
+                        ("url.scheme", urlScheme),
                     
-                    // Conditionally Required
-                    ("error.type", errorType),
-                    ("http.response.status_code", httpResponseStatusCode),
-                    ("http.route", httpRoute),
-                    ("network.protocol.name", networkProtocolName),
+                        // Conditionally Required
+                        ("error.type", errorType),
+                        ("http.response.status_code", httpResponseStatusCode),
+                        ("http.route", httpRoute),
+                        ("network.protocol.name", networkProtocolName),
                     
-                    // Recommended
-                    ("network.protocol.version", networkProtocolVersion),
-                ]
-            ).record(response.body.count)
+                        // Recommended
+                        ("network.protocol.version", networkProtocolVersion),
+                    ]
+                ).record(bodySize)
+            }
             return response
         }
     }

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// `Middleware` is placed between the server and your router. It is capable of
 /// mutating both incoming requests and outgoing responses. `Middleware` can choose
 /// to pass requests on to the next `Middleware` in a chain, or they can short circuit and

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -1,8 +1,7 @@
 import HTTPTypes
 public import Tracing
-import NIOConcurrencyHelpers
 import NIOCore
-import NIOHTTP1
+import NIOConcurrencyHelpers
 
 /// Creates a trace and metadata for every request
 ///

--- a/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
+++ b/Sources/Vapor/Multipart/FormDataDecoder+Content.swift
@@ -6,7 +6,6 @@ public import Foundation
 #endif
 public import MultipartKit
 public import HTTPTypes
-import NIOCore
 
 extension FormDataDecoder: ContentDecoder {
     public func decode<D>(_ decodable: D.Type, from body: Data, headers: HTTPFields, userInfo: [CodingUserInfoKey : any Sendable]) throws -> D where D : Decodable {

--- a/Sources/Vapor/Request/Redirect.swift
+++ b/Sources/Vapor/Request/Redirect.swift
@@ -1,5 +1,4 @@
 public import HTTPTypes
-import NIOConcurrencyHelpers
 
 extension Request {
 

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -152,17 +152,6 @@ public final class Request: CustomStringConvertible, Sendable {
             let byteBuffer = ByteBuffer(data: body)
             self.request.bodyStorage.withLockedValue { $0 = .collected(byteBuffer) }
         }
-
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            guard let body = self.request.body.data else {
-                Logger.current.debug("Request body is empty. If you're trying to stream the body, decoding streaming bodies not supported")
-                throw Abort(.unprocessableContent)
-            }
-            let bodyData = body.getData(at: 0, length: body.readableBytes) ?? Data()
-            var decoded = try decoder.decode(C.self, from: bodyData, headers: self.request.headers, userInfo: [:])
-            try decoded.afterDecode()
-            return decoded
-        }
     }
 
     /// This container is used to read your `Decodable` type using a `ContentDecoder` implementation.

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -5,7 +5,6 @@ import Foundation
 #endif
 public import HTTPTypes
 public import Logging
-import NIOCore
 import RoutingKit
 
 /// Vapor's main ``Responder`` type. Combines configured middleware + router to create a responder.

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -3,7 +3,7 @@ public import FoundationEssentials
 #else
 public import Foundation
 #endif
-import HTTPTypes
+public import HTTPTypes
 import Synchronization
 
 extension Response {
@@ -22,7 +22,8 @@ extension Response {
     }
 
     struct BodyStream: Sendable {
-        let count: Int
+        /// The number of bytes the stream will produce, or `nil` if that is not known in advance.
+        let count: Int?
         let callback: @Sendable (any ResponseBodyWriter) async throws -> ()
         let state = BodyStreamState()
     }
@@ -126,11 +127,14 @@ extension Response {
             }
         }
 
-        /// The size of the HTTP body's data.
-        /// `-1` is a chunked stream whose length is unknown. If the stream has already been collected,
-        /// then the correct length will be reported - including when another copy of the body collected
-        /// it. Collect one with ``collect(max:)``, ``data(max:)`` or ``string(max:)``.
-        public var count: Int {
+        /// The size of the HTTP body's data, or `nil` if it is not known.
+        ///
+        /// Only a chunked stream is unknown, and only until something reads it: once collected the
+        /// real length is reported, including when another copy of the body did the collecting.
+        /// Collect one with ``collect(max:)``, ``data(max:)`` or ``string(max:)``.
+        ///
+        /// An empty body is `0`, not `nil` - its length is known, and it is zero.
+        public var count: Int? {
             switch self.storage {
             case .data(let data): return data.count
             case .staticString(let staticString): return staticString.utf8CodeUnitCount
@@ -212,10 +216,10 @@ extension Response {
                     self.storage = .data(collected)
                     return collected
                 }
-                if let max, stream.count > max {
+                if let max, let declared = stream.count, declared > max {
                     throw Abort(.contentTooLarge)
                 }
-                let initialCapacity = stream.count >= 0 ? stream.count : 0
+                let initialCapacity = stream.count ?? 0
                 let writer = CollectingBodyWriter(capacity: initialCapacity, max: max)
                 try await stream.callback(writer)
                 stream.state.store(writer.data)
@@ -267,9 +271,37 @@ extension Response {
         ///
         /// - Parameters:
         ///   - stream: The closure that writes the body chunks.
-        ///   - count: The number of bytes that will be written. The `stream` **MUST** produce exactly `count` bytes.
-        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), count: Int) {
+        ///   - count: The number of bytes that will be written. The `stream` **MUST** produce exactly
+        ///     `count` bytes. `nil` means the length is not known in advance, and the response is chunked.
+        /// - Throws: ``Response/Body/NegativeCountError`` if `count` is negative.
+        public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> (), count: Int?) throws {
+            // A negative length is not a shorter body, it is an impossible one. Left unchecked it
+            // reaches the wire as a malformed `Content-Length`, so it is rejected at the one point a
+            // bad value can enter. Thrown rather than trapped: a mistake in one handler must not
+            // take down a server that is serving everything else correctly.
+            if let count, count < 0 {
+                throw NegativeCountError(count: count)
+            }
             self.storage = .stream(.init(count: count, callback: stream))
+        }
+
+        /// Thrown when a streaming body is created with a negative length.
+        ///
+        /// Conforms to ``AbortError``, so a handler that lets it propagate fails that one request
+        /// with a `500` and a diagnosable reason rather than bringing the process down.
+        public struct NegativeCountError: Error, Equatable, AbortError, CustomStringConvertible {
+            /// The negative length that was given.
+            public let count: Int
+
+            public init(count: Int) {
+                self.count = count
+            }
+
+            public var status: HTTPResponse.Status { .internalServerError }
+            public var reason: String {
+                "A streaming response body cannot declare a negative length (got \(count)). Pass `nil` when the length is not known in advance."
+            }
+            public var description: String { self.reason }
         }
 
         /// Creates a chunked, streaming HTTP ``Response`` body of unknown length.
@@ -279,7 +311,8 @@ extension Response {
         /// - Parameters:
         ///   - stream: The closure that writes the body chunks.
         public init(stream: @escaping @Sendable (any ResponseBodyWriter) async throws -> ()) {
-            self.init(stream: stream, count: -1)
+            // `nil` can never be rejected, so this stays non-throwing.
+            self.storage = .stream(.init(count: nil, callback: stream))
         }
 
         /// `ExpressibleByStringLiteral` conformance.

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -113,6 +113,9 @@ extension Response {
             return accumulator.value
         }
 
+        /// The body decoded as UTF-8, or `nil` if it is empty or is a stream nothing has collected.
+        ///
+        /// Use ``string(max:)`` to collect the body and always return a string
         public var string: String? {
             switch self.storage {
             case .data(let data): return String(decoding: data, as: UTF8.self)
@@ -124,8 +127,9 @@ extension Response {
         }
 
         /// The size of the HTTP body's data.
-        /// `-1` is a chunked stream whose lenght it unknown. If the stream has already been collected, then the correct length
-        /// will be reported
+        /// `-1` is a chunked stream whose length is unknown. If the stream has already been collected,
+        /// then the correct length will be reported - including when another copy of the body collected
+        /// it. Collect one with ``collect(max:)``, ``data(max:)`` or ``string(max:)``.
         public var count: Int {
             switch self.storage {
             case .data(let data): return data.count
@@ -136,7 +140,9 @@ extension Response {
             }
         }
 
-        /// Returns static data if not streaming.
+        /// The body's bytes, or `nil` if it is empty or is a stream nothing has collected.
+        ///
+        /// Use ``data(max:)`` to collect the body and always return ``Foundation/Data``
         public var data: Data? {
             switch self.storage {
             case .data(let data): return data
@@ -145,6 +151,36 @@ extension Response {
             case .none: return nil
             case .stream(let stream): return stream.state.collected
             }
+        }
+
+        /// The body's bytes, collecting a streaming body first if nothing has collected it yet.
+        ///
+        /// The collecting counterpart to ``data``, for where the body may or may not be a stream and
+        /// the bytes are genuinely needed - a client response, say. An already-collected or buffered
+        /// body is returned without re-reading anything.
+        /// 
+        /// - Parameter max: The most bytes to buffer, as ``collect(max:)``. `nil` buffers whatever
+        ///   the body produces.
+        /// - Returns: The body's bytes, or `nil` if the body is empty.
+        /// - Throws: ``Abort`` with `.contentTooLarge` if a streaming body exceeds `max`.
+        public func data(max: Int? = nil) async throws -> Data? {
+            // Collecting through a copy: `collect(max:)` is `mutating`, but the bytes it produces
+            // land in the stream's shared state, so the caller's body sees them regardless.
+            var body = self
+            return try await body.collect(max: max)
+        }
+
+        /// The body decoded as UTF-8, collecting a streaming body first if nothing has collected it yet.
+        ///
+        /// The collecting counterpart to ``string``. See ``data(max:)`` for the semantics; this
+        /// decodes the result, substituting U+FFFD for any invalid UTF-8 rather than failing.
+        ///
+        /// - Parameter max: The most bytes to buffer, as ``collect(max:)``. `nil` buffers whatever
+        ///   the body produces.
+        /// - Returns: The body decoded as UTF-8, or `nil` if the body is empty.
+        /// - Throws: ``Abort`` with `.contentTooLarge` if a streaming body exceeds `max`.
+        public func string(max: Int? = nil) async throws -> String? {
+            try await self.data(max: max).map { String(decoding: $0, as: UTF8.self) }
         }
 
         /// Reads the whole body into memory, running a streaming body to completion.

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -4,11 +4,27 @@ public import FoundationEssentials
 public import Foundation
 #endif
 import HTTPTypes
+import Synchronization
 
 extension Response {
-    struct BodyStream {
+    /// Shared consumption state for a streaming body, this ensures it's only called once and can be shared amongst copies
+    final class BodyStreamState: Sendable {
+        private let cache = Mutex<Data?>(nil)
+
+        /// The bytes this stream produced, or `nil` if it has not been collected yet.
+        var collected: Data? {
+            self.cache.withLock { $0 }
+        }
+
+        func store(_ data: Data) {
+            self.cache.withLock { $0 = data }
+        }
+    }
+
+    struct BodyStream: Sendable {
         let count: Int
         let callback: @Sendable (any ResponseBodyWriter) async throws -> ()
+        let state = BodyStreamState()
     }
 
     /// Represents a `Response`'s body.
@@ -48,7 +64,12 @@ extension Response {
         public func withStreamingBytes(_ body: @escaping (RawSpan) async throws -> Void) async throws {
             switch self.storage {
             case .stream(let stream):
-                try await stream.callback(ForwardingBodyWriter(body))
+                // See if we're already collection so we don't run again
+                if let collected = stream.state.collected {
+                    try await body(collected.span.bytes)
+                } else {
+                    try await stream.callback(ForwardingBodyWriter(body))
+                }
             case .none:
                 return
             case .data(let data):
@@ -97,19 +118,21 @@ extension Response {
             case .data(let data): return String(decoding: data, as: UTF8.self)
             case .staticString(let staticString): return staticString.description
             case .string(let string): return string
-            default: return nil
+            case .none: return nil
+            case .stream(let stream): return stream.state.collected.map { String(decoding: $0, as: UTF8.self) }
             }
         }
 
         /// The size of the HTTP body's data.
-        /// `-1` is a chunked stream.
+        /// `-1` is a chunked stream whose lenght it unknown. If the stream has already been collected, then the correct length
+        /// will be reported
         public var count: Int {
             switch self.storage {
             case .data(let data): return data.count
             case .staticString(let staticString): return staticString.utf8CodeUnitCount
             case .string(let string): return string.utf8.count
             case .none: return 0
-            case .stream(let stream): return stream.count
+            case .stream(let stream): return stream.state.collected?.count ?? stream.count
             }
         }
 
@@ -120,7 +143,7 @@ extension Response {
             case .staticString(let staticString): return unsafe Data(bytes: staticString.utf8Start, count: staticString.utf8CodeUnitCount)
             case .string(let string): return Data(string.utf8)
             case .none: return nil
-            case .stream: return nil
+            case .stream(let stream): return stream.state.collected
             }
         }
 
@@ -132,15 +155,34 @@ extension Response {
         /// result means anything further down the chain, including the server that serialises the
         /// response, sees an ordinary in-memory body instead.
         ///
+        /// The bytes are also cached in state shared with every *copy* of this body, so collecting
+        /// through one copy is visible from the others. That matters where the collection cannot be
+        /// written back - a `ContentContainer` reached through a computed `content` property holds a
+        /// copy, so without the shared cache decoding a streaming body would drain it and leave the
+        /// original pointing at a spent stream.
+        ///
+        /// Use ``withStreamingBytes(_:)`` instead when the whole body is not genuinely needed in memory.
+        ///
+        /// - Parameter max: The most bytes to buffer. A stream that produces more fails with
+        ///   ``Abort`` `.contentTooLarge` rather than growing without bound - a body arriving from
+        ///   somewhere else, such as a client response, is not bounded by anything this process
+        ///   controls. `nil`, the default, buffers whatever the body produces.
         /// - Returns: The body's bytes, or `nil` if the body is empty.
-        public mutating func collect() async throws -> Data? {
+        /// - Throws: ``Abort`` with `.contentTooLarge` if a streaming body exceeds `max`.
+        public mutating func collect(max: Int? = nil) async throws -> Data? {
             switch self.storage {
             case .stream(let stream):
-                // Reserve the declared length up front when known (`count >= 0`) to avoid repeated
-                // grow-and-copy reallocations; `-1` means unknown/chunked, so start empty.
+                if let collected = stream.state.collected {
+                    self.storage = .data(collected)
+                    return collected
+                }
+                if let max, stream.count > max {
+                    throw Abort(.contentTooLarge)
+                }
                 let initialCapacity = stream.count >= 0 ? stream.count : 0
-                let writer = CollectingBodyWriter(capacity: initialCapacity)
+                let writer = CollectingBodyWriter(capacity: initialCapacity, max: max)
                 try await stream.callback(writer)
+                stream.state.store(writer.data)
                 self.storage = .data(writer.data)
                 return writer.data
             default:
@@ -240,21 +282,31 @@ private final class ForwardingBodyWriter: ResponseBodyWriter {
 
 /// A ``ResponseBodyWriter`` that accumulates everything written into `Data`, used to
 /// eagerly collect a streaming body instead of forwarding it to the connection.
-private final class CollectingBodyWriter: ResponseBodyWriter {    
+private final class CollectingBodyWriter: ResponseBodyWriter {
     var data: Data
+    let max: Int?
 
-    init(capacity: Int) {
+    init(capacity: Int, max: Int?) {
         self.data = Data(capacity: capacity)
+        self.max = max
     }
 
     func write(_ bytes: RawSpan) async throws {
+        try self.checkLimit(adding: bytes.byteCount)
         bytes.withUnsafeBytes { self.data.append(contentsOf: $0) }
     }
 
     /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying
     /// it into a `ContiguousArray` first, as the protocol's default implementation must.
     func write(_ bytes: some Sequence<UInt8>) async throws {
-        // `Data.append(contentsOf:)` already takes the contiguous fast path internally
         self.data.append(contentsOf: bytes)
+        try self.checkLimit(adding: 0)
+    }
+
+    private func checkLimit(adding count: Int) throws {
+        guard let max else { return }
+        guard self.data.count + count <= max else {
+            throw Abort(.contentTooLarge)
+        }
     }
 }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -155,19 +155,19 @@ public struct Response: CustomStringConvertible, Sendable {
 
 
 extension HTTPFields {
-    mutating func updateContentLength(_ contentLength: Int) {
-        let count = contentLength.description
-        switch contentLength {
-        case -1:
+    mutating func updateContentLength(_ contentLength: Int?) {
+        guard let contentLength else {
+            // Length not known in advance, so the body has to be chunked.
             self[.contentLength] = nil
             if "chunked" != self[.transferEncoding] {
                 self[.transferEncoding] = "chunked"
             }
-        default:
-            self[.transferEncoding] = nil
-            if count != self[.contentLength] {
-                self[.contentLength] = count
-            }
+            return
+        }
+        self[.transferEncoding] = nil
+        let count = contentLength.description
+        if count != self[.contentLength] {
+            self[.contentLength] = count
         }
     }
 }

--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -95,15 +95,6 @@ public struct Response: CustomStringConvertible, Sendable {
             try encoder.encode(content, to: &body, headers: &self.response.headers, userInfo: [:])
             self.response.body = .init(data: body)
         }
-
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C: Content {
-            guard let body = self.response.body.data else {
-                throw Abort(.unprocessableContent)
-            }
-            var decoded = try decoder.decode(C.self, from: body, headers: self.response.headers, userInfo: [:])
-            try decoded.afterDecode()
-            return decoded
-        }
     }
 
     public var content: any ContentContainer {

--- a/Sources/Vapor/Sessions/MemorySessions.swift
+++ b/Sources/Vapor/Sessions/MemorySessions.swift
@@ -3,8 +3,6 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOCore
-import NIOConcurrencyHelpers
 
 /// Simple in-memory sessions implementation.
 public struct MemorySessions: SessionDriver, Sendable {

--- a/Sources/Vapor/Sessions/SessionDriver.swift
+++ b/Sources/Vapor/Sessions/SessionDriver.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// Capable of managing CRUD operations for `Session`s.
 public protocol SessionDriver: Sendable {
     func createSession(

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -1,4 +1,3 @@
-import NIOCore
 import NIOConcurrencyHelpers
 
 /// Uses HTTP cookies to save and restore sessions for connecting clients.

--- a/Sources/Vapor/Utilities/AnyResponse.swift
+++ b/Sources/Vapor/Utilities/AnyResponse.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 /// A type erased response useful for routes that can return more than one type.
 ///
 ///     router.get("foo") { req -> AnyResponse in

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -273,7 +273,7 @@ public struct FileIO: Sendable {
 
         let fileSystem = self.fileSystem
         var response = Response(status: responseStatus, headers: headers)
-        response.body = .init(stream: { writer in
+        response.body = try .init(stream: { writer in
             // The scoped `withFileHandle` API would close the handle for us, but its `execute`
             // parameter is `@concurrent` from here (Vapor builds with `NonisolatedNonsendingByDefault`,
             // NIO doesn't), so the closure would have to be sent — and it captures the non-Sendable

--- a/Sources/Vapor/Validation/Validators/Range.swift
+++ b/Sources/Vapor/Validation/Validators/Range.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 extension Validator where T: Comparable & Strideable {
     /// Validates that the data is within the supplied `Range`.
     public static func range(_ range: Swift.Range<T>) -> Validator<T> {

--- a/Sources/Vapor/View/PlaintextRenderer.swift
+++ b/Sources/Vapor/View/PlaintextRenderer.swift
@@ -1,5 +1,4 @@
 import NIOCore
-import NIOPosix
 import Logging
 import _NIOFileSystem
 

--- a/Sources/Vapor/View/ViewRenderer.swift
+++ b/Sources/Vapor/View/ViewRenderer.swift
@@ -1,5 +1,3 @@
-import NIOCore
-
 public protocol ViewRenderer: Sendable {
     func `for`(_ request: Request) -> any ViewRenderer
     func render(_ name: String, _ context: some Encodable) async throws -> View

--- a/Sources/VaporTesting/+TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/+TestingHTTPResponse.swift
@@ -5,6 +5,7 @@ import Foundation
 #endif
 public import Testing
 public import Vapor
+import HTTPTypes
 
 public func expectContent<D>(
     _ type: D.Type,
@@ -12,7 +13,7 @@ public func expectContent<D>(
     contentConfiguration: ContentConfiguration = .default(),
     sourceLocation: SourceLocation = #_sourceLocation,
     _ closure: (D) throws -> ()
-) rethrows where D: Decodable {
+) async rethrows where D: Decodable {
     guard let contentType = res.headers.contentType else {
         Issue.record("response does not contain content type", sourceLocation: sourceLocation)
         return
@@ -22,7 +23,11 @@ public func expectContent<D>(
 
     do {
         let decoder = try contentConfiguration.requireDecoder(for: contentType)
-        content = try decoder.decode(D.self, from: res.body, headers: res.headers, userInfo: [:])
+        var body = res.body
+        guard let data = try await body.collect() else {
+            throw Abort(.lengthRequired)
+        }
+        content = try decoder.decode(D.self, from: data, headers: res.headers, userInfo: [:])
     } catch {
         Issue.record("could not decode body: \(error)", sourceLocation: sourceLocation)
         return

--- a/Sources/VaporTesting/TaskLocalMetricsSystem.swift
+++ b/Sources/VaporTesting/TaskLocalMetricsSystem.swift
@@ -4,7 +4,6 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import NIOConcurrencyHelpers
 public import MetricsTestKit
 public import Testing
 

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -71,11 +71,11 @@ extension Application {
                 return TestingHTTPResponse(
                     status: .init(code: Int(response.status.code)),
                     headers: .init(response.headers, splitCookie: false),
-                    body: .init(stream: { writer in
+                    body: try await request.responseBodyCollection.apply(to: .init(stream: { writer in
                         for try await chunk in response.body {
                             try await writer.write(chunk.readableBytesView)
                         }
-                    }),
+                    })),
                     contentConfiguration: self.app.contentConfiguration
                 )
             } catch {
@@ -99,6 +99,8 @@ extension Application {
         }
 
         package func makeRequest(_ request: TestingHTTPRequest) async throws -> TestingHTTPResponse {
+            // Captured before `request` is shadowed by the `Request` built below.
+            let collection = request.responseBodyCollection
             var headers = request.headers
             headers[.contentLength] = request.body.readableBytes.description
             let request = Request(
@@ -120,7 +122,7 @@ extension Application {
             return TestingHTTPResponse(
                 status: res.status,
                 headers: res.headers,
-                body: res.body,
+                body: try await collection.apply(to: res.body),
                 contentConfiguration: self.app.contentConfiguration
             )
         }
@@ -131,4 +133,22 @@ package enum TestErrors: Error {
     case portNotSet
     case missingPort
     case missingHostname
+}
+
+
+extension ResponseBodyCollection {
+    /// Resolves a response body according to this policy.
+    ///
+    /// `.collect` reads it up front, so the body handed to a test is an ordinary in-memory one and
+    /// the request completes rather than being cancelled when nothing reads it. `.stream` hands it
+    /// over untouched.
+    func apply(to body: Response.Body) async throws -> Response.Body {
+        switch self {
+        case .stream:
+            return body
+        case .collect(let max):
+            var body = body
+            return .init(data: try await body.collect(max: max) ?? Data())
+        }
+    }
 }

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -68,13 +68,14 @@ extension Application {
                 clientRequest.headers = .init(request.headers)
                 clientRequest.body = .bytes(request.body)
                 let response = try await client.execute(clientRequest, timeout: .seconds(30))
-                // Collect up to 1MB
-                let responseBody = try await response.body.collect(upTo: 1024 * 1024)
-                let responseBodyData = responseBody.getData(at: 0, length: responseBody.readableBytes) ?? Data()
                 return TestingHTTPResponse(
                     status: .init(code: Int(response.status.code)),
                     headers: .init(response.headers, splitCookie: false),
-                    body: responseBodyData,
+                    body: .init(stream: { writer in
+                        for try await chunk in response.body {
+                            try await writer.write(chunk.readableBytesView)
+                        }
+                    }),
                     contentConfiguration: self.app.contentConfiguration
                 )
             } catch {
@@ -115,12 +116,11 @@ extension Application {
             case .default:
                 responder = DefaultResponder(routes: app.routes, middleware: app.middleware.resolve())
             }
-            var res = try await responder.respond(to: request)
-            let body = try await res.body.collect() ?? Data()
+            let res = try await responder.respond(to: request)
             return TestingHTTPResponse(
                 status: res.status,
                 headers: res.headers,
-                body: body,
+                body: res.body,
                 contentConfiguration: self.app.contentConfiguration
             )
         }

--- a/Sources/VaporTesting/TestingApplicationNew.swift
+++ b/Sources/VaporTesting/TestingApplicationNew.swift
@@ -32,6 +32,7 @@ extension VaporTestingRunner {
         port: Int? = nil,
         headers: HTTPFields = [:],
         body: ByteBuffer? = nil,
+        responseBodyCollection: ResponseBodyCollection = .collect,
         sourceLocation: SourceLocation = #_sourceLocation,
         beforeRequest: (inout TestingHTTPRequest) async throws -> () = { _ in }
     ) async throws -> TestingHTTPResponse {
@@ -40,7 +41,8 @@ extension VaporTestingRunner {
             url: .init(scheme: "http", host: hostname, port: port, path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfiguration: .default()
+            contentConfiguration: .default(),
+            responseBodyCollection: responseBodyCollection
         )
         try await beforeRequest(&request)
         do {

--- a/Sources/VaporTesting/TestingApplicationTester.swift
+++ b/Sources/VaporTesting/TestingApplicationTester.swift
@@ -38,6 +38,7 @@ extension TestingApplicationTester {
         _ path: String,
         headers: HTTPFields = [:],
         body: ByteBuffer? = nil,
+        responseBodyCollection: ResponseBodyCollection = .collect,
         sourceLocation: SourceLocation = #_sourceLocation,
         afterResponse: (TestingHTTPResponse) async throws -> ()
     ) async throws {
@@ -46,6 +47,7 @@ extension TestingApplicationTester {
             path,
             headers: headers,
             body: body,
+            responseBodyCollection: responseBodyCollection,
             sourceLocation: sourceLocation,
             beforeRequest: { _ in },
             afterResponse: afterResponse
@@ -57,6 +59,7 @@ extension TestingApplicationTester {
         _ path: String,
         headers: HTTPFields = [:],
         body: ByteBuffer? = nil,
+        responseBodyCollection: ResponseBodyCollection = .collect,
         sourceLocation: SourceLocation = #_sourceLocation,
         beforeRequest: (inout TestingHTTPRequest) async throws -> () = { _ in },
         afterResponse: (TestingHTTPResponse) async throws -> () = { _ in }
@@ -66,7 +69,8 @@ extension TestingApplicationTester {
             url: .init(path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfiguration: .default()
+            contentConfiguration: .default(),
+            responseBodyCollection: responseBodyCollection
         )
         try await beforeRequest(&request)
         do {
@@ -85,6 +89,7 @@ extension TestingApplicationTester {
         port: Int? = nil,
         headers: HTTPFields = [:],
         body: ByteBuffer? = nil,
+        responseBodyCollection: ResponseBodyCollection = .collect,
         sourceLocation: SourceLocation = #_sourceLocation,
         beforeRequest: (inout TestingHTTPRequest) async throws -> () = { _ in }
     ) async throws -> TestingHTTPResponse {
@@ -93,7 +98,8 @@ extension TestingApplicationTester {
             url: .init(scheme: "http", host: hostname, port: port, path: path),
             headers: headers,
             body: body ?? ByteBufferAllocator().buffer(capacity: 0),
-            contentConfiguration: .default()
+            contentConfiguration: .default(),
+            responseBodyCollection: responseBodyCollection
         )
         try await beforeRequest(&request)
         do {

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -10,19 +10,49 @@ public import FoundationEssentials
 public import Foundation
 #endif
 
+/// What a tester should do with a response body before handing the response back.
+public enum ResponseBodyCollection: Sendable {
+    /// Read the whole body before returning. The default.
+    ///
+    /// A test that only asserts on headers would otherwise leave the body unread, and dropping an
+    /// unread body cancels the request - which the server sees as the client hanging up mid-response.
+    /// For a handler streaming a file that surfaces as a spurious failure, raced against however
+    /// quickly the server finishes writing.
+    case collect(max: Int?)
+
+    /// Hand the body back still streaming, for asserting on chunk boundaries or for a response too
+    /// large to hold in memory.
+    ///
+    /// The test is then responsible for consuming it - see ``Vapor/Response/Body/withStreamingBytes(_:)``.
+    case stream
+
+    /// Read the whole body before returning, with no size limit.
+    public static var collect: Self { .collect(max: nil) }
+}
+
 public struct TestingHTTPRequest: Sendable {
     public var method: HTTPRequest.Method
     public var url: URI
     public var headers: HTTPFields
     public var body: ByteBuffer
     public var contentConfiguration: ContentConfiguration
+    /// How the tester should hand back the response body. Defaults to ``ResponseBodyCollection/collect``.
+    public var responseBodyCollection: ResponseBodyCollection
 
-    public init(method: HTTPRequest.Method, url: URI, headers: HTTPFields, body: ByteBuffer, contentConfiguration: ContentConfiguration) {
+    public init(
+        method: HTTPRequest.Method,
+        url: URI,
+        headers: HTTPFields,
+        body: ByteBuffer,
+        contentConfiguration: ContentConfiguration,
+        responseBodyCollection: ResponseBodyCollection = .collect
+    ) {
         self.method = method
         self.url = url
         self.headers = headers
         self.body = body
         self.contentConfiguration = contentConfiguration
+        self.responseBodyCollection = responseBodyCollection
     }
 
     private struct _ContentContainer: ContentContainer {

--- a/Sources/VaporTesting/TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/TestingHTTPResponse.swift
@@ -1,18 +1,13 @@
 public import Vapor
 public import HTTPTypes
-#if canImport(FoundationEssentials)
-public import FoundationEssentials
-#else
-public import Foundation
-#endif
 
 public struct TestingHTTPResponse: Sendable {
     public var status: HTTPResponse.Status
     public var headers: HTTPFields
-    public var body: Data
+    public var body: Response.Body
     private let contentConfiguration: ContentConfiguration
 
-    package init(status: HTTPResponse.Status, headers: HTTPFields, body: Data, contentConfiguration: ContentConfiguration) {
+    package init(status: HTTPResponse.Status, headers: HTTPFields, body: Response.Body, contentConfiguration: ContentConfiguration) {
         self.status = status
         self.headers = headers
         self.body = body
@@ -22,7 +17,7 @@ public struct TestingHTTPResponse: Sendable {
 
 extension TestingHTTPResponse {
     private struct _ContentContainer: ContentContainer {
-        var body: Data
+        var body: Response.Body
         var headers: HTTPFields
         let contentConfiguration: ContentConfiguration
 
@@ -34,8 +29,12 @@ extension TestingHTTPResponse {
             fatalError("Encoding to test response is not supported")
         }
 
-        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D : Decodable {
-            try decoder.decode(D.self, from: self.body, headers: self.headers, userInfo: [:])
+        func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) async throws -> D where D : Decodable {
+            var body = self.body
+            guard let data = try await body.collect() else {
+                throw Abort(.lengthRequired)
+            }
+            return try decoder.decode(D.self, from: data, headers: self.headers, userInfo: [:])
         }
     }
 

--- a/Sources/VaporTesting/TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/TestingHTTPResponse.swift
@@ -37,12 +37,6 @@ extension TestingHTTPResponse {
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) throws -> D where D : Decodable {
             try decoder.decode(D.self, from: self.body, headers: self.headers, userInfo: [:])
         }
-
-        func decode<C>(_ content: C.Type, using decoder: any ContentDecoder) throws -> C where C : Content {
-            var decoded = try decoder.decode(C.self, from: self.body, headers: self.headers, userInfo: [:])
-            try decoded.afterDecode()
-            return decoded
-        }
     }
 
     public var content: any ContentContainer {

--- a/Sources/VaporTesting/Utilities.swift
+++ b/Sources/VaporTesting/Utilities.swift
@@ -1,24 +1,3 @@
-#warning("We should remove this when we don't need ByteBuffer")
-public import NIOCore
-
-extension ByteBuffer {
-    public var string: String {
-        .init(decoding: self.readableBytesView, as: UTF8.self)
-    }
-}
-
-#if canImport(FoundationEssentials)
-public import FoundationEssentials
-#else
-public import Foundation
-#endif
-
-extension Data {
-    public var string: String {
-        .init(decoding: self, as: UTF8.self)
-    }
-}
-
 public import Vapor
 import HTTPTypes
 

--- a/Sources/VaporTesting/Utilities.swift
+++ b/Sources/VaporTesting/Utilities.swift
@@ -18,3 +18,15 @@ extension Data {
         .init(decoding: self, as: UTF8.self)
     }
 }
+
+public import Vapor
+import HTTPTypes
+
+extension Response.Body {
+    public func requireString(max: Int? = nil) async throws -> String {
+        guard let string = try await self.string(max: max) else {
+            throw Abort(.unprocessableContent)
+        }
+        return string
+    }
+}

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -15,7 +15,7 @@ public import Logging
 /// @Test
 /// func helloWorld() async throws {
 ///     try await withApp(configure: configure) { app in
-///         try await app.testing().test(.GET, "hello", afterResponse: { res async in
+///         try await app.testing().test(.GET, "hello", afterResponse: { res in
 ///             #expect(res.status == .ok)
 ///             try #expect(await res.body.requireString() == "Hello, world!")
 ///         })

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -17,7 +17,7 @@ public import Logging
 ///     try await withApp(configure: configure) { app in
 ///         try await app.testing().test(.GET, "hello", afterResponse: { res async in
 ///             #expect(res.status == .ok)
-///             #expect(res.body.string == "Hello, world!")
+///             try #expect(await res.body.requireString() == "Hello, world!")
 ///         })
 ///     }
 /// }
@@ -71,7 +71,7 @@ public func withApp<T>(
 ///        try await withRunningApp(app: app) { port in
 ///            let res = try await app.client.get("http://localhost:\(port)/hello")
 ///            #expect(res.status == .ok)
-///            #expect(res.body.string == "Hello, world!")
+///            try #expect(await res.body.requireString() == "Hello, world!")
 ///        }
 ///    }
 /// }

--- a/Tests/VaporMacroIntegrationTests/AuthMiddlewareIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/AuthMiddlewareIntegrationTests.swift
@@ -20,7 +20,7 @@ struct AuthMiddlewareIntegrationTests {
                 headers: [.authorization: "Bearer test-token"]
             ) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -47,7 +47,7 @@ struct AuthMiddlewareIntegrationTests {
                 headers: [.authorization: "Bearer test-token"]
             ) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor promoted 42")
+                try #expect(await res.body.requireString() == "Vapor promoted 42")
             }
         }
     }
@@ -59,7 +59,7 @@ struct AuthMiddlewareIntegrationTests {
 
             try await app.testing().test(.get, "/api/auth/feed") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "anonymous")
+                try #expect(await res.body.requireString() == "anonymous")
             }
         }
     }
@@ -75,7 +75,7 @@ struct AuthMiddlewareIntegrationTests {
                 headers: [.authorization: "Bearer test-token"]
             ) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -99,7 +99,7 @@ struct AuthMiddlewareIntegrationTests {
                 headers: [.authorization: "Bearer admin-token"]
             ) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Admin")
+                try #expect(await res.body.requireString() == "Admin")
             }
         }
     }

--- a/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
@@ -16,7 +16,7 @@ struct ControllerMacroIntegrationTests {
 
             try await app.testing().test(.get, "/api/test/users") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "users")
+                try #expect(await res.body.requireString() == "users")
             }
         }
     }
@@ -28,7 +28,7 @@ struct ControllerMacroIntegrationTests {
 
             try await app.testing().test(.get, "/api/test/users/42") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "user with id: 42")
+                try #expect(await res.body.requireString() == "user with id: 42")
             }
         }
     }
@@ -40,7 +40,7 @@ struct ControllerMacroIntegrationTests {
 
             try await app.testing().test(.post, "/api/test/sync") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Sync")
+                try #expect(await res.body.requireString() == "Sync")
             }
         }
     }
@@ -52,7 +52,7 @@ struct ControllerMacroIntegrationTests {
 
             try await app.testing().test(.patch, "/api/test/users/custom") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "custom HTTP method")
+                try #expect(await res.body.requireString() == "custom HTTP method")
             }
         }
     }
@@ -64,7 +64,7 @@ struct ControllerMacroIntegrationTests {
 
             try await app.testing().test(.patch, "/api/test/users/custom/7") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "custom HTTP method with id: 7")
+                try #expect(await res.body.requireString() == "custom HTTP method with id: 7")
             }
         }
     }

--- a/Tests/VaporMacroIntegrationTests/StandaloneMacroIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/StandaloneMacroIntegrationTests.swift
@@ -16,7 +16,7 @@ struct StandaloneMacroIntegrationTests {
 
             try await app.testing().test(.get, "/standalone/hello") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "hello from standalone")
+                try #expect(await res.body.requireString() == "hello from standalone")
             }
         }
     }
@@ -28,7 +28,7 @@ struct StandaloneMacroIntegrationTests {
 
             try await app.testing().test(.get, "/standalone/users/99") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "standalone user with id: 99")
+                try #expect(await res.body.requireString() == "standalone user with id: 99")
             }
         }
     }
@@ -40,7 +40,7 @@ struct StandaloneMacroIntegrationTests {
 
             try await app.testing().test(.post, "/standalone/create") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "created")
+                try #expect(await res.body.requireString() == "created")
             }
         }
     }
@@ -52,7 +52,7 @@ struct StandaloneMacroIntegrationTests {
 
             try await app.testing().test(.delete, "/standalone/remove/5") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "deleted 5")
+                try #expect(await res.body.requireString() == "deleted 5")
             }
         }
     }

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -40,18 +40,18 @@ struct AuthenticationTests {
                 return try req.auth.require(Test.self).name
             }
 
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="Vapor""#)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "bearer test"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "bearer test"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
             }
@@ -87,18 +87,18 @@ struct AuthenticationTests {
             }
 
             let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Vapor", charset="UTF-8""#)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "basic \(basic)"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "basic \(basic)"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
             }
@@ -123,12 +123,12 @@ struct AuthenticationTests {
                 return response
             }
 
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Private \"Area\"", charset="UTF-8""#)
             }
 
-            try await app.testing().test(.get, "/existing") { res async in
+            try await app.testing().test(.get, "/existing") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Existing""#)
             }
@@ -163,24 +163,24 @@ struct AuthenticationTests {
                 Response(status: .ok)
             }
 
-            try await app.testing().test(.get, "/default") { res async in
+            try await app.testing().test(.get, "/default") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="Vapor""#)
             }
 
-            try await app.testing().test(.get, "/custom") { res async in
+            try await app.testing().test(.get, "/custom") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="API \"v2\"""#)
             }
 
             // A challenge the responder chain set itself must not be replaced.
-            try await app.testing().test(.get, "/existing") { res async in
+            try await app.testing().test(.get, "/existing") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="Existing""#)
             }
 
             // Only unauthorized responses get a challenge.
-            try await app.testing().test(.get, "/ok") { res async in
+            try await app.testing().test(.get, "/ok") { res in
                 #expect(res.status == .ok)
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
@@ -216,27 +216,27 @@ struct AuthenticationTests {
             }
 
             // An unauthorized error picks up the challenge but keeps its own reason.
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer revoked"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer revoked"]) { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="API""#)
                 try #expect(await res.body.requireString().contains("Token has been revoked."))
             }
 
             // An error carrying its own challenge keeps it verbatim.
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer expired"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer expired"]) { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="API", error="invalid_token""#)
                 try #expect(await res.body.requireString().contains("Token has expired."))
             }
 
             // Errors with any other status are left alone.
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer forbidden"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer forbidden"]) { res in
                 #expect(res.status == .forbidden)
                 #expect(res.headers[.wwwAuthenticate] == nil)
                 try #expect(await res.body.requireString().contains("Insufficient scope."))
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer nonsense"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer nonsense"]) { res in
                 #expect(res.status == .internalServerError)
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
@@ -295,7 +295,7 @@ struct AuthenticationTests {
             }
 
             let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Vapor", charset="UTF-8""#)
                 try #expect(await res.body.requireString().contains("The credentials have expired."))
@@ -345,20 +345,20 @@ struct AuthenticationTests {
                 Response(status: .unauthorized)
             }
 
-            try await app.testing().test(.get, "/bearer-innermost") { res async in
+            try await app.testing().test(.get, "/bearer-innermost") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="Bearer Realm""#)
                 // Only one scheme is advertised, even though the route accepts both.
                 #expect(res.headers[values: .wwwAuthenticate].count == 1)
             }
 
-            try await app.testing().test(.get, "/basic-innermost") { res async in
+            try await app.testing().test(.get, "/basic-innermost") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Basic Realm", charset="UTF-8""#)
                 #expect(res.headers[values: .wwwAuthenticate].count == 1)
             }
 
-            try await app.testing().test(.get, "/returned") { res async in
+            try await app.testing().test(.get, "/returned") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="Bearer Realm""#)
             }
@@ -394,11 +394,11 @@ struct AuthenticationTests {
             }
 
             let basic = "test:secret:with:colon".data(using: .utf8)!.base64EncodedString()
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .unauthorized)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
             }
@@ -479,12 +479,12 @@ struct AuthenticationTests {
             }
 
             let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .seeOther)
                 #expect(res.headers[.location] == "/redirect?orig=/test")
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
             }
@@ -537,12 +537,12 @@ struct AuthenticationTests {
             }
 
             var sessionCookie: HTTPCookies.Value?
-            try await app.testing().test(.get, "/test") { res async in
+            try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.setCookie] == nil)
             }
 
-            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
                 if let cookie = res.headers.setCookie?["vapor-session"] {
@@ -552,7 +552,7 @@ struct AuthenticationTests {
                 }
             }
 
-            try await app.testing().test(.get, "/test", headers: [.cookie: sessionCookie!.serialize(name: "vapor-session")]) { res async in
+            try await app.testing().test(.get, "/test", headers: [.cookie: sessionCookie!.serialize(name: "vapor-session")]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.setCookie] != nil)
@@ -752,7 +752,7 @@ struct AuthenticationTests {
             }
 
             var sessionCookie: HTTPCookies.Value?
-            try await app.testing().test(.get, "/login") { res async in
+            try await app.testing().test(.get, "/login") { res in
                 #expect(res.status == .ok)
                 if let cookie = res.headers.setCookie?["vapor-session"] {
                     sessionCookie = cookie
@@ -762,7 +762,7 @@ struct AuthenticationTests {
             }
 
             let cookie = try #require(sessionCookie)
-            try await app.testing().test(.get, "/me", headers: [.cookie: cookie.serialize(name: "vapor-session")]) { res async in
+            try await app.testing().test(.get, "/me", headers: [.cookie: cookie.serialize(name: "vapor-session")]) { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "Vapor")
             }

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -47,13 +47,13 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "bearer test"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -94,13 +94,13 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.wwwAuthenticate] == nil)
             }
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -219,21 +219,21 @@ struct AuthenticationTests {
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer revoked"]) { res async in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="API""#)
-                #expect(res.body.string.contains("Token has been revoked."))
+                try #expect(await res.body.requireString().contains("Token has been revoked."))
             }
 
             // An error carrying its own challenge keeps it verbatim.
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer expired"]) { res async in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Bearer realm="API", error="invalid_token""#)
-                #expect(res.body.string.contains("Token has expired."))
+                try #expect(await res.body.requireString().contains("Token has expired."))
             }
 
             // Errors with any other status are left alone.
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer forbidden"]) { res async in
                 #expect(res.status == .forbidden)
                 #expect(res.headers[.wwwAuthenticate] == nil)
-                #expect(res.body.string.contains("Insufficient scope."))
+                try #expect(await res.body.requireString().contains("Insufficient scope."))
             }
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer nonsense"]) { res async in
@@ -298,7 +298,7 @@ struct AuthenticationTests {
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Vapor", charset="UTF-8""#)
-                #expect(res.body.string.contains("The credentials have expired."))
+                try #expect(await res.body.requireString().contains("The credentials have expired."))
             }
 
             let error = try #require(captured.withLockedValue { $0 })
@@ -400,7 +400,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -441,7 +441,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -486,7 +486,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }
@@ -544,7 +544,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Bearer test"]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
                 if let cookie = res.headers.setCookie?["vapor-session"] {
                     sessionCookie = cookie
                 } else {
@@ -554,7 +554,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test", headers: [.cookie: sessionCookie!.serialize(name: "vapor-session")]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
                 #expect(res.headers[.setCookie] != nil)
             }
         }
@@ -594,7 +594,7 @@ struct AuthenticationTests {
 
             try await app.testing().test(.get, "/test") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == #"{"name":"none"}"#)
+                try #expect(await res.body.requireString() == #"{"name":"none"}"#)
                 #expect(res.headers[.setCookie] == nil)
             }
         }
@@ -764,7 +764,7 @@ struct AuthenticationTests {
             let cookie = try #require(sessionCookie)
             try await app.testing().test(.get, "/me", headers: [.cookie: cookie.serialize(name: "vapor-session")]) { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -93,7 +93,7 @@ struct ClientTests {
 
                 try await withRunningApp(app: app) { port in
                     let res = try await app.client.get("http://127.0.0.1:\(port)/foo")
-                    #expect(res.body.string == "bar")
+                    #expect(try await res.body.string() == "bar")
                 }
             }
         }

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -93,7 +93,7 @@ struct ClientTests {
 
                 try await withRunningApp(app: app) { port in
                     let res = try await app.client.get("http://127.0.0.1:\(port)/foo")
-                    #expect(res.body?.string == "bar")
+                    #expect(res.body.string == "bar")
                 }
             }
         }

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -188,6 +188,108 @@ struct ClientTests {
             throw error
         }
     }
+
+    @Test("Returning a ClientResponse forwards its body", .timeLimit(.minutes(1)))
+    func testClientResponseEncodesItsBody() async throws {
+        try await withApp { app in
+            // Proxy shape: a handler returning a ClientResponse whose body is a live stream. The body
+            // used to be dropped entirely, so this answered 200 with nothing in it.
+            app.get("proxied") { _ -> ClientResponse in
+                var headers = HTTPFields()
+                headers.contentType = .plainText
+                return ClientResponse(
+                    status: .created,
+                    headers: headers,
+                    body: try .init(stream: { writer in
+                        try await writer.write("hello ")
+                        try await writer.write("world")
+                    }, count: 11)
+                )
+            }
+
+            try await app.test(method: .running) { runner in
+                let res = try await runner.sendRequest(.get, "/proxied")
+                #expect(res.status == .created)
+                try #expect(await res.body.requireString() == "hello world")
+                // A declared length survives the proxy instead of being re-framed as chunked.
+                #expect(res.headers[.contentLength] == "11")
+            }
+        }
+    }
+
+    @Test("Returning a ClientResponse of unknown length is chunked", .timeLimit(.minutes(1)))
+    func testClientResponseWithUnknownLengthIsChunked() async throws {
+        try await withApp { app in
+            app.get("proxied") { _ -> ClientResponse in
+                ClientResponse(status: .ok, body: .init(stream: { writer in
+                    try await writer.write("streamed")
+                }))
+            }
+
+            try await app.test(method: .running) { runner in
+                let res = try await runner.sendRequest(.get, "/proxied")
+                try #expect(await res.body.requireString() == "streamed")
+                #expect(res.headers[.contentLength] == nil)
+            }
+        }
+    }
+
+    @Test("Returning a ClientResponse strips the origin's hop-by-hop headers", .timeLimit(.minutes(1)))
+    func testClientResponseStripsHopByHopHeaders() async throws {
+        try await withApp { app in
+            app.get("proxied") { _ -> ClientResponse in
+                var headers = HTTPFields()
+                // What an origin server might have sent us. None of it describes the hop between this
+                // server and its own client.
+                headers[.connection] = "close, X-Origin-Only"
+                headers[.upgrade] = "websocket"
+                headers[HTTPField.Name("Keep-Alive")!] = "timeout=5"
+                headers[HTTPField.Name("X-Origin-Only")!] = "should not be forwarded"
+                headers[HTTPField.Name("X-Kept")!] = "end-to-end"
+                return ClientResponse(status: .ok, headers: headers, body: .init(string: "body"))
+            }
+
+            try await app.test(method: .running) { runner in
+                let res = try await runner.sendRequest(.get, "/proxied")
+                try #expect(await res.body.requireString() == "body")
+
+                #expect(res.headers[.upgrade] == nil)
+                #expect(res.headers[HTTPField.Name("Keep-Alive")!] == nil)
+                // Named by `Connection`, so hop-by-hop for that hop too.
+                #expect(res.headers[HTTPField.Name("X-Origin-Only")!] == nil)
+                // End-to-end fields are untouched.
+                #expect(res.headers[HTTPField.Name("X-Kept")!] == "end-to-end")
+            }
+        }
+    }
+
+    @Test("A client response bounds how much it will buffer")
+    func testClientResponseMaxBodySize() async throws {
+        struct Payload: Content { var value: String }
+
+        var headers = HTTPFields()
+        headers.contentType = .json
+        let response = ClientResponse(
+            status: .ok,
+            headers: headers,
+            body: .init(stream: { writer in
+                try await writer.write(#"{"value":""#)
+                try await writer.write(String(repeating: "x", count: 4096))
+                try await writer.write(#""}"#)
+            }),
+            maxBodySize: 512
+        )
+
+        await #expect(throws: Abort.self) {
+            _ = try await response.content.decode(Payload.self)
+        }
+
+        // Streaming is not bounded by it - the ceiling is on holding the whole body in memory.
+        var seen = 0
+        try await response.body.withStreamingBytes { seen += $0.byteCount }
+        #expect(seen == 4108)
+    }
+
 }
 
 final class CustomClient: Client, Sendable {

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -93,7 +93,7 @@ struct ClientTests {
 
                 try await withRunningApp(app: app) { port in
                     let res = try await app.client.get("http://127.0.0.1:\(port)/foo")
-                    #expect(try await res.body.string() == "bar")
+                    try #expect(await res.body.string() == "bar")
                 }
             }
         }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -536,6 +536,72 @@ struct ContentTests {
         }
     }
 
+    @Test("afterDecode runs when decoding with an explicit content type")
+    func testAfterDecodeWithExplicitContentType() async throws {
+        // `decode(_:as:)` used to bind a `Content` type to the `Decodable` overload, which has no
+        // way to know about the hook, so the value came back unprocessed.
+        try await withApp { app in
+            let request = Request(
+                application: app,
+                collectedBody: .init(string: #"{"name": "before decode"}"#)
+            )
+            request.headers.contentType = .json
+
+            let content = try await request.content.decode(SampleContent.self, as: .json)
+            #expect(content.name == "new name after decode")
+        }
+    }
+
+    @Test("afterDecode runs for a Response's content")
+    func testAfterDecodeOnResponse() async throws {
+        var response = Response(status: .ok)
+        response.headers.contentType = .json
+        response.body = .init(string: #"{"name": "before decode"}"#)
+
+        #expect(try await response.content.decode(SampleContent.self).name == "new name after decode")
+        #expect(try await response.content.decode(SampleContent.self, as: .json).name == "new name after decode")
+    }
+
+    @Test("afterDecode runs for a ClientResponse's content, including a streaming body")
+    func testAfterDecodeOnClientResponse() async throws {
+        var headers = HTTPFields()
+        headers.contentType = .json
+        func response() -> ClientResponse {
+            ClientResponse(
+                status: .ok,
+                headers: headers,
+                body: .init(stream: { writer in try await writer.write(#"{"name": "before decode"}"#) })
+            )
+        }
+
+        #expect(try await response().content.decode(SampleContent.self).name == "new name after decode")
+        #expect(try await response().content.decode(SampleContent.self, as: .json).name == "new name after decode")
+    }
+
+    @Test("afterDecode runs for a TestingHTTPResponse's content")
+    func testAfterDecodeOnTestingHTTPResponse() async throws {
+        var headers = HTTPFields()
+        headers.contentType = .json
+        let response = TestingHTTPResponse(
+            status: .ok,
+            headers: headers,
+            body: Data(#"{"name": "before decode"}"#.utf8),
+            contentConfiguration: .default()
+        )
+
+        #expect(try await response.content.decode(SampleContent.self).name == "new name after decode")
+        #expect(try await response.content.decode(SampleContent.self, as: .json).name == "new name after decode")
+    }
+
+    @Test("afterDecode runs for a ClientRequest's content")
+    func testAfterDecodeOnClientRequest() async throws {
+        var request = ClientRequest(method: .post, url: "/")
+        try request.content.encode(SampleContent(), as: .json)
+
+        #expect(try await request.content.decode(SampleContent.self).name == "new name after decode")
+        #expect(try await request.content.decode(SampleContent.self, as: .json).name == "new name after decode")
+    }
+
     @Test("Test Supports JSON API")
     func testSupportsJsonApi() async throws {
         var body = ByteBufferAllocator().buffer(capacity: 0)

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -518,8 +518,8 @@ struct ContentTests {
         #expect(body == #"{"name":"new name"}"#)
     }
 
-    @Test("Test After Content Encode")
-    func testAfterContentEncode() async throws {
+    @Test("afterDecode runs for a Request's content")
+    func testAfterDecodeOnRequest() async throws {
         var body = ByteBufferAllocator().buffer(capacity: 0)
         body.writeString(#"{"name": "before decode"}"#)
 

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -85,7 +85,7 @@ struct ContentTests {
 
             try await app.testing().test(.get, "/decode_error") { res in
                 #expect(res.status == .badRequest)
-                #expect(res.body.string.contains(#"Value was not of type 'Int' at path 'bar'. Expected to decode Int but found a string"#))
+                try #expect(await res.body.requireString().contains(#"Value was not of type 'Int' at path 'bar'. Expected to decode Int but found a string"#))
             }
         }
     }
@@ -110,7 +110,7 @@ struct ContentTests {
 
             try await app.testing().test(.get, "/encode") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("hi"))
+                try #expect(await res.body.requireString().contains("hi"))
             }
         }
     }
@@ -135,7 +135,7 @@ struct ContentTests {
                 try req.content.encode(FooContent())
             } afterResponse: { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("decoded!"))
+                try #expect(await res.body.requireString().contains("decoded!"))
             }
 
             app.routes.post("decode-bad-header") { req async throws -> String in
@@ -154,7 +154,7 @@ struct ContentTests {
                 req.headers.contentType = .audio
             } afterResponse: { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("decoded!"))
+                try #expect(await res.body.requireString().contains("decoded!"))
             }
         }
     }
@@ -327,10 +327,10 @@ struct ContentTests {
             try await app.testing().test(.get, "/multipart") { res in
                 #expect(res.status == .ok)
                 let boundary = res.headers.contentType?.parameters["boundary"] ?? "none"
-                #expect(res.body.string.contains("Content-Disposition: form-data; name=\"name\""))
-                #expect(res.body.string.contains("--\(boundary)"))
-                #expect(res.body.string.contains("filename=\"droplet.png\""))
-                #expect(res.body.string.contains("name=\"image\""))
+                try #expect(await res.body.requireString().contains("Content-Disposition: form-data; name=\"name\""))
+                try #expect(await res.body.requireString().contains("--\(boundary)"))
+                try #expect(await res.body.requireString().contains("filename=\"droplet.png\""))
+                try #expect(await res.body.requireString().contains("name=\"image\""))
             }
         }
     }
@@ -355,10 +355,10 @@ struct ContentTests {
             try await app.testing().test(.get, "/multipart") { res in
                 #expect(res.status == .ok)
                 let boundary = res.headers.contentType?.parameters["boundary"] ?? "none"
-                #expect(res.body.string.contains("Content-Disposition: form-data; name=\"name\""))
-                #expect(res.body.string.contains("--\(boundary)"))
-                #expect(res.body.string.contains("filename=\"UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png\""))
-                #expect(res.body.string.contains("name=\"image\""))
+                try #expect(await res.body.requireString().contains("Content-Disposition: form-data; name=\"name\""))
+                try #expect(await res.body.requireString().contains("--\(boundary)"))
+                try #expect(await res.body.requireString().contains("filename=\"UTF-8\'\'%E5%A5%B9%E5%9C%A8%E5%90%83%E6%B0%B4%E6%9E%9C.png\""))
+                try #expect(await res.body.requireString().contains("name=\"image\""))
             }
         }
     }
@@ -441,10 +441,10 @@ struct ContentTests {
             try await app.testing().test(.get, "/urlencodedform") { res in
                 #expect(res.status.code == 200)
                 #expect(res.headers.contentType == .urlEncodedForm)
-                #expect(res.body.string.contains("luckyNumbers[]=5"))
-                #expect(res.body.string.contains("luckyNumbers[]=7"))
-                #expect(res.body.string.contains("age=3"))
-                #expect(res.body.string.contains("name=Vapor"))
+                try #expect(await res.body.requireString().contains("luckyNumbers[]=5"))
+                try #expect(await res.body.requireString().contains("luckyNumbers[]=7"))
+                try #expect(await res.body.requireString().contains("age=3"))
+                try #expect(await res.body.requireString().contains("name=Vapor"))
             }
         }
     }
@@ -459,7 +459,7 @@ struct ContentTests {
             try await app.testing().test(.get, "/check", headers: [.init("X-Test-Value")!: "PRESENT"], beforeRequest: { req in
                 try req.content.encode(["foo": "bar"], as: .json)
             }) { res in
-                #expect(res.body.string == "PRESENT.application/json; charset=utf-8")
+                try #expect(await res.body.requireString() == "PRESENT.application/json; charset=utf-8")
             }
         }
     }
@@ -480,7 +480,7 @@ struct ContentTests {
                 try req.content.encode(["foo": "bar"], as: .json)
                 req.headers.contentType = .xml
             }) { res in
-                #expect(res.body.string == "PRESENT.application/xml; charset=utf-8")
+                try #expect(await res.body.requireString() == "PRESENT.application/xml; charset=utf-8")
             }
         }
     }
@@ -585,7 +585,7 @@ struct ContentTests {
         let response = TestingHTTPResponse(
             status: .ok,
             headers: headers,
-            body: Data(#"{"name": "before decode"}"#.utf8),
+            body: .init(string: #"{"name": "before decode"}"#),
             contentConfiguration: .default()
         )
 
@@ -854,7 +854,7 @@ struct ContentTests {
                 try req.content.encode(Message(name: "Vapor"))
             }) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Vapor")
+                try #expect(await res.body.requireString() == "Vapor")
             }
         }
     }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -31,7 +31,7 @@ struct FileTests {
                 }
             }
 
-            try await app.testing(method: .running).test(.get, "/file-stream") { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream") { res in
                 let test = "the quick brown fox"
                 #expect(res.headers[.eTag] != nil)
                 try #expect(await res.body.requireString().contains(test))
@@ -48,7 +48,7 @@ struct FileTests {
 
             var headers = HTTPFields()
             headers[.connection] = "close"
-            try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res in
                 let test = "the quick brown fox"
                 #expect(res.headers[.eTag] != nil)
                 try #expect(await res.body.requireString().contains(test))
@@ -74,7 +74,7 @@ struct FileTests {
                 }
             }
 
-            try await app.testing(method: .running).test(.get, "/file-stream") { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream") { res in
                 #expect(res.status == .internalServerError)
             }
         }
@@ -164,7 +164,7 @@ struct FileTests {
 
             var headerRequest = HTTPFields()
             headerRequest.range = .init(unit: .bytes, ranges: [.tail(value: 20)])
-            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res in
                 let contentRange = res.headers[.contentRange]
                 let contentLength = res.headers[.contentLength]
 
@@ -194,7 +194,7 @@ struct FileTests {
 
             var headerRequest = HTTPFields()
             headerRequest.range = .init(unit: .bytes, ranges: [.start(value: 20)])
-            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res in
 
                 let contentRange = res.headers[.contentRange]
                 let contentLength = res.headers[.contentLength]
@@ -223,7 +223,7 @@ struct FileTests {
 
             var headerRequest = HTTPFields()
             headerRequest.range = .init(unit: .bytes, ranges: [.within(start: 20, end: 25)])
-            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream", headers: headerRequest) { res in
 
                 let contentRange = res.headers[.contentRange]
                 let contentLength = res.headers[.contentLength]
@@ -252,7 +252,7 @@ struct FileTests {
 
             var headers = HTTPFields()
             headers.range = .init(unit: .bytes, ranges: [.within(start: 0, end: 0)])
-            try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res async in
+            try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res in
                 #expect(res.status == .partialContent)
 
                 #expect(res.headers[.contentLength] == "1")
@@ -344,7 +344,7 @@ struct FileTests {
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
             app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
-            try await app.testing().test(.get, "/Utilities/foo%20bar.html") { res async in
+            try await app.testing().test(.get, "/Utilities/foo%20bar.html") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "<h1>Hello</h1>\n")
             }
@@ -357,11 +357,11 @@ struct FileTests {
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
             app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
 
-            try await app.testing().test(.get, "%2e%2e/VaporTests/Utilities/foo.txt") { res async in
+            try await app.testing().test(.get, "%2e%2e/VaporTests/Utilities/foo.txt") { res in
                 #expect(res.status == .forbidden)
             }
 
-            try await app.testing().test(.get, "Utilities/foo.txt") { res async in
+            try await app.testing().test(.get, "Utilities/foo.txt") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "bar\n")
             }
@@ -374,12 +374,12 @@ struct FileTests {
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
             app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "index.html"))
 
-            try await app.testing().test(.get, "Utilities/") { res async in
+            try await app.testing().test(.get, "Utilities/") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }
 
-            try await app.testing().test(.get, "Utilities/SubUtilities/") { res async in
+            try await app.testing().test(.get, "Utilities/SubUtilities/") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "<h1>Subdirectory Default</h1>\n")
             }
@@ -392,12 +392,12 @@ struct FileTests {
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
             app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "/Utilities/index.html"))
 
-            try await app.testing().test(.get, "Utilities/") { res async in
+            try await app.testing().test(.get, "Utilities/") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }
 
-            try await app.testing().test(.get, "Utilities/SubUtilities/") { res async in
+            try await app.testing().test(.get, "Utilities/SubUtilities/") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -259,7 +259,7 @@ struct FileTests {
                 let range = res.headers[.contentRange]!.split(separator: "/").first!.split(separator: " ").last!
                 #expect(range == "0-0")
 
-                #expect(res.body.count == 1)
+                try #expect(await res.body.data()?.count == 1)
             }
         }
     }
@@ -617,7 +617,7 @@ struct FileTests {
                 #expect(res.status == .ok)
                 // The length is advertised even though no body follows it.
                 #expect(res.headers[.contentLength] != nil)
-                #expect(res.body.count == 0)
+                try #expect(await res.body.data()?.count == 0)
             }
 
             // A HEAD response carries no body, so opening and reading the file would be wasted
@@ -636,13 +636,13 @@ struct FileTests {
             try await app.test(method: .running) { runner in
                 let get = try await runner.sendRequest(.get, "/Utilities/foo.txt")
                 #expect(get.status == .ok)
-                #expect(get.body.count > 0)
+                try #expect(await (get.body.data()?.count ?? 0) > 0)
 
                 // HEAD gets the headers a GET would have returned, with no body.
                 let head = try await runner.sendRequest(.head, "/Utilities/foo.txt")
                 #expect(head.status == .ok)
                 #expect(head.headers[.contentLength] == get.headers[.contentLength])
-                #expect(head.body.count == 0)
+                try #expect(await head.body.data()?.count == 0)
 
                 // Everything else falls through the middleware; nothing else is registered here,
                 // so it 404s rather than being answered with the file.

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -34,7 +34,7 @@ struct FileTests {
             try await app.testing(method: .running).test(.get, "/file-stream") { res async in
                 let test = "the quick brown fox"
                 #expect(res.headers[.eTag] != nil)
-                #expect(res.body.string.contains(test))
+                try #expect(await res.body.requireString().contains(test))
             }
         }
     }
@@ -51,7 +51,7 @@ struct FileTests {
             try await app.testing(method: .running).test(.get, "/file-stream", headers: headers) { res async in
                 let test = "the quick brown fox"
                 #expect(res.headers[.eTag] != nil)
-                #expect(res.body.string.contains(test))
+                try #expect(await res.body.requireString().contains(test))
             }
         }
     }
@@ -346,7 +346,7 @@ struct FileTests {
 
             try await app.testing().test(.get, "/Utilities/foo%20bar.html") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "<h1>Hello</h1>\n")
+                try #expect(await res.body.requireString() == "<h1>Hello</h1>\n")
             }
         }
     }
@@ -363,7 +363,7 @@ struct FileTests {
 
             try await app.testing().test(.get, "Utilities/foo.txt") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "bar\n")
+                try #expect(await res.body.requireString() == "bar\n")
             }
         }
     }
@@ -376,12 +376,12 @@ struct FileTests {
 
             try await app.testing().test(.get, "Utilities/") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "<h1>Root Default</h1>\n")
+                try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }
 
             try await app.testing().test(.get, "Utilities/SubUtilities/") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "<h1>Subdirectory Default</h1>\n")
+                try #expect(await res.body.requireString() == "<h1>Subdirectory Default</h1>\n")
             }
         }
     }
@@ -394,12 +394,12 @@ struct FileTests {
 
             try await app.testing().test(.get, "Utilities/") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "<h1>Root Default</h1>\n")
+                try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }
 
             try await app.testing().test(.get, "Utilities/SubUtilities/") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "<h1>Root Default</h1>\n")
+                try #expect(await res.body.requireString() == "<h1>Root Default</h1>\n")
             }
         }
     }

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -29,7 +29,7 @@ struct MiddlewareTests {
                 let order = await store.getOrder()
                 #expect(res.status == .ok)
                 #expect(order == ["a", "b", "c"])
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
             }
         }
     }
@@ -51,7 +51,7 @@ struct MiddlewareTests {
                 let order = await store.getOrder()
                 #expect(res.status == .ok)
                 #expect(order == ["a", "b", "c", "d"])
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
             }
         }
     }
@@ -67,7 +67,7 @@ struct MiddlewareTests {
 
             try await app.testing().test(.get, "/order", headers: [.origin: "foo"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
                 #expect(res.headers[values: .vary] == ["origin"])
                 #expect(res.headers[values: .accessControlAllowOrigin] == ["foo"])
                 #expect(res.headers[values: .accessControlAllowHeaders] == ["origin"])
@@ -110,7 +110,7 @@ struct MiddlewareTests {
 
             try await app.testing().test(.get, "/order", headers: [.origin: "foo"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
                 #expect(res.headers[values: .vary] == ["origin"])
                 #expect(res.headers[values: .accessControlAllowOrigin] == ["foo"])
                 #expect(res.headers[values: .accessControlAllowHeaders] == ["origin"])
@@ -129,7 +129,7 @@ struct MiddlewareTests {
 
             try await app.testing().test(.get, "/order", headers: [.origin: "foo"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
                 #expect(res.headers[values: .vary] == [])
                 #expect(res.headers[values: .accessControlAllowOrigin] == [])
                 #expect(res.headers[values: .accessControlAllowHeaders] == [""])
@@ -167,7 +167,7 @@ struct MiddlewareTests {
 
             try await app.testing().test(.get, "/order", headers: [.origin: "http://example-123.com"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
                 #expect(res.headers[values: .vary] == ["origin"])
                 #expect(res.headers[values: .accessControlAllowOrigin] == ["http://example-123.com"])
                 #expect(res.headers[values: .accessControlAllowHeaders] == [""])
@@ -175,7 +175,7 @@ struct MiddlewareTests {
 
             try await app.testing().test(.get, "/order", headers: [.origin: "foo"]) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "done")
+                try #expect(await res.body.requireString() == "done")
                 #expect(res.headers[values: .vary] == [])
                 #expect(res.headers[values: .accessControlAllowOrigin] == [])
                 #expect(res.headers[values: .accessControlAllowHeaders] == [""])

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -364,6 +364,87 @@ struct MiddlewareTests {
         }
     }
 
+    @Test("Metrics middleware records a streaming response body's declared size", .withMetrics(TestMetrics()))
+    func testMetricsMiddlewareStreamingResponseBodySizeDeclared() async throws {
+        try await withApp { app in
+            app.middleware.use(MetricsMiddleware())
+            // A stream that declares its length can be measured without reading it.
+            app.get("streamMetrics") { _ in
+                Response(body: try .init(stream: { writer in
+                    try await writer.write("alpha")
+                    try await writer.write("beta")
+                }, count: 9))
+            }
+
+            let response = try await app.testing().sendRequest(.get, "/streamMetrics")
+            #expect(response.status == .ok)
+
+            let recorder = try metrics.expectRecorder(
+                "http.server.response.body.size",
+                [
+                    ("http.request.method", "GET"),
+                    ("url.scheme", "http"),
+                    ("error.type", "undefined"),
+                    ("http.response.status_code", "200"),
+                    ("http.route", "/streamMetrics"),
+                    ("network.protocol.name", "http"),
+                    ("network.protocol.version", "1.1"),
+                ]
+            )
+            #expect(recorder.lastValue == 9.0)
+        }
+    }
+
+    @Test("Metrics middleware records no body size for a stream of unknown length", .withMetrics(TestMetrics()))
+    func testMetricsMiddlewareStreamingResponseBodySizeUnknown() async throws {
+        try await withApp { app in
+            app.middleware.use(MetricsMiddleware())
+            // No declared length, and the middleware must not read the body to find one - so there is
+            // no size to record. This used to record the `-1` sentinel as if it were a byte count.
+            app.get("streamMetrics") { _ in
+                Response(body: try .init(stream: { writer in
+                    try await writer.write("alpha")
+                    try await writer.write("beta")
+                }))
+            }
+
+            let response = try await app.testing().sendRequest(.get, "/streamMetrics")
+            #expect(response.status == .ok)
+            try #expect(await response.body.requireString() == "alphabeta")
+
+            // The request itself is still measured; only the body size is absent.
+            #expect(throws: Never.self) {
+                try metrics.expectTimer(
+                    "http.server.request.duration",
+                    [
+                        ("http.request.method", "GET"),
+                        ("url.scheme", "http"),
+                        ("error.type", "undefined"),
+                        ("http.response.status_code", "200"),
+                        ("http.route", "/streamMetrics"),
+                        ("network.protocol.name", "http"),
+                        ("network.protocol.version", "1.1"),
+                    ]
+                )
+            }
+
+            #expect(throws: (any Error).self) {
+                try metrics.expectRecorder(
+                    "http.server.response.body.size",
+                    [
+                        ("http.request.method", "GET"),
+                        ("url.scheme", "http"),
+                        ("error.type", "undefined"),
+                        ("http.response.status_code", "200"),
+                        ("http.route", "/streamMetrics"),
+                        ("network.protocol.name", "http"),
+                        ("network.protocol.version", "1.1"),
+                    ]
+                )
+            }
+        }
+    }
+
     @Test("Test Tracing Middleware", .withTracer(InMemoryTracer()))
     func testTracingMiddleware() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -190,9 +190,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/")
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/foo.txt") { result async in
+            try await app.testing().test(.get, "/foo.txt") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "bar\n")
+                try #expect(await result.body.requireString() == "bar\n")
                 #expect(result.headers[.cacheControl] == nil)
                 #expect(result.headers[.age] == nil)
             }
@@ -205,9 +205,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .browserDefault)
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/foo.txt") { result async in
+            try await app.testing().test(.get, "/foo.txt") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "bar\n")
+                try #expect(await result.body.requireString() == "bar\n")
                 #expect(result.headers[.cacheControl] == nil)
                 #expect(result.headers[.age] == nil)
             }
@@ -221,9 +221,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .noCache)
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/foo.txt") { result async in
+            try await app.testing().test(.get, "/foo.txt") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "bar\n")
+                try #expect(await result.body.requireString() == "bar\n")
                 #expect(result.headers[.cacheControl] == "no-cache")
                 #expect(result.headers[.age] == nil)
             }
@@ -236,9 +236,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cacheUpToDuration(.minutes(5)))
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/foo.txt") { result async in
+            try await app.testing().test(.get, "/foo.txt") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "bar\n")
+                try #expect(await result.body.requireString() == "bar\n")
                 #expect(result.headers[.cacheControl] == "max-age=300")
                 #expect(result.headers[.age] == "0")
             }
@@ -251,9 +251,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .custom(cacheControlHeader: .init(isPublic: true), ageHeader: 10))
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/foo.txt") { result async in
+            try await app.testing().test(.get, "/foo.txt") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "bar\n")
+                try #expect(await result.body.requireString() == "bar\n")
                 #expect(result.headers[.cacheControl] == "public")
                 #expect(result.headers[.age] == "10")
             }
@@ -266,9 +266,9 @@ struct MiddlewareTests {
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "SubUtilities")
             app.middleware.use(fileMiddleware)
 
-            try await app.testing().test(.get, "/index.html") { result async in
+            try await app.testing().test(.get, "/index.html") { result in
                 #expect(result.status == .ok)
-                #expect(result.body.string == "<h1>Subdirectory Default</h1>\n")
+                try #expect(await result.body.requireString() == "<h1>Subdirectory Default</h1>\n")
             }
         }
     }
@@ -393,7 +393,7 @@ struct MiddlewareTests {
                 $0.headers[.userAgent] = "test"
             }) { response in
                 #expect(response.status == .ok)
-                #expect(response.body.string == "done")
+                try #expect(await response.body.requireString() == "done")
 
                 let span = try #require(tracer.finishedSpans.first)
                 #expect(span.operationName == "GET /testTracing")

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -121,7 +121,7 @@ struct QueryTests {
 
             try await app.testing().test(.get, "/todos?a=b") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "hi")
+                try #expect(await res.body.requireString() == "hi")
             }
         }
     }
@@ -202,7 +202,7 @@ struct QueryTests {
             }
 
             try await app.testing().test(.get, "/custom-encode") { res in
-                #expect(res.body.string == """
+                try #expect(await res.body.requireString() == """
             {
               "hello" : "world"
             }

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -232,7 +232,7 @@ struct QueryTests {
 
             try await app.testing().test(.post, "/decode-fail", headers: headers, body: body) { res in
                 #expect(res.status == .badRequest)
-                #expect(res.body.string.contains("missing"))
+                try #expect(await res.body.requireString().contains("missing"))
             }
         }
     }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -231,7 +231,7 @@ struct RequestTests {
 
             let ipV4Hostname = "127.0.0.1"
             try await app.testing(method: .running(hostname: ipV4Hostname, port: 0)).test(.get, "vapor/is/fun") { res in
-                #expect(res.body.string == ipV4Hostname)
+                try #expect(await res.body.requireString() == ipV4Hostname)
             }
         }
     }
@@ -276,7 +276,7 @@ struct RequestTests {
             }
 
             try await app.testing(method: .running).test(.get, "remote") { res in
-                #expect(res.body.string == "[IPv4]192.0.2.60:80")
+                try #expect(await res.body.requireString() == "[IPv4]192.0.2.60:80")
             }
         }
     }
@@ -293,7 +293,7 @@ struct RequestTests {
             }
 
             try await app.testing(method: .running).test(.get, "remote") { res in
-                #expect(res.body.string == "[IPv4]5.6.7.8:80")
+                try #expect(await res.body.requireString() == "[IPv4]5.6.7.8:80")
             }
         }
     }
@@ -310,7 +310,7 @@ struct RequestTests {
 
             let ipV4Hostname = "127.0.0.1"
             try await app.testing(method: .running(hostname: ipV4Hostname, port: 0)).test(.get, "remote") { res in
-                #expect(res.body.string.contains("[IPv4]\(ipV4Hostname)"))
+                try #expect(await res.body.requireString().contains("[IPv4]\(ipV4Hostname)"))
             }
         }
     }
@@ -329,7 +329,7 @@ struct RequestTests {
 
             let ipV4Hostname = "127.0.0.1"
             try await app.testing(method: .running(hostname: ipV4Hostname, port: 0)).test(.get, "remote") { res in
-                #expect(res.body.string == "[IPv4]192.0.2.60:80")
+                try #expect(await res.body.requireString() == "[IPv4]192.0.2.60:80")
             }
         }
     }
@@ -348,7 +348,7 @@ struct RequestTests {
             try await app.testing(method: .running).test(.get, "remote", beforeRequest: { req in
                 req.headers[.xRequestId] = "test"
             }, afterResponse: { res in
-                #expect(res.body.string == "test")
+                try #expect(await res.body.requireString() == "test")
             })
         }
     }
@@ -361,7 +361,7 @@ struct RequestTests {
             }
 
             try await app.testing(method: .running).test(.get, "remote") { res in
-                #expect(res.body.string.contains("IP"))
+                try #expect(await res.body.requireString().contains("IP"))
             }
         }
     }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -269,7 +269,9 @@ struct RouteTests {
             try await app.testing(method: .running).test(.head, "/hello") { res in
                 #expect(res.status == .ok)
                 #expect(res.headers[.contentLength] == "2")
-                #expect(res.body.count == 0)
+                // The body has to be collected before it can be counted: an uncollected stream
+                // reports `-1`, not the number of bytes that actually arrived.
+                try #expect(await res.body.data()?.count == 0)
             }
         }
     }
@@ -288,7 +290,7 @@ struct RouteTests {
             try await app.testing(method: .running).test(.head, "/hello") { res in
                 #expect(res.status == .found)
                 #expect(res.headers[.contentLength] == "0")
-                #expect(res.body.count == 0)
+                try #expect(await res.body.data()?.count == 0)
             }
         }
     }
@@ -322,7 +324,7 @@ struct RouteTests {
 
             try await app.testing(method: .running).test(.get, "/no-content") { res in
                 #expect(res.status.code == 204)
-                #expect(res.body.count == 0)
+                try #expect(await res.body.data()?.count == 0)
             }
         }
     }
@@ -339,10 +341,10 @@ struct RouteTests {
 
             try await app.test(method: .running) { testApp in
                 let rootResponse = try await testApp.sendRequest(.get, "/api/addresses")
-                #expect(rootResponse.body.string == "a")
+                try #expect(await rootResponse.body.requireString() == "a")
 
                 let testResponse = try await testApp.sendRequest(.get, "/api/addresses/search/test")
-                #expect(testResponse.body.string == "b")
+                try #expect(await testResponse.body.requireString() == "b")
 
                 let emptySearch = try await testApp.sendRequest(.get, "/api/addresses/search")
                 #expect(emptySearch.status == .notFound)
@@ -453,35 +455,35 @@ struct RouteTests {
 
             try await app.test(method: .running) { testApp in
                 let happyPath = try await testApp.sendRequest(.get, "/foop/barp/buz")
-                #expect(happyPath.body.string == "foopbarp")
+                try #expect(await happyPath.body.requireString() == "foopbarp")
                 #expect(happyPath.status == .ok)
 
                 let leadingDoubleSlash = try await testApp.sendRequest(.get, "//foop/barp/buz")
-                #expect(leadingDoubleSlash.body.string == "foopbarp")
+                try #expect(await leadingDoubleSlash.body.requireString() == "foopbarp")
                 #expect(leadingDoubleSlash.status == .ok)
 
                 let leadingAndMiddleDoubleSlash = try await testApp.sendRequest(.get, "//foop//barp/buz")
-                #expect(leadingAndMiddleDoubleSlash.body.string == "foopbarp")
+                try #expect(await leadingAndMiddleDoubleSlash.body.requireString() == "foopbarp")
                 #expect(leadingAndMiddleDoubleSlash.status == .ok)
 
                 let leadingMiddleAndTrailingDoubleSlash = try await testApp.sendRequest(.get, "//foop//barp//buz")
-                #expect(leadingMiddleAndTrailingDoubleSlash.body.string == "foopbarp")
+                try #expect(await leadingMiddleAndTrailingDoubleSlash.body.requireString() == "foopbarp")
                 #expect(leadingMiddleAndTrailingDoubleSlash.status == .ok)
 
                 let middleDoubleSlash = try await testApp.sendRequest(.get, "/foop//barp/buz")
-                #expect(middleDoubleSlash.body.string == "foopbarp")
+                try #expect(await middleDoubleSlash.body.requireString() == "foopbarp")
                 #expect(middleDoubleSlash.status == .ok)
 
                 let middleAndTrailingDoubleSlash = try await testApp.sendRequest(.get, "/foop//barp//buz")
-                #expect(middleAndTrailingDoubleSlash.body.string == "foopbarp")
+                try #expect(await middleAndTrailingDoubleSlash.body.requireString() == "foopbarp")
                 #expect(middleAndTrailingDoubleSlash.status == .ok)
 
                 let trailingDoubleSlash = try await testApp.sendRequest(.get, "/foop/barp//buz")
-                #expect(trailingDoubleSlash.body.string == "foopbarp")
+                try #expect(await trailingDoubleSlash.body.requireString() == "foopbarp")
                 #expect(trailingDoubleSlash.status == .ok)
 
                 let leadingAndTrailingDoubleSlash = try await testApp.sendRequest(.get, "//foop/barp//buz")
-                #expect(leadingAndTrailingDoubleSlash.body.string == "foopbarp")
+                try #expect(await leadingAndTrailingDoubleSlash.body.requireString() == "foopbarp")
                 #expect(leadingAndTrailingDoubleSlash.status == .ok)
             }
         }
@@ -516,11 +518,11 @@ struct RouteTests {
 
             try await app.test(method: .running) { testApp in
                 let emoticon = try await testApp.sendRequest(.get, "/Good👍")
-                #expect(emoticon.body.string == "👍")
+                try #expect(await emoticon.body.requireString() == "👍")
                 #expect(emoticon.status == .ok)
 
                 let japanese = try await testApp.sendRequest(.get, "/ようこそ世界へ")
-                #expect(japanese.body.string == "おめでとう")
+                try #expect(await japanese.body.requireString() == "おめでとう")
                 #expect(japanese.status == .ok)
             }
         }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -23,7 +23,7 @@ struct RouteTests {
             }
             try await app.testing().test(.get, "/hello/vapor") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("vapor"))
+                try #expect(await res.body.requireString().contains("vapor"))
             }
 
             try await app.testing().test(.post, "/hello/vapor") { res in
@@ -32,7 +32,7 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/hello/vapor/development") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == #"["vapor","development"]"#)
+                try #expect(await res.body.requireString() == #"["vapor","development"]"#)
             }
         }
     }
@@ -55,12 +55,12 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/string/test") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("test"))
+                try #expect(await res.body.requireString().contains("test"))
             }
 
             try await app.testing().test(.get, "/int/123") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "123")
+                try #expect(await res.body.requireString() == "123")
             }
 
             try await app.testing().test(.get, "/int/not-int") { res in
@@ -82,7 +82,7 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/json") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == #"{"foo":"bar"}"#)
+                try #expect(await res.body.requireString() == #"{"foo":"bar"}"#)
             }
         }
     }
@@ -99,12 +99,12 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "root")
+                try #expect(await res.body.requireString() == "root")
             }
 
             try await app.testing().test(.get, "/foo") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "foo")
+                try #expect(await res.body.requireString() == "foo")
             }
         }
     }
@@ -120,12 +120,12 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/foo") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "foo")
+                try #expect(await res.body.requireString() == "foo")
             }
 
             try await app.testing().test(.get, "/FOO") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "foo")
+                try #expect(await res.body.requireString() == "foo")
             }
         }
     }
@@ -145,14 +145,14 @@ struct RouteTests {
                 try req.query.encode(["number": "true"])
             }) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "42")
+                try #expect(await res.body.requireString() == "42")
             }
 
             try await app.testing().test(.get, "/foo", beforeRequest: { req in
                 try req.query.encode(["number": "false"])
             }) { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "string")
+                try #expect(await res.body.requireString() == "string")
             }
         }
     }
@@ -184,12 +184,12 @@ struct RouteTests {
 
             try await app.testing().test(.get, "/foo?number=true") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "42")
+                try #expect(await res.body.requireString() == "42")
             }
 
             try await app.testing().test(.get, "/foo?number=false") { res async in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "string")
+                try #expect(await res.body.requireString() == "string")
             }
         }
     }
@@ -218,17 +218,17 @@ struct RouteTests {
                 ], as: .json)
             }) { res in
                 #expect(res.status == .badRequest)
-                #expect(res.body.string.contains("email is not a valid email address"))
+                try #expect(await res.body.requireString().contains("email is not a valid email address"))
             }
 
             try await app.testing().test(.post, "/users") { res in
                 #expect(res.status == .unprocessableContent)
-                #expect(res.body.string.replacing("\\", with: "").contains("Missing \"Content-Type\" header"))
+                try #expect(await res.body.requireString().replacing("\\", with: "").contains("Missing \"Content-Type\" header"))
             }
 
             try await app.testing().test(.post, "/users", headers: [.contentType: "application/json"]) { res in
                 #expect(res.status == .unprocessableContent)
-                #expect(res.body.string.contains("Empty Body"))
+                try #expect(await res.body.requireString().contains("Empty Body"))
             }
         }
     }
@@ -251,7 +251,7 @@ struct RouteTests {
             }) { res in
                 #expect(res.status == .created)
                 #expect(res.headers.contentType == .json)
-                #expect(res.body.string == """
+                try #expect(await res.body.requireString() == """
             {"name":"vapor"}
             """)
             }
@@ -308,7 +308,7 @@ struct RouteTests {
             try await app.testing().test(.get, "/get", headers: headers) { res in
                 #expect(res.status == .ok)
                 #expect(res.headers[.setCookie] != nil)
-                #expect(res.body.string == "n/a")
+                try #expect(await res.body.requireString() == "n/a")
             }
         }
     }
@@ -376,7 +376,7 @@ struct RouteTests {
             try await app.register(collection: Foo())
 
             try await app.test(.get, "foo") { res in
-                #expect(res.body.string == "bar")
+                try #expect(await res.body.requireString() == "bar")
             }
         }
     }
@@ -498,7 +498,7 @@ struct RouteTests {
             for method in methods {
                 try await app.testing().test(method, "/universal") { res in
                     #expect(res.status == .ok)
-                    #expect(res.body.string == method.rawValue)
+                    try #expect(await res.body.requireString() == method.rawValue)
                 }
             }
         }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -182,12 +182,12 @@ struct RouteTests {
                 }
             }
 
-            try await app.testing().test(.get, "/foo?number=true") { res async in
+            try await app.testing().test(.get, "/foo?number=true") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "42")
             }
 
-            try await app.testing().test(.get, "/foo?number=false") { res async in
+            try await app.testing().test(.get, "/foo?number=false") { res in
                 #expect(res.status == .ok)
                 try #expect(await res.body.requireString() == "string")
             }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1321,7 +1321,7 @@ struct ServerTests {
 
             try await app.testing().test(.get, "/ping") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "123")
+                try #expect(await res.body.requireString() == "123")
             }
         }
     }

--- a/Tests/VaporTests/SessionTests.swift
+++ b/Tests/VaporTests/SessionTests.swift
@@ -25,7 +25,7 @@ struct SessionTests {
             }
 
             try await app.testing().test(.get, "/set") { res in
-                #expect(res.body.string == "set")
+                try #expect(await res.body.requireString() == "set")
                 cookie = res.headers.setCookie?["vapor-session"]
                 #expect(cookie != nil)
                 let ops = await cache.ops
@@ -42,7 +42,7 @@ struct SessionTests {
             cookies["vapor-session"] = cookie
             headers.cookie = cookies
             try await app.testing().test(.get, "/del", headers: headers) { res in
-                #expect(res.body.string == "del")
+                try #expect(await res.body.requireString() == "del")
                 let ops = await cache.ops
                 #expect(ops == [
                     #"read SessionID(string: "a")"#,
@@ -98,7 +98,7 @@ struct SessionTests {
                 req.headers.cookie = ["vapor-session": newCookie!]
             }, afterResponse: { res in
                 // Session access should be successful.
-                #expect(res.body.string == "bar")
+                try #expect(await res.body.requireString() == "bar")
                 #expect(res.status == .ok)
             })
         }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -764,6 +764,53 @@ struct StreamingBodyTests {
         }
     }
 
+    @Test("data(max:) and string(max:) collect a stream without needing a var")
+    func testCollectingAccessorsWorkOnALet() async throws {
+        let runs = NIOLockedValueBox(0)
+        let (chunks, continuation) = AsyncStream<String>.makeStream()
+        continuation.yield("hello ")
+        continuation.yield("world")
+        continuation.finish()
+
+        // `let`, deliberately: the plain properties cannot collect, so these have to.
+        let body = Response.Body(stream: { writer in
+            runs.withLockedValue { $0 += 1 }
+            for await chunk in chunks { try await writer.write(chunk) }
+        })
+
+        #expect(body.string == nil)
+        #expect(body.data == nil)
+        #expect(body.count == -1)
+
+        #expect(try await body.string() == "hello world")
+
+        // Collecting through the accessor's copy still fills the shared cache, so the plain
+        // properties answer afterwards and the stream is never run a second time.
+        #expect(body.string == "hello world")
+        #expect(body.data.map { String(decoding: $0, as: UTF8.self) } == "hello world")
+        #expect(body.count == 11)
+        #expect(try await body.data().map { String(decoding: $0, as: UTF8.self) } == "hello world")
+        #expect(runs.withLockedValue { $0 } == 1)
+    }
+
+    @Test("The collecting accessors honour their limit")
+    func testCollectingAccessorsHonourMax() async throws {
+        let body = Response.Body(stream: { writer in
+            try await writer.write(String(repeating: "x", count: 1000))
+        })
+        await #expect(throws: Abort.self) { try await body.string(max: 256) }
+        await #expect(throws: Abort.self) { try await body.data(max: 256) }
+    }
+
+    @Test("The collecting accessors pass a buffered body straight through")
+    func testCollectingAccessorsOnBufferedBodies() async throws {
+        #expect(try await Response.Body(string: "plain").string() == "plain")
+        #expect(try await Response.Body(staticString: "static").string() == "static")
+        #expect(try await Response.Body(data: Data("bytes".utf8)).string() == "bytes")
+        #expect(try await Response.Body.empty.string() == nil)
+        #expect(try await Response.Body.empty.data() == nil)
+    }
+
     @Test("An empty write does not corrupt the stream")
     func testEmptyWrite() async throws {
         var body = Response.Body(stream: { writer in

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -648,6 +648,122 @@ struct StreamingBodyTests {
         #expect(try await again.collect().map { String(decoding: $0, as: UTF8.self) } == "alphabeta")
     }
 
+    @Test("Collecting through one copy of a body is visible from the others")
+    func testCollectSharesBytesAcrossCopies() async throws {
+        // A `ContentContainer` reached through a computed `content` property holds a *copy* of the
+        // body, so its collection cannot be written back. Without state shared between copies that
+        // would drain the stream and leave the original pointing at a spent source.
+        let runs = NIOLockedValueBox(0)
+        let original = Response.Body(stream: { writer in
+            runs.withLockedValue { $0 += 1 }
+            try await writer.write("shared")
+        })
+
+        var copy = original
+        #expect(try await copy.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
+
+        // The original still holds `.stream`, but the bytes are reachable without re-running it.
+        #expect(original.string == "shared")
+        #expect(original.data.map { String(decoding: $0, as: UTF8.self) } == "shared")
+        #expect(original.count == 6)
+
+        var second = original
+        #expect(try await second.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
+        #expect(runs.withLockedValue { $0 } == 1)
+    }
+
+    @Test("An unknown-length stream reports its real count once collected")
+    func testCollectedStreamReportsRealCount() async throws {
+        let body = Response.Body(stream: { writer in try await writer.write("twelve bytes") })
+        // `-1` until collected: an unknown-length stream cannot say how long it is in advance.
+        #expect(body.count == -1)
+        var copy = body
+        _ = try await copy.collect()
+        #expect(body.count == 12)
+    }
+
+    @Test("collect(max:) rejects a stream that produces more than the limit")
+    func testCollectMaxRejectsOversizedStream() async throws {
+        var body = Response.Body(stream: { writer in
+            for _ in 0..<10 { try await writer.write(String(repeating: "x", count: 100)) }
+        })
+        await #expect(throws: Abort.self) { try await body.collect(max: 256) }
+    }
+
+    @Test("collect(max:) allows a stream that stays within the limit")
+    func testCollectMaxAllowsStreamWithinLimit() async throws {
+        var body = Response.Body(stream: { writer in try await writer.write("small") })
+        #expect(try await body.collect(max: 256).map { String(decoding: $0, as: UTF8.self) } == "small")
+    }
+
+    @Test("collect(max:) rejects a declared length over the limit without running the stream")
+    func testCollectMaxRejectsDeclaredLengthBeforeRunning() async throws {
+        let ran = NIOLockedValueBox(false)
+        var body = Response.Body(stream: { writer in
+            ran.withLockedValue { $0 = true }
+            try await writer.write(String(repeating: "x", count: 1000))
+        }, count: 1000)
+        await #expect(throws: Abort.self) { try await body.collect(max: 256) }
+        #expect(ran.withLockedValue { $0 } == false)
+    }
+
+    @Test("Streaming a body a copy already collected replays the bytes instead of re-running it")
+    func testStreamingAfterCollectReplaysFromCache() async throws {
+        // A one-shot source - an `AsyncStream`, a file handle, a client response's iterator - yields
+        // nothing on a second run, so re-running the callback here would silently produce an empty
+        // body rather than an error.
+        let runs = NIOLockedValueBox(0)
+        let (chunks, continuation) = AsyncStream<String>.makeStream()
+        continuation.yield("payload")
+        continuation.finish()
+
+        let original = Response.Body(stream: { writer in
+            runs.withLockedValue { $0 += 1 }
+            for await chunk in chunks { try await writer.write(chunk) }
+        })
+
+        var copy = original
+        _ = try await copy.collect()
+
+        var seen = ""
+        try await original.withStreamingBytes { span in
+            seen += String(decoding: span.withUnsafeBytes { Array($0) }, as: UTF8.self)
+        }
+        #expect(seen == "payload")
+        #expect(runs.withLockedValue { $0 } == 1)
+
+        // `reduceBytes` is built on `withStreamingBytes`, so it replays too.
+        let count = try await original.reduceBytes(into: 0) { total, span in total += span.byteCount }
+        #expect(count == 7)
+        #expect(runs.withLockedValue { $0 } == 1)
+    }
+
+    @Test("The server writes the collected bytes for a body drained through a copy", .timeLimit(.minutes(1)))
+    func testServerSerialisesBodyCollectedThroughACopy() async throws {
+        // Exactly what a middleware calling `content.decode` does: the container holds a copy, so the
+        // response still carries `.stream` storage over a source that has already been drained.
+        try await withApp { app in
+            app.get("proxied") { _ -> Response in
+                let (chunks, continuation) = AsyncStream<String>.makeStream()
+                continuation.yield("hello ")
+                continuation.yield("world")
+                continuation.finish()
+
+                let response = Response(status: .ok, body: .init(stream: { writer in
+                    for await chunk in chunks { try await writer.write(chunk) }
+                }))
+                var copy = response.body
+                _ = try await copy.collect()
+                return response
+            }
+
+            try await app.testing(method: .running).test(.get, "/proxied") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "hello world")
+            }
+        }
+    }
+
     @Test("An empty write does not corrupt the stream")
     func testEmptyWrite() async throws {
         var body = Response.Body(stream: { writer in

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -256,7 +256,7 @@ struct StreamingBodyTests {
             // never concluded and the client can never receive the full 8-byte body — it either
             // errors on the truncated response or sees fewer bytes than advertised.
             app.get("abort") { _ -> Response in
-                Response(status: .ok, body: .init(stream: { writer in
+                Response(status: .ok, body: try .init(stream: { writer in
                     try await writer.write("AAAA")
                     throw MidStreamError()
                 }, count: 8))
@@ -438,7 +438,7 @@ struct StreamingBodyTests {
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             // Declares `Content-Length: 2` (via `count`) but only writes a single byte.
             app.get("bad-length") { _ -> Response in
-                Response(status: .ok, body: .init(stream: { writer in
+                Response(status: .ok, body: try .init(stream: { writer in
                     try await writer.write("a")
                 }, count: 2))
             }
@@ -483,7 +483,7 @@ struct StreamingBodyTests {
 
     @Test("collect() gathers a streaming body into a single buffer")
     func testCollectStreamingBody() async throws {
-        var body = Response.Body(stream: { writer in
+        var body = try Response.Body(stream: { writer in
             try await writer.write("Hello, ")
             try await writer.write("collected!")
         })
@@ -675,8 +675,8 @@ struct StreamingBodyTests {
     @Test("An unknown-length stream reports its real count once collected")
     func testCollectedStreamReportsRealCount() async throws {
         let body = Response.Body(stream: { writer in try await writer.write("twelve bytes") })
-        // `-1` until collected: an unknown-length stream cannot say how long it is in advance.
-        #expect(body.count == -1)
+        // `nil` until collected: an unknown-length stream cannot say how long it is in advance.
+        #expect(body.count == nil)
         var copy = body
         _ = try await copy.collect()
         #expect(body.count == 12)
@@ -699,7 +699,7 @@ struct StreamingBodyTests {
     @Test("collect(max:) rejects a declared length over the limit without running the stream")
     func testCollectMaxRejectsDeclaredLengthBeforeRunning() async throws {
         let ran = NIOLockedValueBox(false)
-        var body = Response.Body(stream: { writer in
+        var body = try Response.Body(stream: { writer in
             ran.withLockedValue { $0 = true }
             try await writer.write(String(repeating: "x", count: 1000))
         }, count: 1000)
@@ -780,7 +780,7 @@ struct StreamingBodyTests {
 
         #expect(body.string == nil)
         #expect(body.data == nil)
-        #expect(body.count == -1)
+        #expect(body.count == nil)
 
         try #expect(await body.string() == "hello world")
 
@@ -815,7 +815,7 @@ struct StreamingBodyTests {
     func testTesterResponseBodyCollection() async throws {
         try await withApp { app in
             app.get("stream") { _ in
-                Response(body: .init(stream: { writer in
+                Response(body: try .init(stream: { writer in
                     try await writer.write("alpha")
                     try await writer.write("beta")
                 }))
@@ -834,6 +834,27 @@ struct StreamingBodyTests {
                 try #expect(await streaming.body.requireString() == "alphabeta")
             }
         }
+    }
+
+    @Test("A streaming body rejects a negative declared length")
+    func testNegativeStreamCountIsRejected() async throws {
+        // Thrown, not trapped: a `precondition` here would be checked in release builds too, so one
+        // handler's arithmetic mistake would take down a server serving everything else correctly.
+        #expect(throws: Response.Body.NegativeCountError(count: -5)) {
+            try Response.Body(stream: { _ in }, count: -5)
+        }
+
+        // `nil` is the way to say "length unknown", and zero is a legitimate length.
+        #expect(throws: Never.self) {
+            _ = try Response.Body(stream: { _ in }, count: 0)
+            _ = try Response.Body(stream: { _ in }, count: nil)
+        }
+        _ = Response.Body(stream: { _ in })   // the convenience cannot fail, so it does not throw
+
+        // It surfaces as a 500 with a diagnosable reason rather than an opaque failure.
+        let error = Response.Body.NegativeCountError(count: -5)
+        #expect(error.status == .internalServerError)
+        #expect(error.reason.contains("-5"))
     }
 
     @Test("An empty write does not corrupt the stream")

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -759,7 +759,7 @@ struct StreamingBodyTests {
 
             try await app.testing(method: .running).test(.get, "/proxied") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "hello world")
+                try #expect(await res.body.requireString() == "hello world")
             }
         }
     }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -239,7 +239,7 @@ struct StreamingBodyTests {
                     HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
                 )
                 #expect(ok.status == .ok)
-                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
+                try #expect(await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()
@@ -292,7 +292,7 @@ struct StreamingBodyTests {
                     HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
                 )
                 #expect(ok.status == .ok)
-                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
+                try #expect(await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()
@@ -338,7 +338,7 @@ struct StreamingBodyTests {
                     HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
                 )
                 #expect(ok.status == .ok)
-                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
+                try #expect(await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()
@@ -473,7 +473,7 @@ struct StreamingBodyTests {
                     HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
                 )
                 #expect(ok.status == .ok)
-                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
+                try #expect(await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()
@@ -645,7 +645,7 @@ struct StreamingBodyTests {
         #expect(response.body.string == "alphabeta")
         #expect(response.body.count == 9)
         var again = response.body
-        #expect(try await again.collect().map { String(decoding: $0, as: UTF8.self) } == "alphabeta")
+        try #expect(await again.collect().map { String(decoding: $0, as: UTF8.self) } == "alphabeta")
     }
 
     @Test("Collecting through one copy of a body is visible from the others")
@@ -660,7 +660,7 @@ struct StreamingBodyTests {
         })
 
         var copy = original
-        #expect(try await copy.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
+        try #expect(await copy.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
 
         // The original still holds `.stream`, but the bytes are reachable without re-running it.
         #expect(original.string == "shared")
@@ -668,7 +668,7 @@ struct StreamingBodyTests {
         #expect(original.count == 6)
 
         var second = original
-        #expect(try await second.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
+        try #expect(await second.collect().map { String(decoding: $0, as: UTF8.self) } == "shared")
         #expect(runs.withLockedValue { $0 } == 1)
     }
 
@@ -693,7 +693,7 @@ struct StreamingBodyTests {
     @Test("collect(max:) allows a stream that stays within the limit")
     func testCollectMaxAllowsStreamWithinLimit() async throws {
         var body = Response.Body(stream: { writer in try await writer.write("small") })
-        #expect(try await body.collect(max: 256).map { String(decoding: $0, as: UTF8.self) } == "small")
+        try #expect(await body.collect(max: 256).map { String(decoding: $0, as: UTF8.self) } == "small")
     }
 
     @Test("collect(max:) rejects a declared length over the limit without running the stream")
@@ -782,14 +782,14 @@ struct StreamingBodyTests {
         #expect(body.data == nil)
         #expect(body.count == -1)
 
-        #expect(try await body.string() == "hello world")
+        try #expect(await body.string() == "hello world")
 
         // Collecting through the accessor's copy still fills the shared cache, so the plain
         // properties answer afterwards and the stream is never run a second time.
         #expect(body.string == "hello world")
         #expect(body.data.map { String(decoding: $0, as: UTF8.self) } == "hello world")
         #expect(body.count == 11)
-        #expect(try await body.data().map { String(decoding: $0, as: UTF8.self) } == "hello world")
+        try #expect(await body.data().map { String(decoding: $0, as: UTF8.self) } == "hello world")
         #expect(runs.withLockedValue { $0 } == 1)
     }
 
@@ -804,11 +804,36 @@ struct StreamingBodyTests {
 
     @Test("The collecting accessors pass a buffered body straight through")
     func testCollectingAccessorsOnBufferedBodies() async throws {
-        #expect(try await Response.Body(string: "plain").string() == "plain")
-        #expect(try await Response.Body(staticString: "static").string() == "static")
-        #expect(try await Response.Body(data: Data("bytes".utf8)).string() == "bytes")
-        #expect(try await Response.Body.empty.string() == nil)
-        #expect(try await Response.Body.empty.data() == nil)
+        try #expect(await Response.Body(string: "plain").string() == "plain")
+        try #expect(await Response.Body(staticString: "static").string() == "static")
+        try #expect(await Response.Body(data: Data("bytes".utf8)).string() == "bytes")
+        try #expect(await Response.Body.empty.string() == nil)
+        try #expect(await Response.Body.empty.data() == nil)
+    }
+
+    @Test("Testers collect the response body by default, and can be asked not to", .timeLimit(.minutes(1)))
+    func testTesterResponseBodyCollection() async throws {
+        try await withApp { app in
+            app.get("stream") { _ in
+                Response(body: .init(stream: { writer in
+                    try await writer.write("alpha")
+                    try await writer.write("beta")
+                }))
+            }
+
+            try await app.test(method: .running) { runner in
+                // Default: collected. A test that only asserts on headers still drains the request,
+                // so the server is never left writing into a cancelled response.
+                let collected = try await runner.sendRequest(.get, "/stream")
+                #expect(collected.body.string == "alphabeta")
+                #expect(collected.body.count == 9)
+
+                // Opted in: handed over still streaming, so the test owns consuming it.
+                let streaming = try await runner.sendRequest(.get, "/stream", responseBodyCollection: .stream)
+                #expect(streaming.body.string == nil)
+                try #expect(await streaming.body.requireString() == "alphabeta")
+            }
+        }
     }
 
     @Test("An empty write does not corrupt the stream")
@@ -940,7 +965,7 @@ struct StreamingBodyTests {
                     HTTPClientRequest(url: "http://127.0.0.1:\(port)/ok"), timeout: .seconds(10)
                 )
                 #expect(ok.status == .ok)
-                #expect(try await ok.body.collect(upTo: 1 << 20).string == "ok")
+                try #expect(await ok.body.collect(upTo: 1 << 20).string == "ok")
 
                 await group.triggerGracefulShutdown()
                 try await tg.waitForAll()

--- a/Tests/VaporTests/Utilities/ByteBuffer+Helpers.swift
+++ b/Tests/VaporTests/Utilities/ByteBuffer+Helpers.swift
@@ -6,4 +6,8 @@ extension ByteBuffer {
         buffer.writeString(string)
         self = buffer
     }
+
+    var string: String {
+        .init(decoding: self.readableBytesView, as: UTF8.self)
+    }
 }

--- a/Tests/VaporTests/VaporTesting.swift
+++ b/Tests/VaporTests/VaporTesting.swift
@@ -28,7 +28,7 @@ struct VaporTestingTests {
                 try req.content.encode(FooContent())
             } afterResponse: { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("decoded!"))
+                try #expect(await res.body.string()?.contains("decoded!") ?? false)
             }
 
             app.routes.post("decode-bad-header") { req async throws -> String in
@@ -54,7 +54,7 @@ struct VaporTestingTests {
                 req.headers.contentType = .audio
             } afterResponse: { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string.contains("decoded!"))
+                try #expect(await res.body.string()?.contains("decoded!") ?? false)
             }
         }
     }

--- a/Tests/VaporTests/VaporTesting.swift
+++ b/Tests/VaporTests/VaporTesting.swift
@@ -76,7 +76,7 @@ struct VaporTestingTests {
         try await withApp(configure: configure) { app in
             try await app.testing().test(.get, "hello") { res in
                 #expect(res.status == .ok)
-                #expect(res.body.string == "Hello, world!")
+                try #expect(await res.body.requireString() == "Hello, world!")
             }
         }
     }

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -16,7 +16,7 @@ struct ViewTests {
                 return View(data: data)
             }
 
-            try await app.testing().test(.get, "/view") { res async in
+            try await app.testing().test(.get, "/view") { res in
                 #expect(res.status.code == 200)
                 #expect(res.headers.contentType == .html)
                 try #expect(await res.body.requireString() == "<h1>hello</h1>")

--- a/Tests/VaporTests/ViewTests.swift
+++ b/Tests/VaporTests/ViewTests.swift
@@ -19,7 +19,7 @@ struct ViewTests {
             try await app.testing().test(.get, "/view") { res async in
                 #expect(res.status.code == 200)
                 #expect(res.headers.contentType == .html)
-                #expect(res.body.string == "<h1>hello</h1>")
+                try #expect(await res.body.requireString() == "<h1>hello</h1>")
             }
         }
     }


### PR DESCRIPTION
Migrate all the request types we have to use the same `Response.Body` from the main response so they all get streaming capabiliites. Also removes a load of ByteBuffer references
