### PR TITLE
Remove File Operations

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -3,9 +3,8 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-#warning("Make this internal")
-public import NIOCore
-public import _NIOFileSystem
+import NIOCore
+import _NIOFileSystem
 import HTTPTypes
 import Logging
 import Crypto
@@ -56,16 +55,6 @@ public struct FileIO: Sendable {
         self.request = request
     }
 
-    private func read(
-        path: String,
-        fromOffset offset: Int64,
-        byteCount: Int
-    ) async throws -> ByteBuffer {
-        return try await FileSystem.shared.withFileHandle(forReadingAt: .init(path)) { handle in
-            return try await handle.readChunk(fromAbsoluteOffset: offset, length: .bytes(Int64(byteCount)))
-        }
-    }
-
     /// Generates a fresh ETag for a file or returns its currently cached one.
     /// - Parameters:
     ///   - path: The file's path.
@@ -85,82 +74,6 @@ public struct FileIO: Sendable {
                 }
                 return hasher.finalize().hex
             }
-        }
-    }
-
-    // MARK: - Concurrency
-
-    /// Reads the contents of a file at the supplied path.
-    ///
-    ///     let data = try await req.fileio.collectFile(at: "/path/to/file.txt")
-    ///     print(data) // file data
-    ///
-    /// - parameters:
-    ///     - path: Path to file on the disk.
-    /// - returns: `ByteBuffer` containing the file data.
-    public func collectFile(at path: String) async throws -> ByteBuffer {
-        guard let fileSize = try await FileSystem.shared.info(forFileAt: .init(path))?.size else {
-            throw Abort(.internalServerError)
-        }
-        return try await self.read(path: path, fromOffset: 0, byteCount: Int(fileSize))
-    }
-
-    /// Reads the contents of a file at the supplied path in chunks.
-    ///
-    ///     try await req.fileio.readFile(at: "/path/to/file.txt") { chunks in
-    ///         for try await chunk in chunks {
-    ///             print("chunk: \(chunk)")
-    ///         }
-    ///     }
-    ///
-    /// > Warning: The file is only open for the duration of `processChunks`, so the chunks must be
-    /// > consumed inside the closure rather than escaping it.
-    ///
-    /// - parameters:
-    ///     - path: Path to file on the disk.
-    ///     - chunkSize: Maximum size for the file data chunks.
-    ///     - offset: The offset to start reading from.
-    ///     - byteCount: The number of bytes to read from the file. If `nil`, the file will be read to the end.
-    ///     - processChunks: Closure receiving the ``FileChunks`` to read the file data from.
-    public func readFile(
-        at path: String,
-        chunkSize: Int64 = 128 * 1024, // was the default in NonBlockingFileIO
-        offset: Int64? = nil,
-        byteCount: Int? = nil,
-        processChunks: @Sendable (FileChunks) async throws -> Void
-    ) async throws {
-        let filePath = FilePath(path)
-
-        return try await fileSystem.withFileHandle(forReadingAt: filePath) { readHandle in
-            let chunks: FileChunks
-
-            if let offset {
-                if let byteCount {
-                    chunks = readHandle.readChunks(in: offset..<(offset+Int64(byteCount)), chunkLength: .bytes(chunkSize))
-                } else {
-                    chunks = readHandle.readChunks(in: offset..., chunkLength: .bytes(chunkSize))
-                }
-            } else {
-                chunks = readHandle.readChunks(chunkLength: .bytes(chunkSize))
-            }
-            try await processChunks(chunks)
-        }
-    }
-
-    /// Write the contents of buffer to a file at the supplied path.
-    ///
-    ///     let data = ByteBuffer(string: "ByteBuffer")
-    ///     try await req.fileio.writeFile(data, at: "/path/to/file.txt")
-    ///
-    /// > Warning: This method will overwrite the file if it already exists.
-    ///
-    /// - parameters:
-    ///     - buffer: The `ByteBuffer` to write.
-    ///     - path: Path to file on the disk.
-    public func writeFile(_ buffer: ByteBuffer, at path: String) async throws {
-        // This returns the number of bytes written which we don't need
-        _ = try await FileSystem.shared.withFileHandle(forWritingAt: .init(path), options: .newFile(replaceExisting: true)) { handle in
-            try await handle.write(contentsOf: buffer, toAbsoluteOffset: 0)
         }
     }
 

--- a/Tests/VaporTests/FileTests.swift
+++ b/Tests/VaporTests/FileTests.swift
@@ -534,39 +534,6 @@ struct FileTests {
         }
     }
 
-    #warning("Consider whether we should offer these anymoer instead of just deferring to NIOFileSystem")
-//    func testFileRead() async throws {
-//        let request = Request(application: app, on: app.eventLoopGroup.next())
-//
-//        let path = "/" + #filePath.split(separator: "/").dropLast().joined(separator: "/") + "/Utilities/long-test-file.txt"
-//
-//        let content = try String(contentsOfFile: path, encoding: .utf8)
-//
-//        var readContent = ""
-//        let file = try await request.fileio.readFile(at: path, chunkSize: 16 * 1024) // 32Kb, ~5 chunks
-//        for try await chunk in file {
-//            readContent += String(buffer: chunk)
-//        }
-//
-//        XCTAssertEqual(readContent, content, "The content read from the file does not match the expected content.")
-//    }
-//    func testFileWrite() async throws {
-//        let data = "Hello"
-//        let path = "/tmp/fileio_write.txt"
-//
-//        do {
-//            let request = Request(application: app, on: app.eventLoopGroup.next())
-//
-//            try await request.fileio.writeFile(ByteBuffer(string: data), at: path)
-//
-//            let result = try String(contentsOfFile: path, encoding: .utf8)
-//            XCTAssertEqual(result, data)
-//        } catch {
-//            try await FileSystem.shared.removeItem(at: .init(path))
-//            throw error
-//        }
-//    }
-
     @Test("Cancelling a file stream still closes the file handle")
     func testCancelledFileStreamClosesHandle() async throws {
         // Large enough that a read is still in flight when the cancellation lands: the whole point


### PR DESCRIPTION
The original FileIO purpose was to provide syntactic sugar for the eventloop-based APIs in SwiftNIO's FileIO to ensure they were tied to the right event loop, worked easily with `Request` and were easier to remove.

Since NIOFileSystem now does most of that with Swift Concurrency, there's not a lot of benefit of wrapping these. User's can just call NIOFileSystem directely if they want to read files, as shown in the routes.swift file.

The one thing FileIO does well still is providing a clean helper to stream a file with integration with Vapor, E-Tag support etc and ensuring that stream's correctly as a response. We still keep that
