### PR TITLE
Fix a bunch of unsafe warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -241,6 +241,7 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .strictMemorySafety(),
+//    .treatAllWarnings(as: .error),
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),

--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -90,8 +90,7 @@ extension ClientRequest {
 
     public var content: any ContentContainer {
         get {
-            var bodyData = body
-            return _ContentContainer(body: bodyData?.getData(at: 0, length: bodyData?.readableBytes ?? 0), headers: self.headers, contentConfiguration: self.contentConfiguration) }
+            return _ContentContainer(body: body?.getData(at: 0, length: body?.readableBytes ?? 0), headers: self.headers, contentConfiguration: self.contentConfiguration) }
         set {
             let container = (newValue as! _ContentContainer)
             self.body = ByteBuffer(data: container.body ?? Data())

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -165,7 +165,7 @@ final class NIOResponseBodyWriter: ResponseBodyWriter {
         // We need to copy here so the writer takes ownership of the data
         // TODO: This should be fixed in HTTP Server to avoid the copy
         var out = UniqueArray<UInt8>(minimumCapacity: bytes.byteCount)
-        bytes.withUnsafeBytes { out.append(copying: $0) }
+        bytes.withUnsafeBytes { unsafe out.append(copying: $0) }
         try await self.inner?.write(buffer: &out)
         self.bytesWritten += bytes.byteCount
     }

--- a/Sources/Vapor/Middleware/MetricsMiddleware.swift
+++ b/Sources/Vapor/Middleware/MetricsMiddleware.swift
@@ -11,9 +11,7 @@ public final class MetricsMiddleware: Middleware {
     public init() {}
     
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
-        // per https://github.com/swiftlang/swift-testing/blob/swift-6.1-RELEASE/Sources/Testing/Events/TimeValue.swift#L113
-        let epochDuration = unsafeBitCast((0, 0), to: ContinuousClock.Instant.self).duration(to: .now)
-        let startTime = UInt64(epochDuration.components.seconds * 1_000_000_000 + (epochDuration.components.attoseconds / 1_000_000_000))
+        let startInstant = ContinuousClock.now
         
         // Attributes: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-semantic-conventions
         let httpRequestMethod = request.method.rawValue
@@ -80,8 +78,8 @@ public final class MetricsMiddleware: Middleware {
         
         // http.server.request.duration
         // https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
-        let now = unsafeBitCast((0, 0), to: ContinuousClock.Instant.self).duration(to: .now)
-        let nowNanos = UInt64(now.components.seconds * 1_000_000_000 + (now.components.attoseconds / 1_000_000_000))
+        let elapsed = startInstant.duration(to: .now)
+        let elapsedNanos = elapsed.components.seconds * 1_000_000_000 + (elapsed.components.attoseconds / 1_000_000_000)
         Timer(
             label: "http.server.request.duration",
             dimensions: [
@@ -98,7 +96,7 @@ public final class MetricsMiddleware: Middleware {
                 // Recommended
                 ("network.protocol.version", networkProtocolVersion),
             ]
-        ).recordNanoseconds(nowNanos - startTime)
+        ).recordNanoseconds(elapsedNanos)
         
         switch responseOrError {
         case .error(let error):

--- a/Sources/Vapor/Response/Response+Body.swift
+++ b/Sources/Vapor/Response/Response+Body.swift
@@ -362,7 +362,7 @@ private final class CollectingBodyWriter: ResponseBodyWriter {
 
     func write(_ bytes: RawSpan) async throws {
         try self.checkLimit(adding: bytes.byteCount)
-        bytes.withUnsafeBytes { self.data.append(contentsOf: $0) }
+        bytes.withUnsafeBytes { unsafe self.data.append(contentsOf: $0) }
     }
 
     /// Appending is synchronous, so the sequence's own storage can be borrowed instead of copying

--- a/Sources/Vapor/Utilities/Base32.swift
+++ b/Sources/Vapor/Utilities/Base32.swift
@@ -12,34 +12,42 @@ public import struct Foundation.Data
 extension BaseNEncoding {
     /// Specialization of ``encode(_:base:pad:using:)`` for Base32.
     @inlinable
-    internal static func encode32<C>(_ decoded: C, pad: UInt8?, using tab: [UInt8]) -> [UInt8] where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    internal static func encode32(_ decoded: Span<UInt8>, pad: UInt8?, using tab: [UInt8]) -> [UInt8] {
         assert(tab.count == 32, "Mapping table must have exactly 32 elements.")
         guard !decoded.isEmpty else { return [] }
         let outlen = sizeEnc(for: 5, count: decoded.count), padding = self.padding(for: 5, count: outlen), inp = decoded
-        
-        return .init(unsafeUninitializedCapacity: outlen + padding) { p, n in
-            var idx = inp.startIndex, b00 = 0, b01 = 0; func get(_ offset: Int) -> Int { Int(truncatingIfNeeded: inp[idx &+ offset]) }
-            while inp.endIndex &- idx >= 5 {
+
+        return .init(capacity: outlen + padding) { span in
+            var idx = 0; func get(_ offset: Int) -> Int { Int(truncatingIfNeeded: inp[idx &+ offset]) }
+            while inp.count &- idx >= 5 {
                 let b0 = get(0), b1 = get(1), b2 = get(2), b3 = get(3), b4 = get(4)
-                
-                p[n &+ 0] = tab[((b0 & 0xf8) &>> 3)             ]; p[n &+ 1] = tab[((b0 & 0x07) &<< 2) | (b1 &>> 6)]
-                p[n &+ 2] = tab[((b1 & 0x3e) &>> 1)             ]; p[n &+ 3] = tab[((b1 & 0x01) &<< 4) | (b2 &>> 4)]
-                p[n &+ 4] = tab[((b2 & 0x0f) &<< 1) | (b3 &>> 7)]; p[n &+ 5] = tab[((b3 & 0x7c) &>> 2)             ]
-                p[n &+ 6] = tab[((b3 & 0x03) &<< 3) | (b4 &>> 5)]; p[n &+ 7] = tab[((b4 & 0x1f)      )             ]
-                (idx, n) = (idx &+ 5, n &+ 8)
+
+                span.append(tab[((b0 & 0xf8) &>> 3)             ]); span.append(tab[((b0 & 0x07) &<< 2) | (b1 &>> 6)])
+                span.append(tab[((b1 & 0x3e) &>> 1)             ]); span.append(tab[((b1 & 0x01) &<< 4) | (b2 &>> 4)])
+                span.append(tab[((b2 & 0x0f) &<< 1) | (b3 &>> 7)]); span.append(tab[((b3 & 0x7c) &>> 2)             ])
+                span.append(tab[((b3 & 0x03) &<< 3) | (b4 &>> 5)]); span.append(tab[((b4 & 0x1f)      )             ])
+                idx &+= 5
             }
-            switch padding {
-                case 1: (b01, b00) = (b00, get(3)); p[n &+ 6] = tab[((b00 & 0x03) &<< 3)              ]; p[n &+ 5] = tab[(b00 & 0x7c) &>> 2]; fallthrough
-                case 3: (b01, b00) = (b00, get(2)); p[n &+ 4] = tab[((b00 & 0x0f) &<< 1) | (b01 &>> 7)]                                   ; fallthrough
-                case 4: (b01, b00) = (b00, get(1)); p[n &+ 3] = tab[((b00 & 0x01) &<< 4) | (b01 &>> 4)]; p[n &+ 2] = tab[(b00 & 0x3e) &>> 1]; fallthrough
-                case 6: (b01, b00) = (b00, get(0)); p[n &+ 1] = tab[((b00 & 0x07) &<< 2) | (b01 &>> 6)]; p[n &+ 0] = tab[(b00 & 0xf8) &>> 3]
-                case 0: return; default: fatalError("unreachable")
+            // The remaining 1-4 input bytes emit the same values the main loop would with the
+            // missing input bytes taken as zero, truncated to ceil(remaining * 8 / 5) values.
+            let rem = inp.count &- idx
+            let b0 = rem > 0 ? get(0) : 0, b1 = rem > 1 ? get(1) : 0, b2 = rem > 2 ? get(2) : 0, b3 = rem > 3 ? get(3) : 0
+            switch rem {
+                case 0: return
+                case 1: span.append(tab[((b0 & 0xf8) &>> 3)]); span.append(tab[((b0 & 0x07) &<< 2)             ])
+                case 2: span.append(tab[((b0 & 0xf8) &>> 3)]); span.append(tab[((b0 & 0x07) &<< 2) | (b1 &>> 6)])
+                        span.append(tab[((b1 & 0x3e) &>> 1)]); span.append(tab[((b1 & 0x01) &<< 4)             ])
+                case 3: span.append(tab[((b0 & 0xf8) &>> 3)]); span.append(tab[((b0 & 0x07) &<< 2) | (b1 &>> 6)])
+                        span.append(tab[((b1 & 0x3e) &>> 1)]); span.append(tab[((b1 & 0x01) &<< 4) | (b2 &>> 4)])
+                        span.append(tab[((b2 & 0x0f) &<< 1)])
+                case 4: span.append(tab[((b0 & 0xf8) &>> 3)]); span.append(tab[((b0 & 0x07) &<< 2) | (b1 &>> 6)])
+                        span.append(tab[((b1 & 0x3e) &>> 1)]); span.append(tab[((b1 & 0x01) &<< 4) | (b2 &>> 4)])
+                        span.append(tab[((b2 & 0x0f) &<< 1) | (b3 &>> 7)])
+                        span.append(tab[((b3 & 0x7c) &>> 2)]); span.append(tab[((b3 & 0x03) &<< 3)             ])
+                default: fatalError("unreachable")
             }
-            n &+= 8 &- padding
-            if let pad = pad, padding > 0 {
-                let pn = p.baseAddress!.advanced(by: n)
-                pn.update(repeating: pad, count: padding)
-                n &+= padding
+            if let pad = pad {
+                span.append(repeating: pad, count: padding)
             }
         }
     }
@@ -97,7 +105,7 @@ extension Array where Element == UInt8 {
     /// Decode a string in canonical Base32-encoded representation.
     @inlinable
     public init?(decodingBase32 str: String) {
-        guard let decoded = str.utf8.withContiguousStorageIfAvailable({ Array(decodingBase32: $0) }) ?? Array(decodingBase32: Array(str.utf8))
+        guard let decoded = Base32.default.decode(str.utf8Span.span)
         else { return nil }
         self = decoded
     }
@@ -119,7 +127,7 @@ extension RandomAccessCollection where Element == UInt8, Index == Int {
 
 extension String {
     @inlinable
-    public func base32Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.base32Bytes() } ?? Array(self.utf8).base32Bytes() }
+    public func base32Bytes() -> [UInt8] { Base32.default.encode(self.utf8Span.span) }
 
     @inlinable
     public func base32String() -> String { .init(decoding: self.base32Bytes(), as: Unicode.ASCII.self) }
@@ -127,7 +135,7 @@ extension String {
 
 extension Substring {
     @inlinable
-    public func base32Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.base32Bytes() } ?? Array(self.utf8).base32Bytes() }
+    public func base32Bytes() -> [UInt8] { Base32.default.encode(self.utf8Span.span) }
 
     @inlinable
     public func base32String() -> String { .init(decoding: self.base32Bytes(), as: Unicode.ASCII.self) }
@@ -138,7 +146,7 @@ extension Data {
     /// Decodes a relaxed-Base32-encoded `String`. Returns `nil` if the input is not valid relaxed-Base32.
     @inlinable
     public init?(base32Encoded str: String) {
-        guard let decoded = str.utf8.withContiguousStorageIfAvailable({ Base32.relaxed.decode($0) }) ?? Base32.relaxed.decode(Array(str.utf8))
+        guard let decoded = Base32.relaxed.decode(str.utf8Span.span)
         else { return nil }
         self.init(decoded)
     }
@@ -146,15 +154,15 @@ extension Data {
     /// Decodes relaxed-Base32-encoded `Data`. Returns `nil` if the input is not valid relaxed-Base32.
     @inlinable
     public init?(base32Encoded: Data) {
-        guard let decoded = Base32.relaxed.decode(base32Encoded) else { return nil }
+        guard let decoded = Base32.relaxed.decode(base32Encoded.span) else { return nil }
         self.init(decoded)
     }
 
     /// Return this `Data` encoded with relaxed-Base32 as a `String`.
     @inlinable
-    public func base32EncodedString() -> String { .init(decoding: Base32.relaxed.encode(self), as: Unicode.ASCII.self) }
+    public func base32EncodedString() -> String { .init(decoding: Base32.relaxed.encode(self.span), as: Unicode.ASCII.self) }
 
     /// Return this `Data` encoded with relaxed-Base32 as `Data`.
     @inlinable
-    public func base32EncodedData() -> Data { .init(Base32.relaxed.encode(self)) }
+    public func base32EncodedData() -> Data { .init(Base32.relaxed.encode(self.span)) }
 }

--- a/Sources/Vapor/Utilities/Base64.swift
+++ b/Sources/Vapor/Utilities/Base64.swift
@@ -11,75 +11,70 @@ import struct Foundation.Data
 extension BaseNEncoding {
     /// Specialization of ``encode(_:base:pad:using:)`` for Base64.
     @inlinable
-    internal static func encode64<C>(_ decoded: C, pad: UInt8?, using tab: [UInt8]) -> [UInt8] where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    internal static func encode64(_ decoded: Span<UInt8>, pad: UInt8?, using tab: [UInt8]) -> [UInt8] {
         assert(tab.count == 64, "Mapping table must have exactly 64 elements.")
         guard !decoded.isEmpty else { return [] }
         let outlen = sizeEnc(for: 6, count: decoded.count), padding = self.padding(for: 6, count: outlen), inp = decoded
-        
-        return .init(unsafeUninitializedCapacity: outlen + padding) { p, n in
-            var idx = inp.startIndex, b00 = 0, b01 = 0; func get(_ offset: Int) -> Int { Int(truncatingIfNeeded: inp[idx &+ offset]) }
-            while inp.endIndex &- idx >= 3 {
+
+        return .init(capacity: outlen + padding) { span in
+            var idx = 0; func get(_ offset: Int) -> Int { Int(truncatingIfNeeded: inp[idx &+ offset]) }
+            while inp.count &- idx >= 3 {
                 let b0 = get(0), b1 = get(1), b2 = get(2)
-                p[n &+ 0] = tab[((b0 & 0xfc) &>> 2)             ]; p[n &+ 1] = tab[((b0 & 0x03) &<< 4) | (b1 &>> 4)]
-                p[n &+ 2] = tab[((b1 & 0x0f) &<< 2) | (b2 &>> 6)]; p[n &+ 3] = tab[((b2 & 0x3f)      )             ]
-                (idx, n) = (idx &+ 3, n &+ 4)
+                span.append(tab[((b0 & 0xfc) &>> 2)             ]); span.append(tab[((b0 & 0x03) &<< 4) | (b1 &>> 4)])
+                span.append(tab[((b1 & 0x0f) &<< 2) | (b2 &>> 6)]); span.append(tab[((b2 & 0x3f)      )             ])
+                idx &+= 3
             }
             switch padding {
-                case 1: b01 = get(1); p[n &+ 2] = tab[((b01 & 0x0f) &<< 2)              ]; fallthrough
-                case 2: b00 = get(0); p[n &+ 1] = tab[((b00 & 0x03) &<< 4) | (b01 &>> 4)]
-                                      p[n &+ 0] = tab[((b00 & 0xfc) &>> 2)              ]
+                case 1: let b0 = get(0), b1 = get(1)
+                        span.append(tab[((b0 & 0xfc) &>> 2)            ]); span.append(tab[((b0 & 0x03) &<< 4) | (b1 &>> 4)])
+                        span.append(tab[((b1 & 0x0f) &<< 2)            ])
+                case 2: let b0 = get(0)
+                        span.append(tab[((b0 & 0xfc) &>> 2)            ]); span.append(tab[((b0 & 0x03) &<< 4)             ])
                 case 0: return; default: fatalError("unreachable")
             }
-            n &+= 4 &- padding
-            if let pad = pad, padding > 0 {
-                let pn = p.baseAddress!.advanced(by: n)
-                pn.update(repeating: pad, count: padding)
-                n &+= padding
+            if let pad = pad {
+                span.append(repeating: pad, count: padding)
             }
         }
     }
 
     /// Specialization of ``decode(_:base:using:)`` for Base64 with no ignores and optional padding.
     @inlinable
-    internal static func decode64<C>(_ encoded: C, using mapping: [UInt8]) -> [UInt8]?
-        where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int
-    {
+    internal static func decode64(_ encoded: Span<UInt8>, using mapping: [UInt8]) -> [UInt8]? {
         guard !encoded.isEmpty else { return [] }
         let outlen = self.sizeDec(for: 6, count: encoded.count)
-        
-        return try? [UInt8].init(unsafeUninitializedCapacity: outlen) { p, n in // N.B.: throwing is the only correct way to signal failure
-            var idx = encoded.startIndex, w = 0 as UInt32
+
+        return try? [UInt8].init(capacity: outlen) { p in // N.B.: throwing is the only correct way to signal failure
+            var idx = 0, w = 0 as UInt32
             func get(_ offset: Int) -> UInt32 { UInt32(truncatingIfNeeded: mapping[Int(truncatingIfNeeded: encoded[idx &+ offset])]) &<< (24 &- (offset &<< 3)) }
-            while encoded.endIndex &- idx >= 4 {
+            while encoded.count &- idx >= 4 {
                 w = get(0) | get(1) | get(2) | get(3)
                 if w & 0b11000000_11000000_11000000_11000000 == 0 {
-                    p[n &+ 0] = UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3))
-                    p[n &+ 1] = UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f))
-                    p[n &+ 2] = UInt8(truncatingIfNeeded: ((w &>>  2) & 0xc0) | (w & 0x3f))
-                    (n, idx) = (n &+ 3, idx &+ 4)
-                } else if w & 0b11000000_11000000_11000000_11000000 == 0b00000000_00000000_00000000_10000000, idx &+ 4 == encoded.endIndex {
-                    p[n &+ 0] = UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3))
-                    p[n &+ 1] = UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f))
-                    (n, idx) = (n &+ 2, idx &+ 4)
-                } else if w & 0b11000000_11000000_11000000_11000000 == 0b00000000_00000000_10000000_10000000, idx &+ 4 == encoded.endIndex {
-                    p[n &+ 0] = UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3))
-                    (n, idx) = (n &+ 1, idx &+ 4)
+                    p.append(UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3)))
+                    p.append(UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f)))
+                    p.append(UInt8(truncatingIfNeeded: ((w &>>  2) & 0xc0) | (w & 0x3f)))
+                    idx &+= 4
+                } else if w & 0b11000000_11000000_11000000_11000000 == 0b00000000_00000000_00000000_10000000, idx &+ 4 == encoded.count {
+                    p.append(UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3)))
+                    p.append(UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f)))
+                    idx &+= 4
+                } else if w & 0b11000000_11000000_11000000_11000000 == 0b00000000_00000000_10000000_10000000, idx &+ 4 == encoded.count {
+                    p.append(UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3)))
+                    idx &+= 4
                 } else {
                     throw BreakLoopError()
                 }
             }
-            switch encoded.endIndex &- idx {
+            switch encoded.count &- idx {
                 case 3:
                     w = get(0) | get(1) | get(2)
                     guard w & 0b11000000_11000000_11000000_11111111 == 0 else { throw BreakLoopError() }
-                    p[n &+ 0] = UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3))
-                    p[n &+ 1] = UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f))
-                    n &+= 2
+                    p.append(UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3)))
+                    p.append(UInt8(truncatingIfNeeded: ((w &>> 12) & 0xf0) | ((w &>> 10) & 0x0f)))
                 case 2:
                     w = get(0) | get(1)
                     guard w & 0b11000000_11000000_11111111_11111111 == 0 else { throw BreakLoopError() }
-                    p[n &+ 0] = UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3))
-                    n &+= 1
+                    p.append(UInt8(truncatingIfNeeded: (w &>> 22) | ((w &>> 20) & 0x3)))
                 case 0:
                     break
                 default: throw BreakLoopError()
@@ -112,14 +107,14 @@ extension Array where Element == UInt8 {
     /// Decode a string in canonical Base32-encoded representation.
     @inlinable
     public init?(decodingBase64 str: String) {
-        guard let decoded = str.utf8.withContiguousStorageIfAvailable({ Array(decodingBase64: $0) }) ?? Array(decodingBase64: Array(str.utf8)) else { return nil }
+        guard let decoded = Base64.default.decode(str.utf8Span.span) else { return nil }
         self = decoded
     }
-    
+
     /// Decode a string in Bcrypt-flavored Base64-encoded representation.
     @inlinable
     public init?(decodingBcryptBase64 str: String) {
-        guard let decoded = str.utf8.withContiguousStorageIfAvailable({ Array(decodingBcryptBase64: $0) }) ?? Array(decodingBcryptBase64: Array(str.utf8)) else { return nil }
+        guard let decoded = Base64.bcrypt.decode(str.utf8Span.span) else { return nil }
         self = decoded
     }
     
@@ -150,24 +145,24 @@ extension RandomAccessCollection where Element == UInt8, Index == Int {
 
 extension String {
     @inlinable
-    public func base64Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.base64Bytes() } ?? Array(self.utf8).base64Bytes() }
+    public func base64Bytes() -> [UInt8] { Base64.default.encode(self.utf8Span.span) }
     @inlinable
     public func base64String() -> String { .init(decoding: self.base64Bytes(), as: Unicode.ASCII.self) }
 
     @inlinable
-    public func bcryptBase64Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.bcryptBase64Bytes() } ?? Array(self.utf8).bcryptBase64Bytes() }
+    public func bcryptBase64Bytes() -> [UInt8] { Base64.bcrypt.encode(self.utf8Span.span) }
     @inlinable
     public func bcryptBase64String() -> String { .init(decoding: self.bcryptBase64Bytes(), as: Unicode.ASCII.self) }
 }
 
 extension Substring {
     @inlinable
-    public func base64Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.base64Bytes() } ?? Array(self.utf8).base64Bytes() }
+    public func base64Bytes() -> [UInt8] { Base64.default.encode(self.utf8Span.span) }
     @inlinable
     public func base64String() -> String { .init(decoding: self.base64Bytes(), as: Unicode.ASCII.self) }
 
     @inlinable
-    public func bcryptBase64Bytes() -> [UInt8] { self.utf8.withContiguousStorageIfAvailable { $0.bcryptBase64Bytes() } ?? Array(self.utf8).bcryptBase64Bytes() }
+    public func bcryptBase64Bytes() -> [UInt8] { Base64.bcrypt.encode(self.utf8Span.span) }
     @inlinable
     public func bcryptBase64String() -> String { .init(decoding: self.bcryptBase64Bytes(), as: Unicode.ASCII.self) }
 }

--- a/Sources/Vapor/Utilities/BaseN.swift
+++ b/Sources/Vapor/Utilities/BaseN.swift
@@ -39,28 +39,26 @@ public struct BaseNEncoding: Sendable {
     /// by a count of bits per input values and mapping table relating input bytes to output values. Each element
     /// of the output type describes N bits of input.
     @inlinable
-    internal static func encode<C>(
-        _ decoded: C, base bits: Int, pad: UInt8?, using table: [UInt8]
-    ) -> [UInt8] where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    internal static func encode(
+        _ decoded: Span<UInt8>, base bits: Int, pad: UInt8?, using table: [UInt8]
+    ) -> [UInt8] {
         assert(table.count == (1 << bits), "Mapping table must have exactly \(1 << bits) elements.")
         guard !decoded.isEmpty else { return [] }
-        
+
         let mask = (1 << bits) - 1, outlen = self.sizeEnc(for: bits, count: decoded.count), padding = self.padding(for: bits, count: outlen)
-        
-        return .init(unsafeUninitializedCapacity: outlen + padding) { p, n in
+
+        return .init(capacity: outlen + padding) { span in
             var bufBits = 0, buf = 0
-            
-            for next in decoded {
-                (buf, bufBits) = ((buf &<< 8) | Int(next), bufBits &+ 8)
-                while bufBits >= bits { bufBits &-= bits; p[n] = table[(buf &>> bufBits) & mask]; n &+= 1 }
+
+            for idx in decoded.indices {
+                (buf, bufBits) = ((buf &<< 8) | Int(decoded[idx]), bufBits &+ 8)
+                while bufBits >= bits { bufBits &-= bits; span.append(table[(buf &>> bufBits) & mask]) }
             }
             if padding > 0 {
                 assert((1..<bits).contains(bufBits))
-                p[n] = table[(buf &<< (bits &- bufBits)) & mask]; n &+= 1
+                span.append(table[(buf &<< (bits &- bufBits)) & mask])
                 if let pad = pad {
-                    let pn = p.baseAddress!.advanced(by: n)
-                    pn.update(repeating: pad, count: padding)
-                    n &+= padding
+                    span.append(repeating: pad, count: padding)
                 }
             }
         }
@@ -72,27 +70,27 @@ public struct BaseNEncoding: Sendable {
     /// mapped nor ignored cause decoding to fail. If a pad is specified, the input must be correctly padded
     /// decoding will fail.
     @inlinable
-    internal static func decode<C>(
-        _ encoded: C, base bits: Int, using mapping: [UInt8], checkPad: Bool
-    ) -> [UInt8]? where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    internal static func decode(
+        _ encoded: Span<UInt8>, base bits: Int, using mapping: [UInt8], checkPad: Bool
+    ) -> [UInt8]? {
         guard !encoded.isEmpty else { return [] }
         let outlen = self.sizeDec(for: bits, count: encoded.count)
-        
-        return try? [UInt8].init(unsafeUninitializedCapacity: outlen) { p, n in // N.B.: throwing is the only correct way to signal failure
+
+        return try? [UInt8].init(capacity: outlen) { span in // N.B.: throwing is the only correct way to signal failure
             var buf = 0, bufBits = 0, seenPad = 0
-            
-            for next in encoded {
-                switch mapping[numericCast(next)] {
+
+            for idx in encoded.indices {
+                switch mapping[numericCast(encoded[idx])] {
                     case BaseNEncoding.ignoredByte: break
                     case BaseNEncoding.paddingByte: seenPad &+= 1
                     case BaseNEncoding.invalidByte,
                         _ where seenPad > 0: throw BreakLoopError()
                     case let moreBits:
                         (buf, bufBits) = ((buf &<< bits) | Int(truncatingIfNeeded: moreBits), bufBits &+ bits)
-                        while bufBits >= 8 { bufBits &-= 8; (p[n], n) = (UInt8(truncatingIfNeeded: buf &>> bufBits), n &+ 1) }
+                        while bufBits >= 8 { bufBits &-= 8; span.append(UInt8(truncatingIfNeeded: buf &>> bufBits)) }
                 }
             }
-            guard !checkPad || seenPad == self.padding(for: bits, count: self.sizeEnc(for: bits, count: n)) else { throw BreakLoopError() } // require exact padding
+            guard !checkPad || seenPad == self.padding(for: bits, count: self.sizeEnc(for: bits, count: span.count)) else { throw BreakLoopError() } // require exact padding
             guard bufBits == 0 || (buf & ((1 &<< bufBits) &- 1)) == 0 else { throw BreakLoopError() } // require pad bits to be zero per spec
         }
     }
@@ -161,22 +159,36 @@ public struct BaseNEncoding: Sendable {
         )
     }
     
-    // Generic byte collection interfaces
-    
+    // Span interfaces
+
     @inlinable
-    public func encode<C>(_ decoded: C) -> [UInt8] where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    public func encode(_ decoded: Span<UInt8>) -> [UInt8] {
         switch self.bits {
         case 5: return BaseNEncoding.encode32(decoded, pad: self.pad, using: self.lookupTable)
         case 6: return BaseNEncoding.encode64(decoded, pad: self.pad, using: self.lookupTable)
         case let n: return BaseNEncoding.encode(decoded, base: n, pad: self.pad, using: self.lookupTable)
         }
     }
-    
+
     @inlinable
-    public func decode<C>(_ encoded: C) -> [UInt8]? where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+    public func decode(_ encoded: Span<UInt8>) -> [UInt8]? {
         switch self.bits {
         case 6 where encoded.count > 512 && self.ignores.isEmpty: return BaseNEncoding.decode64(encoded, using: self.reverseTable)
         case let n: return BaseNEncoding.decode(encoded, base: n, using: self.reverseTable, checkPad: self.pad != nil)
         }
+    }
+
+    // Generic byte collection interfaces
+
+    @inlinable
+    public func encode<C>(_ decoded: C) -> [UInt8] where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+        let contiguous = Array(decoded) // no-op for `[UInt8]`, one copy for anything else
+        return self.encode(contiguous.span)
+    }
+
+    @inlinable
+    public func decode<C>(_ encoded: C) -> [UInt8]? where C: RandomAccessCollection, C.Element == UInt8, C.Index == Int {
+        let contiguous = Array(encoded) // no-op for `[UInt8]`, one copy for anything else
+        return self.decode(contiguous.span)
     }
 }

--- a/Sources/Vapor/Utilities/Bytes+Hex.swift
+++ b/Sources/Vapor/Utilities/Bytes+Hex.swift
@@ -23,13 +23,12 @@ extension Collection where Element == UInt8 {
     public func hexEncodedBytes(uppercase: Bool = false) -> [UInt8] {
         let table: [UInt8] = uppercase ? radix16table_uppercase : radix16table_lowercase
         
-        return .init(unsafeUninitializedCapacity: self.count * 2) { buffer, outCount in
+        return .init(capacity: self.count * 2) { span in
             for byte in self {
                 let nibs = byte.quotientAndRemainder(dividingBy: 16)
-                
-                buffer[outCount + 0] = table[numericCast(nibs.quotient)]
-                buffer[outCount + 1] = table[numericCast(nibs.remainder)]
-                outCount += 2
+
+                span.append(table[numericCast(nibs.quotient)])
+                span.append(table[numericCast(nibs.remainder)])
             }
         }
     }

--- a/Sources/Vapor/Utilities/DirectoryConfiguration.swift
+++ b/Sources/Vapor/Utilities/DirectoryConfiguration.swift
@@ -1,11 +1,7 @@
-#if canImport(Glibc)
-import Glibc
-#elseif canImport(Musl)
-import Musl
-#elseif canImport(Android)
-import Android
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.FileManager
 #else
-import Darwin.C
+import class Foundation.FileManager
 #endif
 import Logging
 
@@ -37,21 +33,9 @@ public struct DirectoryConfiguration: Sendable {
     ///
     /// - returns: The derived `DirectoryConfig` if it could be created, otherwise just "./".
     public static func detect() -> DirectoryConfiguration {
-        // get actual working directory
-        let cwd = getcwd(nil, Int(PATH_MAX))
-        defer {
-            if let cwd = cwd {
-                free(cwd)
-            }
-        }
-
-        let workingDirectory: String
-
-        if let cwd, let string = String(validatingCString: cwd) {
-            workingDirectory = string
-        } else {
-            workingDirectory = "./"
-        }
+        // get actual working directory, falling back to "./" if it's inaccessible
+        let cwd = FileManager.default.currentDirectoryPath
+        let workingDirectory = cwd.isEmpty ? "./" : cwd
 
         #if Xcode
         if workingDirectory.contains("DerivedData") {

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -402,7 +402,7 @@ struct MiddlewareTests {
             // No declared length, and the middleware must not read the body to find one - so there is
             // no size to record. This used to record the `-1` sentinel as if it were a byte count.
             app.get("streamMetrics") { _ in
-                Response(body: try .init(stream: { writer in
+                Response(body: .init(stream: { writer in
                     try await writer.write("alpha")
                     try await writer.write("beta")
                 }))

--- a/Tests/VaporTests/ServerTLSTests.swift
+++ b/Tests/VaporTests/ServerTLSTests.swift
@@ -285,7 +285,7 @@ struct ServerTLSTests {
             )
             try await app.boot()
 
-            try await withThrowingTaskGroup(of: Void.self) { group in
+            await withTaskGroup(of: Void.self) { group in
                 group.addTask { try? await app.server.run() }
 
                 // The address never arrives, so every waiter must be handed the startup error

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -483,7 +483,7 @@ struct StreamingBodyTests {
 
     @Test("collect() gathers a streaming body into a single buffer")
     func testCollectStreamingBody() async throws {
-        var body = try Response.Body(stream: { writer in
+        var body = Response.Body(stream: { writer in
             try await writer.write("Hello, ")
             try await writer.write("collected!")
         })
@@ -727,7 +727,7 @@ struct StreamingBodyTests {
 
         var seen = ""
         try await original.withStreamingBytes { span in
-            seen += String(decoding: span.withUnsafeBytes { Array($0) }, as: UTF8.self)
+            seen += String(decoding: span.withUnsafeBytes { unsafe Array($0) }, as: UTF8.self)
         }
         #expect(seen == "payload")
         #expect(runs.withLockedValue { $0 } == 1)
@@ -815,7 +815,7 @@ struct StreamingBodyTests {
     func testTesterResponseBodyCollection() async throws {
         try await withApp { app in
             app.get("stream") { _ in
-                Response(body: try .init(stream: { writer in
+                Response(body: .init(stream: { writer in
                     try await writer.write("alpha")
                     try await writer.write("beta")
                 }))


### PR DESCRIPTION
Fixes 70 or so unsafe warnings by mainly migrating to Span, using alternative APIs or marking callsites with `unsafe` where unavoidable
