### PR TITLE
Request Overhaul

### DIFF
--- a/Performance/Sources/PerformanceServer/main.swift
+++ b/Performance/Sources/PerformanceServer/main.swift
@@ -40,7 +40,7 @@ app.get("bench", "stream") { _ -> Response in
 }
 
 app.get("bench", "file") { req in
-    try await req.fileio.streamFile(at: filePath)
+    try await app.fileio.streamFile(at: filePath, for: req)
 }
 
 print("performance server listening on http://\(host):\(port)")

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -195,7 +195,7 @@ func routes(_ app: Application) async throws {
     }
 
     app.get("client") { req in
-        let response = try await req.application.client.get("http://httpbin.org/status/201")
+        let response = try await app.client.get("http://httpbin.org/status/201")
         return response.description
     }
 
@@ -206,7 +206,7 @@ func routes(_ app: Application) async throws {
             }
             var slideshow: Slideshow
         }
-        let response = try await req.application.client.get("http://httpbin.org/json")
+        let response = try await app.client.get("http://httpbin.org/json")
         let data = try await response.content.decode(HTTPBinResponse.self)
         return data.slideshow.title
     }
@@ -220,7 +220,7 @@ func routes(_ app: Application) async throws {
     }
 
     app.get("view") { req in
-        try await req.view.render("hello.txt", ["name": "world"])
+        try await app.viewRenderer.render("hello.txt", ["name": "world"])
     }
 
     app.get("error") { req -> String in
@@ -255,7 +255,7 @@ func routes(_ app: Application) async throws {
 
     let asyncRoutes = app.grouped("async").grouped(TestMiddleware(number: 1))
     asyncRoutes.get("client") { req async throws -> String in
-        let response = try await req.application.client.get("https://www.google.com")
+        let response = try await app.client.get("https://www.google.com")
         guard let bodyString = response.body.string else {
             throw Abort(.internalServerError)
         }
@@ -263,7 +263,7 @@ func routes(_ app: Application) async throws {
     }
 
     asyncRoutes.get("client2") { req -> String in
-        let response = try await req.application.client.get("https://www.google.com")
+        let response = try await app.client.get("https://www.google.com")
         guard let bodyString = response.body.string else {
             throw Abort(.internalServerError)
         }

--- a/Sources/Vapor/Client/ClientResponse.swift
+++ b/Sources/Vapor/Client/ClientResponse.swift
@@ -105,7 +105,7 @@ extension ClientResponse: ResponseEncodable {
             status: self.status,
             headers: headers,
             body: self.body,
-            contentConfiguration: request.application.contentConfiguration
+            contentConfiguration: request.contentConfiguration
         )
     }
 }

--- a/Sources/Vapor/Content/Content.swift
+++ b/Sources/Vapor/Content/Content.swift
@@ -68,7 +68,7 @@ extension Content {
     }
     
     public func encodeResponse(for request: Request) async throws -> Response {
-        var response = Response(contentConfiguration: request.application.contentConfiguration)
+        var response = Response(contentConfiguration: request.contentConfiguration)
         try response.content.encode(self)
         return response
     }

--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -22,22 +22,22 @@ public actor EndpointCache<T>: Sendable where T: Decodable & Sendable {
     private var request: Task<T, any Error>?
     private var headers: HTTPFields?
     private let uri: URI
+    private let client: any Client
 
     /// The designated initializer.
     /// - Parameters:
     ///   - uri: The `URI` of the resource to be downloaded.
-    public init(uri: URI) {
+    public init(uri: URI, client: any Client) {
         self.uri = uri
         self.request = nil
         self.headers = nil
         self.cached = (nil, nil)
+        self.client = client
     }
 
-    /// Downloads the resource.
-    /// - Parameters:
-    ///   - request: The `Request` which is initiating the download.
-    public func get(on request: Request) async throws -> T {
-        try await self.download(using: request.application.client)
+    /// Downloads the resource
+    public func get() async throws -> T {
+        try await self.download(using: self.client)
     }
 
     /// Downloads the resource.

--- a/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServerHandler.swift
@@ -60,7 +60,6 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
         var responseSender = Optional(consume responseSender)
         try await withLogger(mergingMetadata: ["request-id": "\(requestID)"]) { _ in
             let vaporRequest = Request(
-                application: self.application,
                 method: request.method,
                 url: URI(path: rawPath),
                 version: .init(major: 1, minor: 1),
@@ -68,7 +67,9 @@ struct VaporHTTPServerHandler: HTTPServerRequestHandler {
                 collectedBody: bodyBuffer.readableBytes > 0 ? bodyBuffer : nil,
                 remoteAddress: remoteAddress,
                 peerCertificateChain: peerCerts,
-                requestID: requestID
+                requestID: requestID,
+                contentConfiguration: application.contentConfiguration,
+                defaultMaxBodySize: application.routes.defaultMaxBodySize
             )
 
             // 3. Run responder chain

--- a/Sources/Vapor/Middleware/ErrorMiddleware.swift
+++ b/Sources/Vapor/Middleware/ErrorMiddleware.swift
@@ -56,7 +56,7 @@ public final class ErrorMiddleware: Middleware {
             // attempt to serialize the error to json
             let body: Response.Body
             do {
-                let encoder = try req.application.contentConfiguration.requireEncoder(for: .json)
+                let encoder = try req.contentConfiguration.requireEncoder(for: .json)
                 var data = Data()
                 try encoder.encode(ErrorResponse(error: true, reason: reason), to: &data, headers: &headers, userInfo: [:])
 

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -17,7 +17,7 @@ public final class FileMiddleware: Middleware {
     private let directoryAction: DirectoryAction
     private let advancedETagComparison: Bool
     private let cachePolicy: CachePolicy
-    private let etagCache: FileETagHashCache
+    private let fileIO: FileIO
 
     public struct BundleSetupError: Equatable, Error {
 
@@ -54,7 +54,7 @@ public final class FileMiddleware: Middleware {
         self.directoryAction = directoryAction
         self.advancedETagComparison = advancedETagComparison
         self.cachePolicy = cachePolicy
-        self.etagCache = etagCache
+        self.fileIO = FileIO(fileETagHashCache: etagCache)
     }
 
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
@@ -96,9 +96,8 @@ public final class FileMiddleware: Middleware {
 
                         if try await FileSystem.shared.info(forFileAt: .init(absPath)) != nil {
                             // If the default file exists, stream it
-                            return try await request
-                                .fileio(etagCache: etagCache)
-                                .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
+                            return try await fileIO
+                                .streamFile(at: absPath, for: request, advancedETagComparison: advancedETagComparison)
                                 .applyingCachePolicy(cachePolicy)
                         }
                     }
@@ -111,9 +110,8 @@ public final class FileMiddleware: Middleware {
                 }
             } else {
                 // file exists, stream it
-                return try await request
-                    .fileio(etagCache: etagCache)
-                    .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
+                return try await fileIO
+                    .streamFile(at: absPath, for: request, advancedETagComparison: advancedETagComparison)
                     .applyingCachePolicy(cachePolicy)
             }
         }

--- a/Sources/Vapor/Middleware/FileMiddleware.swift
+++ b/Sources/Vapor/Middleware/FileMiddleware.swift
@@ -17,6 +17,7 @@ public final class FileMiddleware: Middleware {
     private let directoryAction: DirectoryAction
     private let advancedETagComparison: Bool
     private let cachePolicy: CachePolicy
+    private let etagCache: FileETagHashCache
 
     public struct BundleSetupError: Equatable, Error {
 
@@ -45,13 +46,15 @@ public final class FileMiddleware: Middleware {
         defaultFile: String? = nil,
         directoryAction: DirectoryAction = .none,
         advancedETagComparison: Bool = false,
-        cachePolicy: CachePolicy = .browserDefault
+        cachePolicy: CachePolicy = .browserDefault,
+        etagCache: FileETagHashCache
     ) {
         self.publicDirectory = publicDirectory.addTrailingSlash()
         self.defaultFile = defaultFile
         self.directoryAction = directoryAction
         self.advancedETagComparison = advancedETagComparison
         self.cachePolicy = cachePolicy
+        self.etagCache = etagCache
     }
 
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
@@ -94,7 +97,7 @@ public final class FileMiddleware: Middleware {
                         if try await FileSystem.shared.info(forFileAt: .init(absPath)) != nil {
                             // If the default file exists, stream it
                             return try await request
-                                .fileio
+                                .fileio(etagCache: etagCache)
                                 .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
                                 .applyingCachePolicy(cachePolicy)
                         }
@@ -109,7 +112,7 @@ public final class FileMiddleware: Middleware {
             } else {
                 // file exists, stream it
                 return try await request
-                    .fileio
+                    .fileio(etagCache: etagCache)
                     .streamFile(at: absPath, advancedETagComparison: advancedETagComparison)
                     .applyingCachePolicy(cachePolicy)
             }
@@ -135,7 +138,8 @@ public final class FileMiddleware: Middleware {
         publicDirectory: String = "Public",
         defaultFile: String? = nil,
         directoryAction: DirectoryAction = .none,
-        cachePolicy: CachePolicy = .browserDefault
+        cachePolicy: CachePolicy = .browserDefault,
+        etagCache: FileETagHashCache
     ) throws {
         guard let bundleResourceURL = bundle.resourceURL else {
             throw BundleSetupError.bundleResourceURLIsNil
@@ -149,7 +153,8 @@ public final class FileMiddleware: Middleware {
             publicDirectory: publicDirectoryURL.path,
             defaultFile: defaultFile,
             directoryAction: directoryAction,
-            cachePolicy: cachePolicy
+            cachePolicy: cachePolicy,
+            etagCache: etagCache
         )
     }
     #endif

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -15,9 +15,10 @@ public final class TracingMiddleware: Middleware {
     /// - Parameter setCustomAttributes: Closure that allows setting custom span attributes for a particular request. A custom span attribute could be extracted from a request
     /// header, for example. This closure is called during span creation on every request, so should be lightweight.
     /// - Parameter serverAddress: The address the server is running on
+    #warning("We need to check server address is set at the point we can use it, or path a closure we can call")
     public init(
-        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in },
-        serverAddress: SocketAddress?
+        serverAddress: SocketAddress?,
+        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in }
     ) {
         self.setCustomAttributes = setCustomAttributes
         self.serverAddress = serverAddress

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -9,15 +9,18 @@ import NIOConcurrencyHelpers
 /// See https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 public final class TracingMiddleware: Middleware {
     private let setCustomAttributes: @Sendable (inout SpanAttributes, Request) -> Void
-    private let serverAddress: SocketAddress?
+    private let serverAddress: @Sendable () -> SocketAddress?
 
     /// Create a TracingMiddleware
+    /// - Parameter serverAddress: The address the server is running on, resolved once per request.
+    /// This is a closure rather than a value because middleware is built while routes are registered,
+    /// which happens before the server binds and therefore before its address is known. Reading it
+    /// eagerly would capture `nil` for the middleware's whole lifetime and silently drop the
+    /// `server.address` and `server.port` attributes.
     /// - Parameter setCustomAttributes: Closure that allows setting custom span attributes for a particular request. A custom span attribute could be extracted from a request
     /// header, for example. This closure is called during span creation on every request, so should be lightweight.
-    /// - Parameter serverAddress: The address the server is running on
-    #warning("We need to check server address is set at the point we can use it, or path a closure we can call")
     public init(
-        serverAddress: SocketAddress?,
+        serverAddress: @escaping @Sendable () -> SocketAddress?,
         setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in }
     ) {
         self.setCustomAttributes = setCustomAttributes
@@ -27,6 +30,9 @@ public final class TracingMiddleware: Middleware {
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
         var parentContext = ServiceContext.current ?? ServiceContext.topLevel
         InstrumentationSystem.instrument.extract(request.headers, into: &parentContext, using: HTTPHeadersExtractor())
+
+        // Resolved here rather than at init, when the server may not have bound yet.
+        let serverAddress = self.serverAddress()
 
         return try await withSpan(
             // Name: https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
@@ -47,7 +53,7 @@ public final class TracingMiddleware: Middleware {
                 }
 
                 attributes["network.protocol.name"] = "http"
-                switch self.serverAddress {
+                switch serverAddress {
                 case .v4:
                     fallthrough
                 case .v6:

--- a/Sources/Vapor/Middleware/TracingMiddleware.swift
+++ b/Sources/Vapor/Middleware/TracingMiddleware.swift
@@ -1,6 +1,7 @@
 import HTTPTypes
 public import Tracing
-import NIOCore
+#warning("Make this internal")
+public import NIOCore
 import NIOConcurrencyHelpers
 
 /// Creates a trace and metadata for every request
@@ -8,19 +9,18 @@ import NIOConcurrencyHelpers
 /// See https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 public final class TracingMiddleware: Middleware {
     private let setCustomAttributes: @Sendable (inout SpanAttributes, Request) -> Void
-
-    /// Create a TracingMiddleware
-    public init() {
-        self.setCustomAttributes = { _, _ in }
-    }
+    private let serverAddress: SocketAddress?
 
     /// Create a TracingMiddleware
     /// - Parameter setCustomAttributes: Closure that allows setting custom span attributes for a particular request. A custom span attribute could be extracted from a request
     /// header, for example. This closure is called during span creation on every request, so should be lightweight.
+    /// - Parameter serverAddress: The address the server is running on
     public init(
-        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void
+        setCustomAttributes: @escaping @Sendable (inout SpanAttributes, Request) -> Void = { _, _ in },
+        serverAddress: SocketAddress?
     ) {
         self.setCustomAttributes = setCustomAttributes
+        self.serverAddress = serverAddress
     }
 
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
@@ -46,15 +46,14 @@ public final class TracingMiddleware: Middleware {
                 }
 
                 attributes["network.protocol.name"] = "http"
-                let address = request.application.sharedAddress.withLockedValue({ $0 })
-                switch address {
+                switch self.serverAddress {
                 case .v4:
                     fallthrough
                 case .v6:
-                    attributes["server.address"] = address?.ipAddress
-                    attributes["server.port"] = address?.port
+                    attributes["server.address"] = serverAddress?.ipAddress
+                    attributes["server.port"] = serverAddress?.port
                 case .unixDomainSocket:
-                    attributes["server.address"] = address?.description
+                    attributes["server.address"] = serverAddress?.description
                 case .none:
                     break
                 }

--- a/Sources/Vapor/Request/Request+Body.swift
+++ b/Sources/Vapor/Request/Request+Body.swift
@@ -5,25 +5,6 @@ import NIOConcurrencyHelpers
 import HTTPTypes
 
 extension Request {
-    public struct NewBody: Sendable {
-        let underlying: AsyncStream<ByteBuffer>?
-        let maxBodySize: Int
-
-        public var data: ByteBuffer? {
-            get async throws {
-                guard let stream = underlying else { return nil }
-                var collected = ByteBuffer()
-                for await var chunk in stream {
-                    collected.writeBuffer(&chunk)
-                    guard collected.readableBytes <= maxBodySize else {
-                        throw Abort(.contentTooLarge)
-                    }
-                }
-                return collected
-            }
-        }
-    }
-
     public struct Body: CustomStringConvertible, Sendable {
         let request: Request
 

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -26,10 +26,7 @@ public struct Request: CustomStringConvertible, Sendable {
     public let method: HTTPRequest.Method
 
     /// The URL used on this request.
-    public var url: URI {
-        get { self.requestBox.withLockedValue { $0.url } }
-        set { self.requestBox.withLockedValue { $0.url = newValue } }
-    }
+    public var url: URI
 
     /// The version for this HTTP request.
     public let version: HTTPVersion
@@ -194,7 +191,6 @@ public struct Request: CustomStringConvertible, Sendable {
     public let auth: Authentication
 
     struct RequestBox: Sendable {
-        var url: URI
         var headers: HTTPFields
     }
 
@@ -250,7 +246,6 @@ public struct Request: CustomStringConvertible, Sendable {
         }
 
         let storageBox = RequestBox(
-            url: url,
             headers: headers,
         )
         self.requestBox = .init(storageBox)
@@ -268,6 +263,7 @@ public struct Request: CustomStringConvertible, Sendable {
         self.version = version
         self.route = nil
         self.parameters = .init()
+        self.url = url
     }
 
     package init(_ other: Request, route: Route?, parameters: Parameters) {
@@ -284,6 +280,7 @@ public struct Request: CustomStringConvertible, Sendable {
         self.streamBodyStorage = other.streamBodyStorage
         self.route = route
         self.parameters = parameters
+        self.url = other.url
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -211,11 +211,6 @@ public final class Request: CustomStringConvertible, Sendable {
         set { self._storage.withLockedValue { $0 = newValue } }
     }
 
-    public var byteBufferAllocator: ByteBufferAllocator {
-        get { self.requestBox.withLockedValue { $0.byteBufferAllocator } }
-        set { self.requestBox.withLockedValue { $0.byteBufferAllocator = newValue } }
-    }
-
     struct RequestBox: Sendable {
         var method: HTTPRequest.Method
         var url: URI
@@ -225,7 +220,6 @@ public final class Request: CustomStringConvertible, Sendable {
         var route: Route?
         var parameters: Parameters
         var peerCertificateChain: ValidatedCertificateChain?
-        var byteBufferAllocator: ByteBufferAllocator
     }
 
     let requestBox: NIOLockedValueBox<RequestBox>
@@ -243,7 +237,6 @@ public final class Request: CustomStringConvertible, Sendable {
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
-        byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         requestID: String = UUID().uuidString
     ) {
         self.init(
@@ -255,7 +248,6 @@ public final class Request: CustomStringConvertible, Sendable {
             collectedBody: collectedBody,
             remoteAddress: remoteAddress,
             peerCertificateChain: peerCertificateChain,
-            byteBufferAllocator: byteBufferAllocator,
             requestID: requestID
         )
         if let body = collectedBody {
@@ -272,7 +264,6 @@ public final class Request: CustomStringConvertible, Sendable {
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
-        byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         requestID: String = UUID().uuidString
     ) {
         let bodyStorage: BodyStorage
@@ -291,7 +282,6 @@ public final class Request: CustomStringConvertible, Sendable {
             route: nil,
             parameters: .init(),
             peerCertificateChain: peerCertificateChain,
-            byteBufferAllocator: byteBufferAllocator
         )
         self.requestBox = .init(storageBox)
         self.id = requestID
@@ -305,7 +295,7 @@ public final class Request: CustomStringConvertible, Sendable {
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {
-        var collected = self.byteBufferAllocator.buffer(capacity: 0)
+        var collected = ByteBuffer()
         for await var chunk in stream {
             collected.writeBuffer(&chunk)
             guard collected.readableBytes <= maxSize else {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -37,7 +37,10 @@ public struct Request: CustomStringConvertible, Sendable {
     /// The header fields for this HTTP request.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.
-    public var headers: HTTPFields
+    public var headers: HTTPFields {
+        get { self.requestBox.withLockedValue { $0.headers } }
+        set { self.requestBox.withLockedValue { $0.headers = newValue } }
+    }
 
     /// A unique ID for the request.
     ///
@@ -202,6 +205,7 @@ public struct Request: CustomStringConvertible, Sendable {
 
     struct RequestBox: Sendable {
         var url: URI
+        var headers: HTTPFields
         var isKeepAlive: Bool
         var route: Route?
         var parameters: Parameters
@@ -261,6 +265,7 @@ public struct Request: CustomStringConvertible, Sendable {
 
         let storageBox = RequestBox(
             url: url,
+            headers: headers,
             isKeepAlive: true,
             route: nil,
             parameters: .init(),
@@ -277,9 +282,8 @@ public struct Request: CustomStringConvertible, Sendable {
         self.sessionCache = SessionCache()
 
         self.method = method
-        self.headers = headers
-        self.version = version
         self.peerCertificateChain = peerCertificateChain
+        self.version = version
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -32,18 +32,12 @@ public struct Request: CustomStringConvertible, Sendable {
     }
 
     /// The version for this HTTP request.
-    public var version: HTTPVersion {
-        get { self.requestBox.withLockedValue { $0.version } }
-        set { self.requestBox.withLockedValue { $0.version = newValue } }
-    }
+    public let version: HTTPVersion
 
     /// The header fields for this HTTP request.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.
-    public var headers: HTTPFields {
-        get { self.requestBox.withLockedValue { $0.headers } }
-        set { self.requestBox.withLockedValue { $0.headers = newValue } }
-    }
+    public var headers: HTTPFields
 
     /// A unique ID for the request.
     ///
@@ -83,9 +77,7 @@ public struct Request: CustomStringConvertible, Sendable {
 
     /// The validated certificate chain. This returns nil if the peer did not authenticate with a certificate. Requires
     /// configuring a `customCertificateVerifyCallbackWithMetadata` that performs the verification.
-    public var peerCertificateChain: ValidatedCertificateChain? {
-        return self.requestBox.withLockedValue { $0.peerCertificateChain }
-    }
+    public let peerCertificateChain: ValidatedCertificateChain?
 
     // MARK: Content
 
@@ -210,12 +202,9 @@ public struct Request: CustomStringConvertible, Sendable {
 
     struct RequestBox: Sendable {
         var url: URI
-        var version: HTTPVersion
-        var headers: HTTPFields
         var isKeepAlive: Bool
         var route: Route?
         var parameters: Parameters
-        var peerCertificateChain: ValidatedCertificateChain?
     }
 
     let requestBox: NIOLockedValueBox<RequestBox>
@@ -272,12 +261,9 @@ public struct Request: CustomStringConvertible, Sendable {
 
         let storageBox = RequestBox(
             url: url,
-            version: version,
-            headers: headers,
             isKeepAlive: true,
             route: nil,
             parameters: .init(),
-            peerCertificateChain: peerCertificateChain,
         )
         self.requestBox = .init(storageBox)
         self.id = requestID
@@ -291,6 +277,9 @@ public struct Request: CustomStringConvertible, Sendable {
         self.sessionCache = SessionCache()
 
         self.method = method
+        self.headers = headers
+        self.version = version
+        self.peerCertificateChain = peerCertificateChain
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -16,17 +16,14 @@ import ServiceContextModule
 public import X509
 
 /// Represents an HTTP request in an application.
-public final class Request: CustomStringConvertible, Sendable {
+public struct Request: CustomStringConvertible, Sendable {
     public let application: Application
 
     /// The HTTP method for this request.
     ///
     ///     httpReq.method = .get
     ///
-    public var method: HTTPRequest.Method {
-        get { self.requestBox.withLockedValue { $0.method } }
-        set { self.requestBox.withLockedValue { $0.method = newValue } }
-    }
+    public let method: HTTPRequest.Method
 
     /// The URL used on this request.
     public var url: URI {
@@ -93,7 +90,7 @@ public final class Request: CustomStringConvertible, Sendable {
     // MARK: Content
 
     private struct _URLQueryContainer: URLQueryContainer, Sendable {
-        let request: Request
+        var request: Request
         let contentConfiguration: ContentConfiguration
 
         func decode<D>(_ decodable: D.Type, using decoder: any URLQueryDecoder) throws -> D
@@ -102,7 +99,7 @@ public final class Request: CustomStringConvertible, Sendable {
             try decoder.decode(D.self, from: self.request.url)
         }
 
-        func encode(_ encodable: some Encodable, using encoder: any URLQueryEncoder) throws {
+        mutating func encode(_ encodable: some Encodable, using encoder: any URLQueryEncoder) throws {
             try encoder.encode(encodable, to: &self.request.url)
         }
     }
@@ -113,7 +110,7 @@ public final class Request: CustomStringConvertible, Sendable {
     }
 
     private struct _ContentContainer: ContentContainer, Sendable {
-        let request: Request
+        var request: Request
 
         var contentType: HTTPMediaType? {
             self.request.headers.contentType
@@ -123,7 +120,7 @@ public final class Request: CustomStringConvertible, Sendable {
             self.request.application.contentConfiguration
         }
 
-        func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E : Encodable {
+        mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E : Encodable {
             var body = Data()
             try encoder.encode(encodable, to: &body, headers: &self.request.headers, userInfo: [:])
             let byteBuffer = ByteBuffer(data: body)
@@ -144,7 +141,7 @@ public final class Request: CustomStringConvertible, Sendable {
             return try decoder.decode(D.self, from: bodyData, headers: self.request.headers, userInfo: [:])
         }
 
-        func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C : Content {
+        mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C : Content {
             var content = content
             try content.beforeEncode()
             var body = Data()
@@ -212,7 +209,6 @@ public final class Request: CustomStringConvertible, Sendable {
     }
 
     struct RequestBox: Sendable {
-        var method: HTTPRequest.Method
         var url: URI
         var version: HTTPVersion
         var headers: HTTPFields
@@ -227,8 +223,9 @@ public final class Request: CustomStringConvertible, Sendable {
     private let _storage: NIOLockedValueBox<Storage>
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
     internal let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
+    internal let sessionCache: SessionCache
 
-    public convenience init(
+    public init(
         application: Application,
         method: HTTPRequest.Method = .get,
         url: URI = "/",
@@ -255,7 +252,7 @@ public final class Request: CustomStringConvertible, Sendable {
         }
     }
 
-    package init(
+    internal init(
         application: Application,
         method: HTTPRequest.Method,
         url: URI,
@@ -274,7 +271,6 @@ public final class Request: CustomStringConvertible, Sendable {
         }
 
         let storageBox = RequestBox(
-            method: method,
             url: url,
             version: version,
             headers: headers,
@@ -292,6 +288,9 @@ public final class Request: CustomStringConvertible, Sendable {
         self.bodyStorage = .init(bodyStorage)
         self.streamBodyStorage = .init(nil)
         self.auth = Authentication()
+        self.sessionCache = SessionCache()
+
+        self.method = method
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -197,12 +197,6 @@ public struct Request: CustomStringConvertible, Sendable {
     /// Authentication storage for the request
     public let auth: Authentication
 
-    /// This container is used as arbitrary request-local storage during the request-response lifecycle.Z
-    public var storage: Storage {
-        get { self._storage.withLockedValue { $0 } }
-        set { self._storage.withLockedValue { $0 = newValue } }
-    }
-
     struct RequestBox: Sendable {
         var url: URI
         var headers: HTTPFields
@@ -213,7 +207,6 @@ public struct Request: CustomStringConvertible, Sendable {
 
     let requestBox: NIOLockedValueBox<RequestBox>
 
-    private let _storage: NIOLockedValueBox<Storage>
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
     internal let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
     internal let sessionCache: SessionCache
@@ -275,7 +268,6 @@ public struct Request: CustomStringConvertible, Sendable {
         self.application = application
 
         self.remoteAddress = remoteAddress
-        self._storage = .init(.init())
         self.bodyStorage = .init(bodyStorage)
         self.streamBodyStorage = .init(nil)
         self.auth = Authentication()

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -184,6 +184,7 @@ public struct Request: CustomStringConvertible, Sendable {
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
     internal let sessionCache: SessionCache
     internal let contentConfiguration: ContentConfiguration
+    internal let defaultMaxBodySize: ByteCount
 
     public init(
         application: Application,
@@ -195,7 +196,8 @@ public struct Request: CustomStringConvertible, Sendable {
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
         requestID: String = UUID().uuidString,
-        contentConfiguration: ContentConfiguration = .default()
+        contentConfiguration: ContentConfiguration = .default(),
+        defaultMaxBodySize: ByteCount = "16kb",
     ) {
         self.init(
             application: application,
@@ -207,7 +209,8 @@ public struct Request: CustomStringConvertible, Sendable {
             remoteAddress: remoteAddress,
             peerCertificateChain: peerCertificateChain,
             requestID: requestID,
-            contentConfiguration: contentConfiguration
+            contentConfiguration: contentConfiguration,
+            defaultMaxBodySize: defaultMaxBodySize,
         )
         if let body = collectedBody {
             self.headers.updateContentLength(body.readableBytes)
@@ -224,7 +227,8 @@ public struct Request: CustomStringConvertible, Sendable {
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
         requestID: String = UUID().uuidString,
-        contentConfiguration: ContentConfiguration = .default()
+        contentConfiguration: ContentConfiguration = .default(),
+        defaultMaxBodySize: ByteCount = "16kb",
     ) {
         let bodyStorage: BodyStorage
         if let body = collectedBody {
@@ -249,6 +253,7 @@ public struct Request: CustomStringConvertible, Sendable {
         self.url = url
         self.headers = headers
         self.contentConfiguration = contentConfiguration
+        self.defaultMaxBodySize = defaultMaxBodySize
     }
 
     package init(_ other: Request, route: Route?, parameters: Parameters) {
@@ -266,5 +271,6 @@ public struct Request: CustomStringConvertible, Sendable {
         self.url = other.url
         self.headers = other.headers
         self.contentConfiguration = other.contentConfiguration
+        self.defaultMaxBodySize = other.defaultMaxBodySize
     }
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -13,7 +13,7 @@ public import X509
 
 /// Represents an HTTP request in an application.
 public struct Request: CustomStringConvertible, Sendable {
-    public let application: Application
+//    public let application: Application
 
     /// The HTTP method for this request.
     public let method: HTTPRequest.Method
@@ -84,7 +84,7 @@ public struct Request: CustomStringConvertible, Sendable {
     /// This container is used to read and write the request's query string. Changes (e.g. via `req.query.encode`)
     /// are written back to the request
     public var query: any URLQueryContainer {
-        get { _URLQueryContainer(url: self.url, contentConfiguration: self.application.contentConfiguration) }
+        get { _URLQueryContainer(url: self.url, contentConfiguration: self.contentConfiguration) }
         set { self.url = (newValue as! _URLQueryContainer).url }
     }
 
@@ -132,7 +132,7 @@ public struct Request: CustomStringConvertible, Sendable {
             _ContentContainer(
                 body: self.body.data,
                 headers: self.headers,
-                contentConfiguration: self.application.contentConfiguration,
+                contentConfiguration: self.contentConfiguration,
             )
         }
         set {
@@ -183,6 +183,7 @@ public struct Request: CustomStringConvertible, Sendable {
 
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
     internal let sessionCache: SessionCache
+    internal let contentConfiguration: ContentConfiguration
 
     public init(
         application: Application,
@@ -193,7 +194,8 @@ public struct Request: CustomStringConvertible, Sendable {
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
-        requestID: String = UUID().uuidString
+        requestID: String = UUID().uuidString,
+        contentConfiguration: ContentConfiguration = .default()
     ) {
         self.init(
             application: application,
@@ -204,7 +206,8 @@ public struct Request: CustomStringConvertible, Sendable {
             collectedBody: collectedBody,
             remoteAddress: remoteAddress,
             peerCertificateChain: peerCertificateChain,
-            requestID: requestID
+            requestID: requestID,
+            contentConfiguration: contentConfiguration
         )
         if let body = collectedBody {
             self.headers.updateContentLength(body.readableBytes)
@@ -220,7 +223,8 @@ public struct Request: CustomStringConvertible, Sendable {
         collectedBody: ByteBuffer? = nil,
         remoteAddress: SocketAddress? = nil,
         peerCertificateChain: ValidatedCertificateChain? = nil,
-        requestID: String = UUID().uuidString
+        requestID: String = UUID().uuidString,
+        contentConfiguration: ContentConfiguration = .default()
     ) {
         let bodyStorage: BodyStorage
         if let body = collectedBody {
@@ -230,7 +234,7 @@ public struct Request: CustomStringConvertible, Sendable {
         }
 
         self.id = requestID
-        self.application = application
+//        self.application = application
 
         self.remoteAddress = remoteAddress
         self.bodyStorage = .init(bodyStorage)
@@ -244,10 +248,11 @@ public struct Request: CustomStringConvertible, Sendable {
         self.parameters = .init()
         self.url = url
         self.headers = headers
+        self.contentConfiguration = contentConfiguration
     }
 
     package init(_ other: Request, route: Route?, parameters: Parameters) {
-        self.application = other.application
+//        self.application = other.application
         self.method = other.method
         self.version = other.version
         self.id = other.id
@@ -260,5 +265,6 @@ public struct Request: CustomStringConvertible, Sendable {
         self.parameters = parameters
         self.url = other.url
         self.headers = other.headers
+        self.contentConfiguration = other.contentConfiguration
     }
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -6,13 +6,9 @@ public import Foundation
 #warning("Make this internal")
 public import NIOCore
 import NIOFoundationEssentialsCompat
-import NIOHTTP1
-import Logging
 public import RoutingKit
 import NIOConcurrencyHelpers
 public import HTTPTypes
-import NIOPosix
-import ServiceContextModule
 public import X509
 
 /// Represents an HTTP request in an application.

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -16,9 +16,6 @@ public struct Request: CustomStringConvertible, Sendable {
     public let application: Application
 
     /// The HTTP method for this request.
-    ///
-    ///     httpReq.method = .get
-    ///
     public let method: HTTPRequest.Method
 
     /// The URL used on this request.
@@ -28,8 +25,6 @@ public struct Request: CustomStringConvertible, Sendable {
     public let version: HTTPVersion
 
     /// The header fields for this HTTP request.
-    /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
-    /// when the `body` property is mutated.
     public var headers: HTTPFields
 
     /// A unique ID for the request.

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -55,10 +55,7 @@ public struct Request: CustomStringConvertible, Sendable {
     ///
     ///     req.route?.description // "GET /hello/:name"
     ///
-    public var route: Route? {
-        get { self.requestBox.withLockedValue { $0.route } }
-        set { self.requestBox.withLockedValue { $0.route = newValue } }
-    }
+    public let route: Route?
 
     /// We try to determine true peer address if load balancer or reversed proxy provided info in headers
     ///
@@ -189,10 +186,7 @@ public struct Request: CustomStringConvertible, Sendable {
 
     /// A container containing the route parameters that were captured when receiving this request.
     /// Use this container to grab any non-static parameters from the URL, such as model IDs in a REST API.
-    public var parameters: Parameters {
-        get { self.requestBox.withLockedValue { $0.parameters } }
-        set { self.requestBox.withLockedValue { $0.parameters = newValue } }
-    }
+    public let parameters: Parameters
 
     /// Authentication storage for the request
     public let auth: Authentication
@@ -200,8 +194,6 @@ public struct Request: CustomStringConvertible, Sendable {
     struct RequestBox: Sendable {
         var url: URI
         var headers: HTTPFields
-        var route: Route?
-        var parameters: Parameters
     }
 
     let requestBox: NIOLockedValueBox<RequestBox>
@@ -258,8 +250,6 @@ public struct Request: CustomStringConvertible, Sendable {
         let storageBox = RequestBox(
             url: url,
             headers: headers,
-            route: nil,
-            parameters: .init(),
         )
         self.requestBox = .init(storageBox)
         self.id = requestID
@@ -274,6 +264,24 @@ public struct Request: CustomStringConvertible, Sendable {
         self.method = method
         self.peerCertificateChain = peerCertificateChain
         self.version = version
+        self.route = nil
+        self.parameters = .init()
+    }
+
+    package init(_ other: Request, route: Route?, parameters: Parameters) {
+        self.application = other.application
+        self.method = other.method
+        self.version = other.version
+        self.id = other.id
+        self.remoteAddress = other.remoteAddress
+        self.peerCertificateChain = other.peerCertificateChain
+        self.auth = other.auth
+        self.sessionCache = other.sessionCache
+        self.requestBox = other.requestBox
+        self.bodyStorage = other.bodyStorage
+        self.streamBodyStorage = other.streamBodyStorage
+        self.route = route
+        self.parameters = parameters
     }
 
     internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -82,23 +82,25 @@ public struct Request: CustomStringConvertible, Sendable {
     // MARK: Content
 
     private struct _URLQueryContainer: URLQueryContainer, Sendable {
-        var request: Request
+        var url: URI
         let contentConfiguration: ContentConfiguration
 
         func decode<D>(_ decodable: D.Type, using decoder: any URLQueryDecoder) throws -> D
             where D: Decodable
         {
-            try decoder.decode(D.self, from: self.request.url)
+            try decoder.decode(D.self, from: self.url)
         }
 
         mutating func encode(_ encodable: some Encodable, using encoder: any URLQueryEncoder) throws {
-            try encoder.encode(encodable, to: &self.request.url)
+            try encoder.encode(encodable, to: &self.url)
         }
     }
 
+    /// This container is used to read and write the request's query string. Changes (e.g. via `req.query.encode`)
+    /// are written back to the request
     public var query: any URLQueryContainer {
-        get { _URLQueryContainer(request: self, contentConfiguration: self.application.contentConfiguration) }
-        set { } // ignore since Request is a reference type
+        get { _URLQueryContainer(url: self.url, contentConfiguration: self.application.contentConfiguration) }
+        set { self.url = (newValue as! _URLQueryContainer).url }
     }
 
     private struct _ContentContainer: ContentContainer, Sendable {

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -200,7 +200,6 @@ public struct Request: CustomStringConvertible, Sendable {
     struct RequestBox: Sendable {
         var url: URI
         var headers: HTTPFields
-        var isKeepAlive: Bool
         var route: Route?
         var parameters: Parameters
     }
@@ -259,7 +258,6 @@ public struct Request: CustomStringConvertible, Sendable {
         let storageBox = RequestBox(
             url: url,
             headers: headers,
-            isKeepAlive: true,
             route: nil,
             parameters: .init(),
         )

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -34,10 +34,7 @@ public struct Request: CustomStringConvertible, Sendable {
     /// The header fields for this HTTP request.
     /// The `"Content-Length"` and `"Transfer-Encoding"` headers will be set automatically
     /// when the `body` property is mutated.
-    public var headers: HTTPFields {
-        get { self.requestBox.withLockedValue { $0.headers } }
-        set { self.requestBox.withLockedValue { $0.headers = newValue } }
-    }
+    public var headers: HTTPFields
 
     /// A unique ID for the request.
     ///
@@ -101,52 +98,71 @@ public struct Request: CustomStringConvertible, Sendable {
     }
 
     private struct _ContentContainer: ContentContainer, Sendable {
-        var request: Request
+        var body: ByteBuffer?
+        var headers: HTTPFields
+        let contentConfiguration: ContentConfiguration
+
+        /// The request's own box rather than a snapshot: a streamed body is consumed as it is read,
+        /// so the container has to draw from the same stream the request holds.
+        let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
+        let maxBodySize: Int
 
         var contentType: HTTPMediaType? {
-            self.request.headers.contentType
-        }
-
-        var contentConfiguration: ContentConfiguration {
-            self.request.application.contentConfiguration
+            self.headers.contentType
         }
 
         mutating func encode<E>(_ encodable: E, using encoder: any ContentEncoder) throws where E : Encodable {
             var body = Data()
-            try encoder.encode(encodable, to: &body, headers: &self.request.headers, userInfo: [:])
-            let byteBuffer = ByteBuffer(data: body)
-            self.request.bodyStorage.withLockedValue { $0 = .collected(byteBuffer) }
+            try encoder.encode(encodable, to: &body, headers: &self.headers, userInfo: [:])
+            self.body = ByteBuffer(data: body)
         }
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) async throws -> D where D : Decodable {
-            if let stream = self.request.streamBodyStorage.withLockedValue({ $0 }) {
-                let buffer = try await self.request.collectStream(stream, maxSize: request.application.routes.defaultMaxBodySize.value)
+            if let stream = self.streamBodyStorage.withLockedValue({ $0 }) {
+                let buffer = try await Request.collectStream(stream, maxSize: self.maxBodySize)
                 let bufferData = buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
-                return try decoder.decode(D.self, from: bufferData, headers: self.request.headers, userInfo: [:])
+                return try decoder.decode(D.self, from: bufferData, headers: self.headers, userInfo: [:])
             }
-            guard let body = self.request.body.data else {
+            guard let body = self.body else {
                 Logger.current.debug("Request body is empty. If you're trying to stream the body, decoding streaming bodies not supported")
                 throw Abort(.unprocessableContent)
             }
             let bodyData = body.getData(at: 0, length: body.readableBytes) ?? Data()
-            return try decoder.decode(D.self, from: bodyData, headers: self.request.headers, userInfo: [:])
+            return try decoder.decode(D.self, from: bodyData, headers: self.headers, userInfo: [:])
         }
 
         mutating func encode<C>(_ content: C, using encoder: any ContentEncoder) throws where C : Content {
             var content = content
             try content.beforeEncode()
             var body = Data()
-            try encoder.encode(content, to: &body, headers: &self.request.headers, userInfo: [:])
-            let byteBuffer = ByteBuffer(data: body)
-            self.request.bodyStorage.withLockedValue { $0 = .collected(byteBuffer) }
+            try encoder.encode(content, to: &body, headers: &self.headers, userInfo: [:])
+            self.body = ByteBuffer(data: body)
         }
     }
 
     /// This container is used to read your `Decodable` type using a `ContentDecoder` implementation.
     /// If no `ContentDecoder` is provided, a `Request`'s `Content-Type` header is used to select a registered decoder.
+    ///
+    /// As with ``query``, the container holds copies of the body and headers and the setter writes
+    /// them back, so `req.content.encode(_:)` propagates without relying on that state living behind
+    /// a reference.
     public var content: any ContentContainer {
-        get { _ContentContainer(request: self) }
-        set { } // ignore since Request is a reference type
+        get {
+            _ContentContainer(
+                body: self.body.data,
+                headers: self.headers,
+                contentConfiguration: self.application.contentConfiguration,
+                streamBodyStorage: self.streamBodyStorage,
+                maxBodySize: self.application.routes.defaultMaxBodySize.value
+            )
+        }
+        set {
+            let container = newValue as! _ContentContainer
+            self.headers = container.headers
+            self.bodyStorage.withLockedValue { storage in
+                storage = container.body.map { .collected($0) } ?? .none
+            }
+        }
     }
 
     public var body: Body {
@@ -189,12 +205,6 @@ public struct Request: CustomStringConvertible, Sendable {
 
     /// Authentication storage for the request
     public let auth: Authentication
-
-    struct RequestBox: Sendable {
-        var headers: HTTPFields
-    }
-
-    let requestBox: NIOLockedValueBox<RequestBox>
 
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
     internal let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
@@ -245,10 +255,6 @@ public struct Request: CustomStringConvertible, Sendable {
             bodyStorage = .none
         }
 
-        let storageBox = RequestBox(
-            headers: headers,
-        )
-        self.requestBox = .init(storageBox)
         self.id = requestID
         self.application = application
 
@@ -264,6 +270,7 @@ public struct Request: CustomStringConvertible, Sendable {
         self.route = nil
         self.parameters = .init()
         self.url = url
+        self.headers = headers
     }
 
     package init(_ other: Request, route: Route?, parameters: Parameters) {
@@ -275,15 +282,15 @@ public struct Request: CustomStringConvertible, Sendable {
         self.peerCertificateChain = other.peerCertificateChain
         self.auth = other.auth
         self.sessionCache = other.sessionCache
-        self.requestBox = other.requestBox
         self.bodyStorage = other.bodyStorage
         self.streamBodyStorage = other.streamBodyStorage
         self.route = route
         self.parameters = parameters
         self.url = other.url
+        self.headers = other.headers
     }
 
-    internal func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {
+    internal static func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {
         var collected = ByteBuffer()
         for await var chunk in stream {
             collected.writeBuffer(&chunk)

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -187,7 +187,6 @@ public struct Request: CustomStringConvertible, Sendable {
     internal let defaultMaxBodySize: ByteCount
 
     public init(
-        application: Application,
         method: HTTPRequest.Method = .get,
         url: URI = "/",
         version: HTTPVersion = .init(major: 1, minor: 1),
@@ -200,7 +199,6 @@ public struct Request: CustomStringConvertible, Sendable {
         defaultMaxBodySize: ByteCount = "16kb",
     ) {
         self.init(
-            application: application,
             method: method,
             url: url,
             version: version,
@@ -218,7 +216,6 @@ public struct Request: CustomStringConvertible, Sendable {
     }
 
     internal init(
-        application: Application,
         method: HTTPRequest.Method,
         url: URI,
         version: HTTPVersion = .init(major: 1, minor: 1),
@@ -238,13 +235,10 @@ public struct Request: CustomStringConvertible, Sendable {
         }
 
         self.id = requestID
-//        self.application = application
-
         self.remoteAddress = remoteAddress
         self.bodyStorage = .init(bodyStorage)
         self.auth = Authentication()
         self.sessionCache = SessionCache()
-
         self.method = method
         self.peerCertificateChain = peerCertificateChain
         self.version = version
@@ -257,7 +251,6 @@ public struct Request: CustomStringConvertible, Sendable {
     }
 
     package init(_ other: Request, route: Route?, parameters: Parameters) {
-//        self.application = other.application
         self.method = other.method
         self.version = other.version
         self.id = other.id

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -102,11 +102,6 @@ public struct Request: CustomStringConvertible, Sendable {
         var headers: HTTPFields
         let contentConfiguration: ContentConfiguration
 
-        /// The request's own box rather than a snapshot: a streamed body is consumed as it is read,
-        /// so the container has to draw from the same stream the request holds.
-        let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
-        let maxBodySize: Int
-
         var contentType: HTTPMediaType? {
             self.headers.contentType
         }
@@ -118,13 +113,8 @@ public struct Request: CustomStringConvertible, Sendable {
         }
 
         func decode<D>(_ decodable: D.Type, using decoder: any ContentDecoder) async throws -> D where D : Decodable {
-            if let stream = self.streamBodyStorage.withLockedValue({ $0 }) {
-                let buffer = try await Request.collectStream(stream, maxSize: self.maxBodySize)
-                let bufferData = buffer.getData(at: 0, length: buffer.readableBytes) ?? Data()
-                return try decoder.decode(D.self, from: bufferData, headers: self.headers, userInfo: [:])
-            }
             guard let body = self.body else {
-                Logger.current.debug("Request body is empty. If you're trying to stream the body, decoding streaming bodies not supported")
+                // This shouldn't be an issue when we support streaming bodies, we should just be able to collect the body
                 throw Abort(.unprocessableContent)
             }
             let bodyData = body.getData(at: 0, length: body.readableBytes) ?? Data()
@@ -152,8 +142,6 @@ public struct Request: CustomStringConvertible, Sendable {
                 body: self.body.data,
                 headers: self.headers,
                 contentConfiguration: self.application.contentConfiguration,
-                streamBodyStorage: self.streamBodyStorage,
-                maxBodySize: self.application.routes.defaultMaxBodySize.value
             )
         }
         set {
@@ -167,10 +155,6 @@ public struct Request: CustomStringConvertible, Sendable {
 
     public var body: Body {
         Body(self)
-    }
-
-    public var newBody: NewBody {
-        NewBody(underlying: self.streamBodyStorage.withLockedValue({ $0 }), maxBodySize: 16*1024)
     }
 
     internal enum BodyStorage: Sendable {
@@ -207,7 +191,6 @@ public struct Request: CustomStringConvertible, Sendable {
     public let auth: Authentication
 
     internal let bodyStorage: NIOLockedValueBox<BodyStorage>
-    internal let streamBodyStorage: NIOLockedValueBox<AsyncStream<ByteBuffer>?>
     internal let sessionCache: SessionCache
 
     public init(
@@ -260,7 +243,6 @@ public struct Request: CustomStringConvertible, Sendable {
 
         self.remoteAddress = remoteAddress
         self.bodyStorage = .init(bodyStorage)
-        self.streamBodyStorage = .init(nil)
         self.auth = Authentication()
         self.sessionCache = SessionCache()
 
@@ -283,21 +265,9 @@ public struct Request: CustomStringConvertible, Sendable {
         self.auth = other.auth
         self.sessionCache = other.sessionCache
         self.bodyStorage = other.bodyStorage
-        self.streamBodyStorage = other.streamBodyStorage
         self.route = route
         self.parameters = parameters
         self.url = other.url
         self.headers = other.headers
-    }
-
-    internal static func collectStream(_ stream: AsyncStream<ByteBuffer>, maxSize: Int) async throws -> ByteBuffer {
-        var collected = ByteBuffer()
-        for await var chunk in stream {
-            collected.writeBuffer(&chunk)
-            guard collected.readableBytes <= maxSize else {
-                throw Abort(.contentTooLarge)
-            }
-        }
-        return collected
     }
 }

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -50,36 +50,53 @@ package struct DefaultResponder: Responder {
 
     // See `Responder.respond(to:)`
     package func respond(to request: Request) async throws -> Response {
-        var request = request
-        if let cachedRoute = self.getRoute(for: &request) {
-            request.route = cachedRoute.route
-            return try await cachedRoute.responder.respond(to: request)
-        } else {
+        var parameters = Parameters()
+        guard let cachedRoute = self.getRoute(
+            method: request.method,
+            path: request.url.path,
+            parameters: &parameters
+        ) else {
             return try await self.notFoundResponder.respond(to: request)
         }
+        return try await cachedRoute.responder.respond(
+            to: Request(request, route: cachedRoute.route, parameters: parameters)
+        )
     }
 
     /// Gets a `Route` from the underlying `TrieRouter`.
-    private func getRoute(for request: inout Request) -> CachedRoute? {
-        let pathComponents = request.url.path
+    private func getRoute(
+        method: HTTPRequest.Method,
+        path: String,
+        parameters: inout Parameters
+    ) -> CachedRoute? {
+        let pathComponents = path
             .split(separator: "/")
             .map { String($0).removingPercentEncoding ?? String($0) }
 
         // If it's a HEAD request and a HEAD route exists, return that route...
-        if request.method == .head, let route = self.router.route(
-            path: [HTTPRequest.Method.head.rawValue] + pathComponents,
-            parameters: &request.parameters
-        ) {
-            return route
+        if method == .head {
+            var headParameters = Parameters()
+            if let route = self.router.route(
+                path: [HTTPRequest.Method.head.rawValue] + pathComponents,
+                parameters: &headParameters
+            ) {
+                parameters = headParameters
+                return route
+            }
         }
 
         // ...otherwise forward HEAD requests to GET route
-        let method = (request.method == .head) ? .get : request.method
+        let resolvedMethod = (method == .head) ? .get : method
 
-        return self.router.route(
-            path: [method.rawValue] + pathComponents,
-            parameters: &request.parameters
-        )
+        var routeParameters = Parameters()
+        guard let route = self.router.route(
+            path: [resolvedMethod.rawValue] + pathComponents,
+            parameters: &routeParameters
+        ) else {
+            return nil
+        }
+        parameters = routeParameters
+        return route
     }
 }
 

--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -50,7 +50,8 @@ package struct DefaultResponder: Responder {
 
     // See `Responder.respond(to:)`
     package func respond(to request: Request) async throws -> Response {
-        if let cachedRoute = self.getRoute(for: request) {
+        var request = request
+        if let cachedRoute = self.getRoute(for: &request) {
             request.route = cachedRoute.route
             return try await cachedRoute.responder.respond(to: request)
         } else {
@@ -59,7 +60,7 @@ package struct DefaultResponder: Responder {
     }
 
     /// Gets a `Route` from the underlying `TrieRouter`.
-    private func getRoute(for request: Request) -> CachedRoute? {
+    private func getRoute(for request: inout Request) -> CachedRoute? {
         let pathComponents = request.url.path
             .split(separator: "/")
             .map { String($0).removingPercentEncoding ?? String($0) }

--- a/Sources/Vapor/Response/ResponseCodable.swift
+++ b/Sources/Vapor/Response/ResponseCodable.swift
@@ -68,7 +68,7 @@ extension Response: ResponseEncodable {
 extension StaticString: ResponseEncodable {
     // See `AsyncResponseEncodable`.
     public func encodeResponse(for request: Request) async throws -> Response {
-        let res = Response(headers: staticStringHeaders, body: .init(staticString: self), contentConfiguration: request.application.contentConfiguration)
+        let res = Response(headers: staticStringHeaders, body: .init(staticString: self), contentConfiguration: request.contentConfiguration)
         return res
     }
 }
@@ -76,7 +76,7 @@ extension StaticString: ResponseEncodable {
 extension String: ResponseEncodable {
     // See `AsyncResponseEncodable`.
     public func encodeResponse(for request: Request) async throws -> Response {
-        let res = Response(headers: staticStringHeaders, body: .init(string: self), contentConfiguration: request.application.contentConfiguration)
+        let res = Response(headers: staticStringHeaders, body: .init(string: self), contentConfiguration: request.contentConfiguration)
         return res
     }
 }

--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -167,7 +167,7 @@ extension RoutesBuilder {
         let responder = BasicResponder { request in
             if case .collect(let max) = body, request.body.data == nil {
                 _ = try await MultiThreadedEventLoopGroup.singleton.any().flatSubmit {
-                    request.body.collect(max: max?.value ?? request.application.routes.defaultMaxBodySize.value)
+                    request.body.collect(max: max?.value ?? request.defaultMaxBodySize.value)
                 }.get()
 
             }

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -32,18 +32,4 @@ extension Request {
     public var hasSession: Bool {
         self.sessionCache.session.withLockedValue { $0 != nil }
     }
-
-    private struct SessionCacheKey: StorageKey {
-        typealias Value = SessionCache
-    }
-
-//    internal var _sessionCache: SessionCache {
-//        if let existing = self.storage[SessionCacheKey.self] {
-//            return existing
-//        } else {
-//            let new = SessionCache()
-//            self.storage[SessionCacheKey.self] = new
-//            return new
-//        }
-//    }
 }

--- a/Sources/Vapor/Sessions/Request+Session.swift
+++ b/Sources/Vapor/Sessions/Request+Session.swift
@@ -11,14 +11,14 @@ extension Request {
     /// - note: `SessionsMiddleware` must be added and enabled.
     /// - returns: `Session` for this `Request`.
     public var session: Session {
-        if !self._sessionCache.middlewareFlag.withLockedValue({ $0 }) {
+        if !self.sessionCache.middlewareFlag.withLockedValue({ $0 }) {
             // No `SessionsMiddleware` was detected on your app.
             // Suggested solutions:
             // - Add the `SessionsMiddleware` globally to your app using `app.middleware.use`
             // - Add the `SessionsMiddleware` to a route group.
             assertionFailure("No `SessionsMiddleware` detected.")
         }
-        return self._sessionCache.session.withLockedValue { storedSession in
+        return self.sessionCache.session.withLockedValue { storedSession in
             if let existing = storedSession {
                 return existing
             } else {
@@ -30,20 +30,20 @@ extension Request {
     }
 
     public var hasSession: Bool {
-        self._sessionCache.session.withLockedValue { $0 != nil }
+        self.sessionCache.session.withLockedValue { $0 != nil }
     }
 
     private struct SessionCacheKey: StorageKey {
         typealias Value = SessionCache
     }
 
-    internal var _sessionCache: SessionCache {
-        if let existing = self.storage[SessionCacheKey.self] {
-            return existing
-        } else {
-            let new = SessionCache()
-            self.storage[SessionCacheKey.self] = new
-            return new
-        }
-    }
+//    internal var _sessionCache: SessionCache {
+//        if let existing = self.storage[SessionCacheKey.self] {
+//            return existing
+//        } else {
+//            let new = SessionCache()
+//            self.storage[SessionCacheKey.self] = new
+//            return new
+//        }
+//    }
 }

--- a/Sources/Vapor/Sessions/SessionCache.swift
+++ b/Sources/Vapor/Sessions/SessionCache.swift
@@ -1,6 +1,7 @@
 import NIOConcurrencyHelpers
 
 /// Singleton service cache for a `Session`. Used with a message's private container.
+#warning("Match the Authentication style to avoid lots of allocations on every `Request`")
 internal final class SessionCache: Sendable {
     /// Set to `true` when passing through middleware.
     let middlewareFlag: NIOLockedValueBox<Bool>

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -34,7 +34,7 @@ public final class SessionsMiddleware: Middleware {
 
     public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
         // Signal middleware has been added.
-        request._sessionCache.middlewareFlag.withLockedValue { $0 = true }
+        request.sessionCache.middlewareFlag.withLockedValue { $0 = true }
 
         // Check for an existing session
         if let cookieValue = request.cookies[self.configuration.cookieName] {
@@ -42,10 +42,10 @@ public final class SessionsMiddleware: Middleware {
             let id = SessionID(string: cookieValue.string)
             if let data = try await self.session.readSession(id, for: request) {
                 // Session found, restore data and id.
-                request._sessionCache.session.withLockedValue { $0 = .init(id: id, data: data) }
+                request.sessionCache.session.withLockedValue { $0 = .init(id: id, data: data) }
             } else {
                 // Session id not found, create new session.
-                request._sessionCache.session.withLockedValue { $0 = .init() }
+                request.sessionCache.session.withLockedValue { $0 = .init() }
             }
         }
 
@@ -56,7 +56,7 @@ public final class SessionsMiddleware: Middleware {
     /// Adds session cookie to response or clears if session was deleted.
     private func addCookies(to response: Response, for request: Request) async throws -> Response {
         var response = response
-        if let session = request._sessionCache.session.withLockedValue({ $0 }), session.isValid.withLockedValue({ $0 }) {
+        if let session = request.sessionCache.session.withLockedValue({ $0 }), session.isValid.withLockedValue({ $0 }) {
             // A session exists or has been created. we must
             // set a cookie value on the response
             let sessionID: SessionID

--- a/Sources/Vapor/Utilities/FileETagHashCache.swift
+++ b/Sources/Vapor/Utilities/FileETagHashCache.swift
@@ -10,7 +10,7 @@ public import Foundation
 /// rather than a dictionary in `Application.storage` for two reasons: storage hands back a copy, so
 /// read-modify-write updates could lose entries, and a shared mutable dictionary can't dedupe
 /// concurrent work. Here a miss becomes a single task that every caller for that file awaits.
-package actor FileETagHashCache {
+public actor FileETagHashCache {
     /// A cached hash, along with what it was computed from.
     package struct Entry: Sendable, Equatable {
         package let lastModified: Date

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -12,49 +12,26 @@ import NIOConcurrencyHelpers
 import _NIOFileSystemFoundationCompat
 import NIOHTTP1
 
-extension Request {
-    public func fileio(etagCache: FileETagHashCache) -> FileIO {
+extension Application {
+    public var fileio: FileIO {
         return .init(
-            request: self,
-            fileETagHashCache: etagCache,
+            fileETagHashCache: self.fileETagHashCache,
         )
     }
 }
 
 // MARK: FileIO
 
-/// `FileIO` is a convenience wrapper around SwiftNIO's `FileSystem`.
-///
-/// It can read files, both in their entirety and chunked.
-///
-///     try await req.fileio.readFile(at: "/path/to/file.txt") { chunks in
-///         for try await chunk in chunks {
-///             print(chunk) // part of file
-///         }
-///     }
-///
-///     let file = try await req.fileio.collectFile(at: "/path/to/file.txt")
-///     print(file) // entire file
-///
-/// It can also create streaming HTTP responses.
-///
-///     app.get("file-stream") { req -> Response in
-///         return try await req.fileio.streamFile(at: "/path/to/file.txt")
-///     }
-///
-/// Streaming file responses respect `E-Tag` headers present in the request.
+/// `FileIO` is a convenience wrapper around SwiftNIO's `FileSystem` for streaming files with a ``Request``
+/// to a ``Response``. It handles streaming file chunks to the response body, ETag support and caching and request ranges.
 public struct FileIO: Sendable {
     /// Cache for eTag hashes for each file
     let fileETagHashCache: FileETagHashCache
-
-    let request: Request
-
     let fileSystem: FileSystem = .shared
 
     /// Creates a new ``FileIO``.
-    internal init(request: Request, fileETagHashCache: FileETagHashCache) {
+    internal init(fileETagHashCache: FileETagHashCache) {
         self.fileETagHashCache = fileETagHashCache
-        self.request = request
     }
 
     /// Generates a fresh ETag for a file or returns its currently cached one.
@@ -99,6 +76,7 @@ public struct FileIO: Sendable {
     /// - returns: A `200 OK` response containing the file stream and appropriate headers.
     public func streamFile(
         at path: String,
+        for request: Request,
         chunkSize: Int64 = 128 * 1024, // was the default in NonBlockingFileIO
         mediaType: HTTPMediaType? = nil,
         advancedETagComparison: Bool = false,
@@ -226,7 +204,6 @@ public struct FileIO: Sendable {
 }
 
 extension HTTPFields.Range.Value {
-
     fileprivate func asByteBufferBounds(withMaxSize size: Int) throws -> (offset: Int64, byteCount: Int) {
         switch self {
             case .start(let value):

--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -14,9 +14,10 @@ import _NIOFileSystemFoundationCompat
 import NIOHTTP1
 
 extension Request {
-    public var fileio: FileIO {
+    public func fileio(etagCache: FileETagHashCache) -> FileIO {
         return .init(
-            request: self
+            request: self,
+            fileETagHashCache: etagCache,
         )
     }
 }
@@ -44,15 +45,16 @@ extension Request {
 ///
 /// Streaming file responses respect `E-Tag` headers present in the request.
 public struct FileIO: Sendable {
-    /// HTTP request context.
+    /// Cache for eTag hashes for each file
+    let fileETagHashCache: FileETagHashCache
+
     let request: Request
 
     let fileSystem: FileSystem = .shared
 
     /// Creates a new ``FileIO``.
-    ///
-    /// Use ``Request/fileio`` to get one.
-    internal init(request: Request) {
+    internal init(request: Request, fileETagHashCache: FileETagHashCache) {
+        self.fileETagHashCache = fileETagHashCache
         self.request = request
     }
 
@@ -72,7 +74,7 @@ public struct FileIO: Sendable {
     ///   - lastModified: When the file was last modified.
     /// - Returns: A `String` which holds the ETag.
     private func generateETagHash(path: String, lastModified: Date, size: Int64) async throws -> String {
-        try await self.request.application.fileETagHashCache.digestHex(
+        try await self.fileETagHashCache.digestHex(
             forFileAt: path,
             lastModified: lastModified,
             size: size

--- a/Sources/Vapor/Validation/Validatable.swift
+++ b/Sources/Vapor/Validation/Validatable.swift
@@ -18,7 +18,7 @@ extension Validatable {
     }
     
     public static func validate(query request: Request) throws {
-        try self.validations().validate(query: request.url, contentConfiguration: request.application.contentConfiguration).assert()
+        try self.validations().validate(query: request.url, contentConfiguration: request.contentConfiguration).assert()
     }
     
     public static func validate(json: String, contentConfiguration: ContentConfiguration = .default()) throws {

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -59,7 +59,7 @@ public struct Validations: Sendable {
         guard let body = request.body.data, let bodyData = body.getData(at: 0, length: body.readableBytes) else {
             throw Abort(.unprocessableContent, reason: "Empty Body")
         }
-        let contentDecoder = try request.application.contentConfiguration.requireDecoder(for: contentType)
+        let contentDecoder = try request.contentConfiguration.requireDecoder(for: contentType)
         return try contentDecoder.decode(ValidationsExecutor.self, from: bodyData, headers: request.headers, userInfo: [.pendingValidations: self]).results
     }
 

--- a/Sources/Vapor/View/Request+View.swift
+++ b/Sources/Vapor/View/Request+View.swift
@@ -1,5 +1,5 @@
-extension Request {
-    public var view: any ViewRenderer {
-        self.application.viewRenderer
-    }
-}
+//extension Request {
+//    public var view: any ViewRenderer {
+//        self.application.viewRenderer
+//    }
+//}

--- a/Sources/Vapor/View/Request+View.swift
+++ b/Sources/Vapor/View/Request+View.swift
@@ -1,5 +1,0 @@
-//extension Request {
-//    public var view: any ViewRenderer {
-//        self.application.viewRenderer
-//    }
-//}

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -104,12 +104,13 @@ extension Application {
             var headers = request.headers
             headers[.contentLength] = request.body.readableBytes.description
             let request = Request(
-                application: app,
                 method: request.method,
                 url: request.url,
                 headers: headers,
                 collectedBody: request.body.readableBytes == 0 ? nil : request.body,
-                remoteAddress: nil
+                remoteAddress: nil,
+                contentConfiguration: app.contentConfiguration,
+                defaultMaxBodySize: app.routes.defaultMaxBodySize
             )
             let responder: any Responder
             switch self.app.responder {

--- a/Tests/VaporTests/ApplicationTests.swift
+++ b/Tests/VaporTests/ApplicationTests.swift
@@ -229,7 +229,7 @@ struct ApplicationTests {
             }
 
             app.get("hello") { req -> AddressConfig in
-                let config = AddressConfig(hostname: req.application.sharedAddress.withLockedValue({ $0 })?.hostname, port: req.application.sharedAddress.withLockedValue({ $0 })?.port)
+                let config = AddressConfig(hostname: app.sharedAddress.withLockedValue({ $0 })?.hostname, port: app.sharedAddress.withLockedValue({ $0 })?.port)
                 return config
             }
 
@@ -274,7 +274,7 @@ struct ApplicationTests {
             }
 
             app.get("hello") { req -> AddressConfig in
-                let config = AddressConfig(hostname: req.application.serverConfiguration.hostname, port: req.application.serverConfiguration.port)
+                let config = AddressConfig(hostname: app.serverConfiguration.hostname, port: app.serverConfiguration.port)
                 return config
             }
 

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -635,7 +635,7 @@ struct AuthenticationTests {
         try await withApp { app in
             var lost = 0
             for _ in 0..<1_000 {
-                let request = Request(application: app)
+                let request = Request()
 
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask { request.auth.login(User(name: "Vapor")) }
@@ -661,7 +661,7 @@ struct AuthenticationTests {
         }
 
         try await withApp { app in
-            let request = Request(application: app)
+            let request = Request()
             request.auth.login(User(name: "Vapor"))
             request.auth.login(Token(value: "secret"))
 
@@ -683,7 +683,7 @@ struct AuthenticationTests {
         }
 
         try await withApp { app in
-            let request = Request(application: app)
+            let request = Request()
             request.auth.login(User(name: "Vapor"))
             request.auth.login(User(name: "Vapor 2"))
 
@@ -703,7 +703,7 @@ struct AuthenticationTests {
         }
 
         try await withApp { app in
-            let request = Request(application: app)
+            let request = Request()
 
             // Nothing authenticated to begin with.
             #expect(!request.auth.has(User.self))

--- a/Tests/VaporTests/ClientTests.swift
+++ b/Tests/VaporTests/ClientTests.swift
@@ -81,7 +81,7 @@ struct ClientTests {
 
                 app.get("foo") { req async throws -> String in
                     do {
-                        let response = try await req.application.client.get("http://127.0.0.1:\(remoteAppPort)/status/201")
+                        let response = try await app.client.get("http://127.0.0.1:\(remoteAppPort)/status/201")
                         #expect(response.status.code == 201)
                         // Server shutdown handled by task cancellation
                         return "bar"
@@ -118,7 +118,7 @@ struct ClientTests {
     func testGH2716() async throws {
         try await withApp { app in
             app.get("client") { req in
-                let response = try await req.application.client.get("htp://localhost/status/2 1")
+                let response = try await app.client.get("htp://localhost/status/2 1")
                 return response.description
             }
 

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -783,7 +783,7 @@ struct ConditionalCompressionTests {
             on app: Application,
             sourceLocation: SourceLocation = #_sourceLocation
         ) async throws {
-            let response = try await middleware.respond(to: Request(application: app), chainingTo: responder)
+            let response = try await middleware.respond(to: Request(), chainingTo: responder)
             let header = response.headers[values: .xVaporResponseCompression]
 
             #expect(header == compressionValue.map { $0.components(separatedBy: ", ") }?.map { String($0[...]) } ?? [], sourceLocation: sourceLocation)

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -17,7 +17,6 @@ struct ContentTests {
     func testContent() async throws {
         try await withApp { app throws in
             var request = Request(
-                application: app,
                 collectedBody: .init(string: #"{"hello": "world"}"#)
             )
             request.headers.contentType = .json
@@ -59,7 +58,6 @@ struct ContentTests {
 
         try await withApp { app throws in
             var request = Request(
-                application: app,
                 collectedBody: .init(string: complexJSON)
             )
             request.headers.contentType = .json
@@ -127,7 +125,7 @@ struct ContentTests {
             // asserted deliberately: a container that reached the body through a reference but the
             // headers through a copy would still land the body while silently dropping the content
             // type the encoder sets, leaving the request undecodable for a non-obvious reason.
-            var request = Request(application: app)
+            var request = Request()
             try request.content.encode(FooContent())
 
             #expect(request.headers.contentType == .json)
@@ -135,7 +133,7 @@ struct ContentTests {
             #expect(try await request.content.decode(FooContent.self) == FooContent())
 
             // Same again for the overload taking an explicit content type.
-            var explicit = Request(application: app)
+            var explicit = Request()
             try explicit.content.encode(FooContent(), as: .json)
 
             #expect(explicit.headers.contentType == .json)
@@ -151,7 +149,7 @@ struct ContentTests {
         }
 
         try await withApp { app in
-            var request = Request(application: app, collectedBody: .init(string: "xx"))
+            var request = Request(collectedBody: .init(string: "xx"))
             #expect(request.headers[.contentLength] == "2")
 
             try request.content.encode(FooContent())
@@ -577,7 +575,6 @@ struct ContentTests {
 
         try await withApp { app in
             var request = Request(
-                application: app,
                 collectedBody: body
             )
 
@@ -594,7 +591,6 @@ struct ContentTests {
         // way to know about the hook, so the value came back unprocessed.
         try await withApp { app in
             var request = Request(
-                application: app,
                 collectedBody: .init(string: #"{"name": "before decode"}"#)
             )
             request.headers.contentType = .json
@@ -661,7 +657,6 @@ struct ContentTests {
 
         try await withApp { app in
             var request = Request(
-                application: app,
                 collectedBody: body
             )
 
@@ -676,7 +671,6 @@ struct ContentTests {
     func testQueryHooks() async throws {
         try await withApp { app in
             var request = Request(
-                application: app,
                 collectedBody: .init(string: "")
             )
             request.url.query = "name=before+decode"
@@ -693,7 +687,6 @@ struct ContentTests {
     func testDecodePercentEncodedQuery() async throws {
         try await withApp { app throws in
             var request = Request(
-                application: app,
                 collectedBody: .init(string: "")
             )
             request.url = .init(string: "/?name=value%20has%201%25%20of%20its%20percents")
@@ -720,7 +713,7 @@ struct ContentTests {
     @Test("Test Snake Case Coding Key Error")
     func testSnakeCaseCodingKeyError() async throws {
         try await withApp { app in
-            var req = Request(application: app)
+            var req = Request()
             try req.content.encode([
                 "title": "The title"
             ], as: .json)
@@ -747,7 +740,6 @@ struct ContentTests {
     func testDataCorruptionError() async throws {
         try await withApp { app in
             var req = Request(
-                application: app,
                 method: .get,
                 url: URI(string: "https://vapor.codes"),
                 collectedBody: ByteBuffer(string: #"{"badJson: "Key doesn't have a trailing quote"}"#)
@@ -768,7 +760,7 @@ struct ContentTests {
     @Test("Test ValueNotFoundError")
     func testValueNotFoundError() async throws {
         try await withApp { app in
-            var req = Request(application: app)
+            var req = Request()
             try req.content.encode([
                 "items": ["1"]
             ], as: .json)
@@ -797,7 +789,7 @@ struct ContentTests {
     @Test("Test Type Mismatch Error")
     func testTypeMismatchError() async throws {
         try await withApp { app in
-            var req = Request(application: app)
+            var req = Request()
             try req.content.encode([
                 "item": [
                     "title": "The title"

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -16,7 +16,7 @@ struct ContentTests {
     @Test("Test Content")
     func testContent() async throws {
         try await withApp { app throws in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: .init(string: #"{"hello": "world"}"#)
             )
@@ -58,7 +58,7 @@ struct ContentTests {
         """
 
         try await withApp { app throws in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: .init(string: complexJSON)
             )
@@ -524,7 +524,7 @@ struct ContentTests {
         body.writeString(#"{"name": "before decode"}"#)
 
         try await withApp { app in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: body
             )
@@ -541,7 +541,7 @@ struct ContentTests {
         // `decode(_:as:)` used to bind a `Content` type to the `Decodable` overload, which has no
         // way to know about the hook, so the value came back unprocessed.
         try await withApp { app in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: .init(string: #"{"name": "before decode"}"#)
             )
@@ -608,7 +608,7 @@ struct ContentTests {
         body.writeString(#"{"data": ["entity0", "entity1"], "meta": {}}"#)
 
         try await withApp { app in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: body
             )
@@ -623,7 +623,7 @@ struct ContentTests {
     @Test("Test Query Hooks")
     func testQueryHooks() async throws {
         try await withApp { app in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: .init(string: "")
             )
@@ -640,7 +640,7 @@ struct ContentTests {
     @Test("Test Decode Percent Encoded Query", .bug("https://github.com/vapor/vapor/issues/3135"))
     func testDecodePercentEncodedQuery() async throws {
         try await withApp { app throws in
-            let request = Request(
+            var request = Request(
                 application: app,
                 collectedBody: .init(string: "")
             )
@@ -668,7 +668,7 @@ struct ContentTests {
     @Test("Test Snake Case Coding Key Error")
     func testSnakeCaseCodingKeyError() async throws {
         try await withApp { app in
-            let req = Request(application: app)
+            var req = Request(application: app)
             try req.content.encode([
                 "title": "The title"
             ], as: .json)
@@ -694,13 +694,13 @@ struct ContentTests {
     @Test("Test Data Corruption Error")
     func testDataCorruptionError() async throws {
         try await withApp { app in
-            let req = Request(
+            var req = Request(
                 application: app,
                 method: .get,
                 url: URI(string: "https://vapor.codes"),
-                headersNoUpdate: [.contentType: "application/json"],
                 collectedBody: ByteBuffer(string: #"{"badJson: "Key doesn't have a trailing quote"}"#)
             )
+            req.headers.contentType = .json
 
             struct DecodeModel: Content {
                 let badJson: String
@@ -716,7 +716,7 @@ struct ContentTests {
     @Test("Test ValueNotFoundError")
     func testValueNotFoundError() async throws {
         try await withApp { app in
-            let req = Request(application: app)
+            var req = Request(application: app)
             try req.content.encode([
                 "items": ["1"]
             ], as: .json)
@@ -745,7 +745,7 @@ struct ContentTests {
     @Test("Test Type Mismatch Error")
     func testTypeMismatchError() async throws {
         try await withApp { app in
-            let req = Request(application: app)
+            var req = Request(application: app)
             try req.content.encode([
                 "item": [
                     "title": "The title"

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -115,6 +115,35 @@ struct ContentTests {
         }
     }
 
+    @Test("Encoding a Request's content writes back both the body and the content type")
+    func testRequestContentContainerEncodeWritesBack() async throws {
+        struct FooContent: Content, Equatable {
+            var message: String = "hi"
+        }
+
+        try await withApp { app in
+            // `content` vends a value, so `encode` mutates a copy and the setter on
+            // ``Request/content`` is what puts the result back on the request. Both halves are
+            // asserted deliberately: a container that reached the body through a reference but the
+            // headers through a copy would still land the body while silently dropping the content
+            // type the encoder sets, leaving the request undecodable for a non-obvious reason.
+            var request = Request(application: app)
+            try request.content.encode(FooContent())
+
+            #expect(request.headers.contentType == .json)
+            #expect(request.body.string == #"{"message":"hi"}"#)
+            #expect(try await request.content.decode(FooContent.self) == FooContent())
+
+            // Same again for the overload taking an explicit content type.
+            var explicit = Request(application: app)
+            try explicit.content.encode(FooContent(), as: .json)
+
+            #expect(explicit.headers.contentType == .json)
+            #expect(explicit.body.string == #"{"message":"hi"}"#)
+            #expect(try await explicit.content.decode(FooContent.self) == FooContent())
+        }
+    }
+
     @Test("Test Content Container Decode")
     func testContentContainerDecode() async throws {
         struct FooContent: Content, Equatable {

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -144,6 +144,29 @@ struct ContentTests {
         }
     }
 
+    @Test("Encoding a Request's content updates Content-Length")
+    func testRequestContentContainerEncodeUpdatesContentLength() async throws {
+        struct FooContent: Content, Equatable {
+            var message: String = "hi"
+        }
+
+        try await withApp { app in
+            var request = Request(application: app, collectedBody: .init(string: "xx"))
+            #expect(request.headers[.contentLength] == "2")
+
+            try request.content.encode(FooContent())
+
+            // The body really is replaced...
+            #expect(request.body.string == #"{"message":"hi"}"#)
+
+            // ...but the header is left describing the old one.
+            #warning("`Request.body` is computed, so unlike `Response` there is no `didSet` to refresh Content-Length when the body changes. Fix in the body overhaul and drop this `withKnownIssue`")
+            withKnownIssue("Content-Length still describes the previous body") {
+                #expect(request.headers[.contentLength] == "16")
+            }
+        }
+    }
+
     @Test("Test Content Container Decode")
     func testContentContainerDecode() async throws {
         struct FooContent: Content, Equatable {

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -34,7 +34,7 @@ struct EndpointCacheTests {
             }
 
             try await withRunningApp(app: app) { port in
-                let cache = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/number")
+                let cache = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/number", client: app.client)
                 do {
                     let test = try await cache.get(
                         using: app.client
@@ -80,7 +80,7 @@ struct EndpointCacheTests {
 
             try await withRunningApp(app: app) { port in
                 // Two reads inside a lifetime nothing can outlast must return the same value.
-                let cached = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/cached")
+                let cached = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/cached", client: app.client)
                 let first = try await cached.get(using: app.client).number
                 let second = try await cached.get(using: app.client).number
                 #expect(first == second, "cached value changed inside its lifetime")
@@ -89,7 +89,7 @@ struct EndpointCacheTests {
                 // time can break this one, and a slow machine only ever adds more of it. The
                 // new value is whatever the counter has reached, so assert that it moved
                 // rather than pinning a number the timing above could legitimately change.
-                let expiring = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/expiring")
+                let expiring = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/expiring", client: app.client)
                 let before = try await expiring.get(using: app.client).number
                 try await Task.sleep(for: .seconds(shortMaxAge + 1))
                 let refreshed = try await expiring.get(using: app.client).number
@@ -117,7 +117,7 @@ struct EndpointCacheTests {
             }
 
             try await withRunningApp(app: app) { port in
-                let cache = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/number")
+                let cache = EndpointCache<Test>(uri: "http://127.0.0.1:\(port)/number", client: app.client)
                 async let request1 = cache.get(using: app.client)
                 async let request2 = cache.get(using: app.client)
                 try await Task.sleep(for: .milliseconds(100))

--- a/Tests/VaporTests/FileETagHashCacheTests.swift
+++ b/Tests/VaporTests/FileETagHashCacheTests.swift
@@ -97,10 +97,10 @@ struct FileETagHashCacheTests {
                 .path
 
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true)
             }
             app.get("other") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: otherFile, advancedETagComparison: true)
+                try await app.fileio.streamFile(at: otherFile, for: req, advancedETagComparison: true)
             }
 
             try await app.test(method: .running) { runner in

--- a/Tests/VaporTests/FileETagHashCacheTests.swift
+++ b/Tests/VaporTests/FileETagHashCacheTests.swift
@@ -97,10 +97,10 @@ struct FileETagHashCacheTests {
                 .path
 
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true)
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
             }
             app.get("other") { req -> Response in
-                try await req.fileio.streamFile(at: otherFile, advancedETagComparison: true)
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: otherFile, advancedETagComparison: true)
             }
 
             try await app.test(method: .running) { runner in

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -22,7 +22,7 @@ struct FileTests {
     func testStreamFile() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -43,7 +43,7 @@ struct FileTests {
     func testStreamFileConnectionClose() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true)
             }
 
             var headers = HTTPFields()
@@ -65,7 +65,7 @@ struct FileTests {
                     tmpPath = try await FilePath(FileSystem.shared.temporaryDirectory.description).appending(UUID().uuidString).string
                 } while try await FileSystem.shared.info(forFileAt: .init(tmpPath)) != nil
 
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: tmpPath, advancedETagComparison: true) { result in
+                return try await app.fileio.streamFile(at: tmpPath, for: req, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                         Issue.record("File Stream should have failed")
@@ -84,7 +84,7 @@ struct FileTests {
     func testAdvancedETagHeaders() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -106,7 +106,7 @@ struct FileTests {
     func testAdvancedETagHashIsCached() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true)
             }
 
             #expect(await app.fileETagHashCache.entry(forFileAt: #filePath) == nil)
@@ -129,7 +129,7 @@ struct FileTests {
     func testSimpleETagHeaders() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: false) { result in
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: false) { result in
                     do {
                         try result.get()
                     } catch {
@@ -153,7 +153,7 @@ struct FileTests {
     func testStreamFileContentHeaderTail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -183,7 +183,7 @@ struct FileTests {
     func testStreamFileContentHeaderStart() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -214,7 +214,7 @@ struct FileTests {
     func testStreamFileContentHeadersWithin() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -243,7 +243,7 @@ struct FileTests {
     func testStreamFileContentHeadersOnlyFirstByte() async throws {
         try await withApp { app in
             app.get("file-stream") { req in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -268,7 +268,7 @@ struct FileTests {
     func testStreamFileContentHeadersWithinFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -294,7 +294,7 @@ struct FileTests {
     func testStreamFileContentHeadersStartFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -318,7 +318,7 @@ struct FileTests {
     func testStreamFileContentHeadersTailFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -496,7 +496,7 @@ struct FileTests {
     func testInvalidRangeHeaderDoesNotCrash() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: true)
             }
 
             try await app.test(method: .running) { runner in
@@ -551,8 +551,8 @@ struct FileTests {
             // `deinit` precondition — which traps the process rather than throwing. Cancelling
             // repeatedly at slightly different points covers the window between open and close.
             for iteration in 1...10 {
-                let response = try await request.fileio(etagCache: app.fileETagHashCache).streamFile(
-                    at: filePath, advancedETagComparison: false)
+                let response = try await app.fileio.streamFile(
+                    at: filePath, for: request, advancedETagComparison: false)
 
                 // `collect()` is mutating, so the Task works on its own copy of the body. That
                 // is fine here: this test is about descriptor cleanup on cancellation, not the
@@ -577,7 +577,7 @@ struct FileTests {
         try await withApp { app in
             let fileWasRead = NIOLockedValueBox(false)
             app.get("file-stream") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: false) { _ in
+                try await app.fileio.streamFile(at: #filePath, for: req, advancedETagComparison: false) { _ in
                     fileWasRead.withLockedValue { $0 = true }
                 }
             }

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -22,7 +22,7 @@ struct FileTests {
     func testStreamFile() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -43,7 +43,7 @@ struct FileTests {
     func testStreamFileConnectionClose() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true)
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
             }
 
             var headers = HTTPFields()
@@ -65,7 +65,7 @@ struct FileTests {
                     tmpPath = try await FilePath(FileSystem.shared.temporaryDirectory.description).appending(UUID().uuidString).string
                 } while try await FileSystem.shared.info(forFileAt: .init(tmpPath)) != nil
 
-                return try await req.fileio.streamFile(at: tmpPath, advancedETagComparison: true) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: tmpPath, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                         Issue.record("File Stream should have failed")
@@ -84,7 +84,7 @@ struct FileTests {
     func testAdvancedETagHeaders() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -106,7 +106,7 @@ struct FileTests {
     func testAdvancedETagHashIsCached() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true)
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
             }
 
             #expect(await app.fileETagHashCache.entry(forFileAt: #filePath) == nil)
@@ -129,7 +129,7 @@ struct FileTests {
     func testSimpleETagHeaders() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: false) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: false) { result in
                     do {
                         try result.get()
                     } catch {
@@ -153,7 +153,7 @@ struct FileTests {
     func testStreamFileContentHeaderTail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -183,7 +183,7 @@ struct FileTests {
     func testStreamFileContentHeaderStart() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                return try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                return try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     do {
                         try result.get()
                     } catch {
@@ -214,7 +214,7 @@ struct FileTests {
     func testStreamFileContentHeadersWithin() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -243,7 +243,7 @@ struct FileTests {
     func testStreamFileContentHeadersOnlyFirstByte() async throws {
         try await withApp { app in
             app.get("file-stream") { req in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -268,7 +268,7 @@ struct FileTests {
     func testStreamFileContentHeadersWithinFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -294,7 +294,7 @@ struct FileTests {
     func testStreamFileContentHeadersStartFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -318,7 +318,7 @@ struct FileTests {
     func testStreamFileContentHeadersTailFail() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true) { result in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true) { result in
                     #expect(throws: Never.self) {
                         try result.get()
                     }
@@ -342,7 +342,7 @@ struct FileTests {
     func testPercentDecodedFilePath() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, etagCache: app.fileETagHashCache))
 
             try await app.testing().test(.get, "/Utilities/foo%20bar.html") { res in
                 #expect(res.status == .ok)
@@ -355,7 +355,7 @@ struct FileTests {
     func testPercentDecodedRelativePath() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, etagCache: app.fileETagHashCache))
 
             try await app.testing().test(.get, "%2e%2e/VaporTests/Utilities/foo.txt") { res in
                 #expect(res.status == .forbidden)
@@ -372,7 +372,7 @@ struct FileTests {
     func testDefaultFileRelative() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "index.html"))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "index.html", etagCache: app.fileETagHashCache))
 
             try await app.testing().test(.get, "Utilities/") { res in
                 #expect(res.status == .ok)
@@ -390,7 +390,7 @@ struct FileTests {
     func testDefaultFileAbsolute() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "/Utilities/index.html"))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, defaultFile: "/Utilities/index.html", etagCache: app.fileETagHashCache))
 
             try await app.testing().test(.get, "Utilities/") { res in
                 #expect(res.status == .ok)
@@ -408,7 +408,7 @@ struct FileTests {
     func testNoDefaultFile() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, etagCache: app.fileETagHashCache))
 
             try await app.testing().test(.get, "Utilities/") { res in
                 #expect(res.status == .notFound)
@@ -424,7 +424,8 @@ struct FileTests {
                 FileMiddleware(
                     publicDirectory: "/" + path,
                     defaultFile: "index.html",
-                    directoryAction: .redirect
+                    directoryAction: .redirect,
+                    etagCache: app.fileETagHashCache
                 )
             )
 
@@ -446,7 +447,8 @@ struct FileTests {
                 FileMiddleware(
                     publicDirectory: "/" + path,
                     defaultFile: "index.html",
-                    directoryAction: .redirect
+                    directoryAction: .redirect,
+                    etagCache: app.fileETagHashCache
                 )
             )
 
@@ -475,7 +477,8 @@ struct FileTests {
                 FileMiddleware(
                     publicDirectory: "/" + path,
                     defaultFile: "index.html",
-                    directoryAction: .none
+                    directoryAction: .none,
+                    etagCache: app.fileETagHashCache
                 )
             )
 
@@ -493,7 +496,7 @@ struct FileTests {
     func testInvalidRangeHeaderDoesNotCrash() async throws {
         try await withApp { app in
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: true)
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: true)
             }
 
             try await app.test(method: .running) { runner in
@@ -581,7 +584,7 @@ struct FileTests {
             // `deinit` precondition — which traps the process rather than throwing. Cancelling
             // repeatedly at slightly different points covers the window between open and close.
             for iteration in 1...10 {
-                let response = try await request.fileio.streamFile(
+                let response = try await request.fileio(etagCache: app.fileETagHashCache).streamFile(
                     at: filePath, advancedETagComparison: false)
 
                 // `collect()` is mutating, so the Task works on its own copy of the body. That
@@ -607,7 +610,7 @@ struct FileTests {
         try await withApp { app in
             let fileWasRead = NIOLockedValueBox(false)
             app.get("file-stream") { req -> Response in
-                try await req.fileio.streamFile(at: #filePath, advancedETagComparison: false) { _ in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: #filePath, advancedETagComparison: false) { _ in
                     fileWasRead.withLockedValue { $0 = true }
                 }
             }
@@ -631,7 +634,7 @@ struct FileTests {
     func testFileMiddlewareOnlyServesGetAndHead() async throws {
         try await withApp { app in
             let path = #filePath.split(separator: "/").dropLast().joined(separator: "/")
-            app.middleware.use(FileMiddleware(publicDirectory: "/" + path))
+            app.middleware.use(FileMiddleware(publicDirectory: "/" + path, etagCache: app.fileETagHashCache))
 
             try await app.test(method: .running) { runner in
                 let get = try await runner.sendRequest(.get, "/Utilities/foo.txt")

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -577,7 +577,7 @@ struct FileTests {
         let filePath = try await makeTemporaryFile(size: 8 << 20)
 
         try await withApp { app in
-            let request = Request(application: app)
+            let request = Request()
 
             // `close()` is dispatched through a thread pool that refuses cancelled work, so a
             // handle closed naively from a cancelled task stays open and trips NIOFileSystem's

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -457,7 +457,7 @@ struct MiddlewareTests {
             }
 
             app.grouped(
-                TracingMiddleware(serverAddress: app.sharedAddress.withLockedValue({ $0 })) { attributes, _ in
+                TracingMiddleware(serverAddress: { app.sharedAddress.withLockedValue({ $0 }) }) { attributes, _ in
                     attributes["custom"] = "custom"
                 }
             ).grouped(

--- a/Tests/VaporTests/MiddlewareTests.swift
+++ b/Tests/VaporTests/MiddlewareTests.swift
@@ -187,7 +187,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware From Bundle")
     func testFileMiddlewareFromBundle() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/")
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in
@@ -202,7 +202,7 @@ struct MiddlewareTests {
     @Test("Test File MIddleware With Browser Default Cache Policy")
     func testFileMiddlewareWithBrowserDefaultCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .browserDefault)
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .browserDefault, etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in
@@ -218,7 +218,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware With No Cache Policy")
     func testFileMiddlewareWithNoCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .noCache)
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .noCache, etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in
@@ -234,7 +234,7 @@ struct MiddlewareTests {
     func testFileMiddlewareWithMaxAgeCachePolicy() async throws {
         try await withApp { app in
             let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .cache(upTo:
-                    .seconds(300)))
+                    .seconds(300)), etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in
@@ -249,7 +249,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware With Custom Cache Policy")
     func testFileMiddlewareWithCustomCachePolicy() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .custom(cacheControlHeader: .init(isPublic: true), ageHeader: 10))
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "/", cachePolicy: .custom(cacheControlHeader: .init(isPublic: true), ageHeader: 10), etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/foo.txt") { result in
@@ -264,7 +264,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware From Bundle Subfolder")
     func testFileMiddlewareFromBundleSubfolder() async throws {
         try await withApp { app in
-            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "SubUtilities")
+            let fileMiddleware = try FileMiddleware(bundle: .module, publicDirectory: "SubUtilities", etagCache: app.fileETagHashCache)
             app.middleware.use(fileMiddleware)
 
             try await app.testing().test(.get, "/index.html") { result in
@@ -277,7 +277,7 @@ struct MiddlewareTests {
     @Test("Test File Middleware From Bundle Invalid Public Directory")
     func testFileMiddlewareFromBundleInvalidPublicDirectory() {
         #expect(throws: FileMiddleware.BundleSetupError.publicDirectoryIsNotAFolder) {
-            try FileMiddleware(bundle: .module, publicDirectory: "/totally-real/folder")
+            try FileMiddleware(bundle: .module, publicDirectory: "/totally-real/folder", etagCache: FileETagHashCache(capacity: 10))
         }
     }
     #endif
@@ -457,7 +457,7 @@ struct MiddlewareTests {
             }
 
             app.grouped(
-                TracingMiddleware() { attributes, _ in
+                TracingMiddleware(serverAddress: app.sharedAddress.withLockedValue({ $0 })) { attributes, _ in
                     attributes["custom"] = "custom"
                 }
             ).grouped(

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -12,7 +12,7 @@ struct QueryTests {
     @Test("Test Query")
     func testQuery() async throws {
         try await withApp { app throws in
-            var request = Request(application: app)
+            var request = Request()
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = "hello=world"
@@ -23,7 +23,7 @@ struct QueryTests {
     @Test("Test Query as Array")
     func testQueryAsArray() async throws {
         try await withApp { app throws in
-            var request = Request(application: app)
+            var request = Request()
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = "hello=world&hello[]=you"
@@ -35,7 +35,7 @@ struct QueryTests {
     @Test("Test Wrapped Single Value Query Decoding", .bug("https://github.com/vapor/vapor/pull/2163"))
     func testWrappedSingleValueQueryDecoding() async throws {
         try await withApp { app throws in
-            var request = Request(application: app)
+            var request = Request()
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = ""
@@ -59,7 +59,7 @@ struct QueryTests {
     @Test("Test Does Not Crash with an Array with Percent Encoding")
     func testNotCrashingArrayWithPercentEncoding() async throws {
         try await withApp { app throws in
-            var request = Request(application: app)
+            var request = Request()
             request.headers.contentType = .json
             request.url.path = "/"
             request.url.query = "emailsToSearch%5B%5D=xyz"
@@ -72,7 +72,6 @@ struct QueryTests {
     func testQueryGet() async throws {
         try await withApp { app throws in
             var request1 = Request(
-                application: app,
                 method: .get,
                 url: .init(string: "/path?foo=a")
             )
@@ -100,7 +99,6 @@ struct QueryTests {
             #expect(request1.query[String.self, at: "bar"] == nil)
 
             let request2 = Request(
-                application: app,
                 method: .get,
                 url: .init(string: "/path")
             )
@@ -243,7 +241,7 @@ struct QueryTests {
             var name: String
         }
         try await withApp { app in
-            var req = Request(application: app)
+            var req = Request()
             try req.query.encode(TestQueryStringContainer(name: "Vapor Test"))
             #expect(req.url.query == "name=Vapor%20Test")
         }
@@ -278,7 +276,6 @@ struct QueryTests {
     func testOptionalGet() async throws {
         try await withApp { app in
             var req = Request(
-                application: app,
                 method: .get,
                 url: URI(string: "/")
             )
@@ -299,7 +296,6 @@ struct QueryTests {
     func testValuelessParamGet() async throws {
         try await withApp { app throws in
             var req = Request(
-                application: app,
                 method: .get,
                 url: URI(string: "/")
             )
@@ -340,7 +336,7 @@ struct QueryTests {
         }
 
         try await withApp { app in
-            var request = Request(application: app)
+            var request = Request()
             request.headers.contentType = .json
             request.url.path = "/"
             request.url.query = "closedRange=1"

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -12,7 +12,7 @@ struct QueryTests {
     @Test("Test Query")
     func testQuery() async throws {
         try await withApp { app throws in
-            let request = Request(application: app)
+            var request = Request(application: app)
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = "hello=world"
@@ -23,7 +23,7 @@ struct QueryTests {
     @Test("Test Query as Array")
     func testQueryAsArray() async throws {
         try await withApp { app throws in
-            let request = Request(application: app)
+            var request = Request(application: app)
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = "hello=world&hello[]=you"
@@ -35,7 +35,7 @@ struct QueryTests {
     @Test("Test Wrapped Single Value Query Decoding", .bug("https://github.com/vapor/vapor/pull/2163"))
     func testWrappedSingleValueQueryDecoding() async throws {
         try await withApp { app throws in
-            let request = Request(application: app)
+            var request = Request(application: app)
             request.headers.contentType = .json
             request.url.path = "/foo"
             request.url.query = ""
@@ -59,7 +59,7 @@ struct QueryTests {
     @Test("Test Does Not Crash with an Array with Percent Encoding")
     func testNotCrashingArrayWithPercentEncoding() async throws {
         try await withApp { app throws in
-            let request = Request(application: app)
+            var request = Request(application: app)
             request.headers.contentType = .json
             request.url.path = "/"
             request.url.query = "emailsToSearch%5B%5D=xyz"
@@ -71,7 +71,7 @@ struct QueryTests {
     @Test("Test Query Get")
     func testQueryGet() async throws {
         try await withApp { app throws in
-            let request1 = Request(
+            var request1 = Request(
                 application: app,
                 method: .get,
                 url: .init(string: "/path?foo=a")
@@ -243,7 +243,7 @@ struct QueryTests {
             var name: String
         }
         try await withApp { app in
-            let req = Request(application: app)
+            var req = Request(application: app)
             try req.query.encode(TestQueryStringContainer(name: "Vapor Test"))
             #expect(req.url.query == "name=Vapor%20Test")
         }
@@ -277,7 +277,7 @@ struct QueryTests {
     @Test("Test Optional Get")
     func testOptionalGet() async throws {
         try await withApp { app in
-            let req = Request(
+            var req = Request(
                 application: app,
                 method: .get,
                 url: URI(string: "/")
@@ -298,7 +298,7 @@ struct QueryTests {
     @Test("Test Valueluss Param Get")
     func testValuelessParamGet() async throws {
         try await withApp { app throws in
-            let req = Request(
+            var req = Request(
                 application: app,
                 method: .get,
                 url: URI(string: "/")
@@ -340,7 +340,7 @@ struct QueryTests {
         }
 
         try await withApp { app in
-            let request = Request(application: app)
+            var request = Request(application: app)
             request.headers.contentType = .json
             request.url.path = "/"
             request.url.query = "closedRange=1"

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -82,6 +82,35 @@ struct RequestTests {
         }
     }
 
+    @Test("Test Streaming Request Content Decoding", .timeLimit(.minutes(1)))
+    func testStreamingRequestContentDecoding() async throws {
+        struct Payload: Content, Equatable {
+            var message: String
+        }
+
+        try await withApp { app in
+            app.on(.post, "stream-decode", body: .stream) { req async throws -> String in
+                #expect(req.body.data != nil)
+                return try await req.content.decode(Payload.self).message
+            }
+
+            try await withRunningApp(app: app) { port in
+                let testValue = String.randomDigits()
+                let json = #"{"message":"\#(testValue)"}"#
+
+                var request = HTTPClientRequest(url: "http://localhost:\(port)/stream-decode")
+                request.method = .POST
+                request.headers.add(name: "content-type", value: "application/json")
+                request.body = .stream(json.utf8.async, length: .unknown)
+
+                let response = try await HTTPClient.shared.execute(request, timeout: .seconds(5))
+                #expect(response.status == .ok)
+                let body = try await response.body.collect(upTo: 1024 * 1024)
+                #expect(body.string == testValue)
+            }
+        }
+    }
+
     @Test("Test Streaming Request Body Cleanup", .disabled())
     func testStreamingRequestBodyCleansUp() async throws {
         try await withApp { app in

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -267,7 +267,8 @@ struct RequestTests {
     @Test("Test Request Peer Address Forwarded")
     func testRequestPeerAddressForwarded() async throws {
         try await withApp { app in
-            app.get("remote") { req -> String in
+            app.get("remote") { request -> String in
+                var req = request
                 req.headers[.forwarded] = "for=192.0.2.60; proto=http; by=203.0.113.43"
                 guard let peerAddress = req.peerAddress else {
                     return "n/a"
@@ -284,7 +285,8 @@ struct RequestTests {
     @Test("Test Request Peer Address X-Forwarded-For")
     func testRequestPeerAddressXForwardedFor() async throws {
         try await withApp { app in
-            app.get("remote") { req -> String in
+            app.get("remote") { request -> String in
+                var req = request
                 req.headers[.xForwardedFor] = "5.6.7.8"
                 guard let peerAddress = req.peerAddress else {
                     return "n/a"
@@ -318,7 +320,8 @@ struct RequestTests {
     @Test("Test Request Peer Address Multiple Headers Order")
     func testRequestPeerAddressMultipleHeadersOrder() async throws {
         try await withApp { app in
-            app.get("remote") { req -> String in
+            app.get("remote") { request -> String in
+                var req = request
                 req.headers[.xForwardedFor] = "5.6.7.8"
                 req.headers[.forwarded] = "for=192.0.2.60; proto=http; by=203.0.113.43"
                 guard let peerAddress = req.peerAddress else {

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -268,8 +268,8 @@ struct RequestTests {
     @Test("Test Request IDs are Unique")
     func testRequestIdsAreUnique() async throws {
         try await withApp { app in
-            let request1 = Request(application: app)
-            let request2 = Request(application: app)
+            let request1 = Request()
+            let request2 = Request()
 
             #expect(request1.id != request2.id)
         }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -955,7 +955,7 @@ struct StreamingBodyTests {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: filePath, advancedETagComparison: false)
+                try await app.fileio.streamFile(at: filePath, for: req, advancedETagComparison: false)
             }
             app.get("ok") { _ in "ok" }
 
@@ -1042,7 +1042,7 @@ struct StreamingBodyTests {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: filePath, advancedETagComparison: false) { _ in
+                try await app.fileio.streamFile(at: filePath, for: req, advancedETagComparison: false) { _ in
                     completions.withLockedValue { $0 += 1 }
                 }
             }

--- a/Tests/VaporTests/StreamingBodyTests.swift
+++ b/Tests/VaporTests/StreamingBodyTests.swift
@@ -955,7 +955,7 @@ struct StreamingBodyTests {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio.streamFile(at: filePath, advancedETagComparison: false)
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: filePath, advancedETagComparison: false)
             }
             app.get("ok") { _ in "ok" }
 
@@ -1042,7 +1042,7 @@ struct StreamingBodyTests {
         try await withApp { app in
             app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
             app.get("file") { req -> Response in
-                try await req.fileio.streamFile(at: filePath, advancedETagComparison: false) { _ in
+                try await req.fileio(etagCache: app.fileETagHashCache).streamFile(at: filePath, advancedETagComparison: false) { _ in
                     completions.withLockedValue { $0 += 1 }
                 }
             }


### PR DESCRIPTION
Overhaul `Request`:

* Remove all the lock accesses for properties
* Change `Request` to a struct
* Remove `Application` which requires some changes to various places that expect it
* Tidies up `FileIO` as request is now simplified

It also doesn't include any of the Request Body changes, I've left those mostly alone apart from cleaning up my old streaming experiment as these will land in #3543
