### PR TITLE
Fail server startup on an empty TLS certificate chain

### DIFF
--- a/Sources/Vapor/HTTP/Server/NIOHTTPServerAdapter.swift
+++ b/Sources/Vapor/HTTP/Server/NIOHTTPServerAdapter.swift
@@ -15,6 +15,10 @@ enum NIOHTTPServerAdapterError: Error {
 
     /// No HTTP versions were configured. ``ServerConfiguration/httpVersions`` must contain at least one version.
     case noHTTPVersionsSpecified
+
+    /// The in-memory TLS credentials carried an empty certificate chain. A server has nothing to present
+    /// during the handshake without at least a leaf certificate.
+    case emptyCertificateChain
 }
 
 /// Adapts `NIOHTTPServer` to Vapor's `Server` protocol using structured concurrency.
@@ -74,6 +78,9 @@ final class NIOHTTPServerAdapter: Server, Sendable {
             let credentials: NIOHTTPServerConfiguration.TransportSecurity.TLSCredentials
             switch tls.source {
             case .inMemory(let chain, let key):
+                guard !chain.isEmpty else {
+                    throw NIOHTTPServerAdapterError.emptyCertificateChain
+                }
                 credentials = .x509(.certificates(chain: chain, privateKey: key))
             case .pemFile(let certPath, let keyPath):
                 credentials = .x509(.pemFile(certificateChainPath: certPath, privateKeyPath: keyPath))

--- a/Tests/VaporTests/ServerTLSTests.swift
+++ b/Tests/VaporTests/ServerTLSTests.swift
@@ -355,6 +355,30 @@ struct ServerTLSTests {
         }
     }
 
+    @Test("Server startup fails when the in-memory certificate chain is empty", .timeLimit(.minutes(1)))
+    func testEmptyCertificateChainFailsServerStartup() async throws {
+        try await withApp { app in
+            let credentials = try TestCredentials.localhost()
+            app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
+            app.serverConfiguration.tlsConfiguration = .inMemory(
+                certificateChain: [],
+                privateKey: credentials.privateKey
+            )
+            app.get("hello") { _ in "world" }
+
+            try await app.boot()
+
+            do {
+                try await app.server.run()
+                Issue.record("Expected run() to throw for an empty certificate chain.")
+            } catch NIOHTTPServerAdapterError.emptyCertificateChain {
+                // Expected.
+            } catch {
+                Issue.record("Expected emptyCertificateChain but got \(error).")
+            }
+        }
+    }
+
     @Test("Waiting on the listening address fails when startup fails", .timeLimit(.minutes(1)))
     func testListeningAddressFailsWhenStartupFails() async throws {
         try await withApp { app in


### PR DESCRIPTION
Fails server startup when `.inMemory` TLS credentials carry an empty certificate chain (fixes #3540).

Previously `.inMemory(certificateChain: [], privateKey:)` started the server. `run()` did not throw and `listeningAddress` resolved, so the application looked healthy while every TLS handshake failed with `TLSV1_ALERT_INTERNAL_ERROR` and nothing on the server side reported why. A mismatched private key and `.pemFile` with missing paths both already fail at startup; the empty chain was the one bad credential that got through.

`NIOHTTPServerAdapter` now rejects it where the TLS credentials are built, throwing the new `NIOHTTPServerAdapterError.emptyCertificateChain`.

```swift
// Now throws at startup instead of failing every handshake later.
app.serverConfiguration.tlsConfiguration = .inMemory(certificateChain: [], privateKey: privateKey)
try await app.server.run()
```

Covered by a negative-path test in `ServerTLSTests`.