### PR TITLE
Migrate off TimeAmount

### DIFF
--- a/Sources/Vapor/Client/ClientRequest.swift
+++ b/Sources/Vapor/Client/ClientRequest.swift
@@ -13,7 +13,7 @@ public struct ClientRequest: Sendable {
     public var url: URI
     public var headers: HTTPFields
     public var body: ByteBuffer?
-    public var timeout: TimeAmount
+    public var timeout: Duration
     public var maxResponseBodySize: Int
     private let contentConfiguration: ContentConfiguration
 
@@ -22,7 +22,7 @@ public struct ClientRequest: Sendable {
         url: URI = "/",
         headers: HTTPFields = [:],
         body: ByteBuffer? = nil,
-        timeout: TimeAmount? = nil,
+        timeout: Duration? = nil,
         maxResponseBodySize: Int = 10 * 1024 * 1024, // Default to 10 MB
         contentConfiguration: ContentConfiguration = .default()
     ) {

--- a/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
+++ b/Sources/Vapor/HTTP/Client/EventLoopHTTPClient.swift
@@ -29,7 +29,7 @@ internal struct VaporHTTPClient: Client {
         }
         let response = try await self.http.execute(
             request,
-            deadline: .now() + clientRequest.timeout,
+            deadline: .now() + TimeAmount(clientRequest.timeout),
             logger: Logger.current)
         // Wrapping AHC's body ourselves means losing its `collect(upTo:)` size check, so the declared
         // length is rejected here instead - before a byte is read, as AHC did.

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -3,8 +3,7 @@ public import FoundationEssentials
 #else
 public import Foundation
 #endif
-#warning("Make this internal")
-public import NIOCore
+import NIOCore
 import _NIOFileSystem
 public import HTTPTypes
 
@@ -220,8 +219,8 @@ extension FileMiddleware {
         /// The browser will cache the file for the specified duration.
         ///
         /// A typical cache duration may be 5 minutes, for instance: `.cacheUpToDuration(.minutes(5))`
-        public static func cacheUpToDuration(_ duration: TimeAmount) -> CachePolicy {
-            CachePolicy(cacheControlHeader: .init(maxAge: Int(duration.nanoseconds/1_000_000_000)), ageHeader: 0)
+        public static func cacheUpToDuration(_ duration: Duration) -> CachePolicy {
+            CachePolicy(cacheControlHeader: .init(maxAge: Int(duration.components.seconds)), ageHeader: 0)
         }
 
         /// A custom cache control policy that should be used for all files.

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -218,8 +218,8 @@ extension FileMiddleware {
 
         /// The browser will cache the file for the specified duration.
         ///
-        /// A typical cache duration may be 5 minutes, for instance: `.cacheUpToDuration(.minutes(5))`
-        public static func cacheUpToDuration(_ duration: Duration) -> CachePolicy {
+        /// A typical cache duration may be 5 minutes, for instance: `.cache(upTo: .seconds(300))`
+        public static func cache(upTo duration: Duration) -> CachePolicy {
             CachePolicy(cacheControlHeader: .init(maxAge: Int(duration.components.seconds)), ageHeader: 0)
         }
 

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -233,7 +233,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware With Max Age Cache Policy")
     func testFileMiddlewareWithMaxAgeCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cacheUpToDuration(.seconds(300)))
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cache(upTo: .seconds(300)))
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -233,7 +233,8 @@ struct MiddlewareTests {
     @Test("Test File Middleware With Max Age Cache Policy")
     func testFileMiddlewareWithMaxAgeCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cache(upTo: .seconds(300)))
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cache(upTo:
+                    .seconds(300)))
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -233,7 +233,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware With Max Age Cache Policy")
     func testFileMiddlewareWithMaxAgeCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cacheUpToDuration(.minutes(5)))
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cacheUpToDuration(.seconds(300)))
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in


### PR DESCRIPTION
We only use TimeAmount in a couple of places and it requires a public import of NIO. Duration is the modern standard library equivalent so lets use it
